### PR TITLE
Fix grammatical typos

### DIFF
--- a/docs/samples/Microsoft.ML.Samples/Dynamic/SimpleDataViewImplementation.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/SimpleDataViewImplementation.cs
@@ -44,7 +44,7 @@ namespace Samples.Dynamic
 
             {
                 // Note that it is best to get the getters and values *before*
-                // iteration, so as to faciliate buffer sharing (if applicable),
+                // iteration, so as to facilitate buffer sharing (if applicable),
                 // and column-type validation once, rather than many times.
                 ReadOnlyMemory<char> textValue = default;
                 VBuffer<ReadOnlyMemory<char>> tokensValue = default;

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/TensorFlow/TextClassification.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/TensorFlow/TextClassification.cs
@@ -54,7 +54,7 @@ namespace Samples.Dynamic
                );
 
             // Load the TensorFlow model once.
-            //      - Use it for quering the schema for input and output in the
+            //      - Use it for queering the schema for input and output in the
             //            model
             //      - Use it for prediction in the pipeline.
             // Unfrozen (SavedModel format) models are loaded by providing the
@@ -78,7 +78,7 @@ namespace Samples.Dynamic
             // In this sample, CustomMappingEstimator is used to resize variable
             // length vector to fixed length vector.
             // The following ML.NET pipeline
-            //      1. tokenzies the string into words, 
+            //      1. tokenizes the string into words, 
             //      2. maps each word to an integer which is an index in the
             //         dictionary ('lookupMap'),
             //      3. Resizes the integer vector to a fixed length vector using

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/TensorFlow/TextClassification.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/TensorFlow/TextClassification.cs
@@ -54,7 +54,7 @@ namespace Samples.Dynamic
                );
 
             // Load the TensorFlow model once.
-            //      - Use it for queering the schema for input and output in the
+            //      - Use it for querying the schema for input and output in the
             //            model
             //      - Use it for prediction in the pipeline.
             // Unfrozen (SavedModel format) models are loaded by providing the

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/AnomalyDetection/RandomizedPcaSample.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/AnomalyDetection/RandomizedPcaSample.cs
@@ -27,7 +27,7 @@ namespace Samples.Dynamic.Trainers.AnomalyDetection
                 new DataPoint(){ Features = new float[3] {2, 0, 0} }
             };
 
-            // Convert the List<DataPoint> to IDataView, a consumble format to
+            // Convert the List<DataPoint> to IDataView, a consumable format to
             // ML.NET functions.
             var data = mlContext.Data.LoadFromEnumerable(samples);
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/AnomalyDetection/RandomizedPcaSampleWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/AnomalyDetection/RandomizedPcaSampleWithOptions.cs
@@ -29,7 +29,7 @@ namespace Samples.Dynamic.Trainers.AnomalyDetection
                 new DataPoint(){ Features = new float[3] {1, 0, 0} }
             };
 
-            // Convert the List<DataPoint> to IDataView, a consumble format to
+            // Convert the List<DataPoint> to IDataView, a consumable format to
             // ML.NET functions.
             var data = mlContext.Data.LoadFromEnumerable(samples);
 
@@ -76,14 +76,14 @@ namespace Samples.Dynamic.Trainers.AnomalyDetection
                         i, featuresInText, result.Score);
             }
             // Lines printed out should be
-            // The 0 - th example with features[0, 2, 1] isan inlier with a score of being outlier 0.2264826
-            // The 1 - th example with features[0, 2, 3] isan inlier with a score of being outlier 0.1739471
-            // The 2 - th example with features[0, 2, 4] isan inlier with a score of being outlier 0.05711612
-            // The 3 - th example with features[0, 2, 1] isan inlier with a score of being outlier 0.2264826
-            // The 4 - th example with features[0, 2, 2] isan inlier with a score of being outlier 0.3868995
-            // The 5 - th example with features[0, 2, 3] isan inlier with a score of being outlier 0.1739471
-            // The 6 - th example with features[0, 2, 4] isan inlier with a score of being outlier 0.05711612
-            // The 7 - th example with features[1, 0, 0] isan outlier with a score of being outlier 0.6260795
+            // The 0 - th example with features[0, 2, 1] is an inlier with a score of being outlier 0.2264826
+            // The 1 - th example with features[0, 2, 3] is an inlier with a score of being outlier 0.1739471
+            // The 2 - th example with features[0, 2, 4] is an inlier with a score of being outlier 0.05711612
+            // The 3 - th example with features[0, 2, 1] is an inlier with a score of being outlier 0.2264826
+            // The 4 - th example with features[0, 2, 2] is an inlier with a score of being outlier 0.3868995
+            // The 5 - th example with features[0, 2, 3] is an inlier with a score of being outlier 0.1739471
+            // The 6 - th example with features[0, 2, 4] is an inlier with a score of being outlier 0.05711612
+            // The 7 - th example with features[1, 0, 0] is an outlier with a score of being outlier 0.6260795
         }
 
         // Example with 3 feature values. A training data set is a collection of

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/Calibrators/Isotonic.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/Calibrators/Isotonic.cs
@@ -55,7 +55,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification.Calibrators
 
             var calibratorTransformer = calibratorEstimator.Fit(scoredData);
 
-            // Transform the scored data with a calibrator transfomer by adding a
+            // Transform the scored data with a calibrator transformer by adding a
             // new column names "Probability". This column is a calibrated version
             // of the "Score" column, meaning its values are a valid probability
             // value in the [0, 1] interval representing the chance that the

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachine.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachine.cs
@@ -93,11 +93,11 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             }
 
             // Expected output:
-            //   Actual label: True, predicted label: True, score of being positive class: 1.115094, and probability of beling positive class: 0.7530775.
-            //   Actual label: False, predicted label: False, score of being positive class: -3.478797, and probability of beling positive class: 0.02992158.
-            //   Actual label: True, predicted label: True, score of being positive class: 3.191896, and probability of beling positive class: 0.9605282.
-            //   Actual label: False, predicted label: False, score of being positive class: -3.400863, and probability of beling positive class: 0.03226851.
-            //   Actual label: True, predicted label: True, score of being positive class: 4.06056, and probability of beling positive class: 0.9830528.
+            //   Actual label: True, predicted label: True, score of being positive class: 1.115094, and probability of being positive class: 0.7530775.
+            //   Actual label: False, predicted label: False, score of being positive class: -3.478797, and probability of being positive class: 0.02992158.
+            //   Actual label: True, predicted label: True, score of being positive class: 3.191896, and probability of being positive class: 0.9605282.
+            //   Actual label: False, predicted label: False, score of being positive class: -3.400863, and probability of being positive class: 0.03226851.
+            //   Actual label: True, predicted label: True, score of being positive class: 4.06056, and probability of being positive class: 0.9830528.
         }
 
         // Number of features per field.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachine.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachine.tt
@@ -25,11 +25,11 @@ string TrainerDescription = @"// This trainer trains field-aware factorization (
 string TrainerOptions = null;
 
 string ExpectedOutputPerInstance= @"// Expected output:
-            //   Actual label: True, predicted label: True, score of being positive class: 1.115094, and probability of beling positive class: 0.7530775.
-            //   Actual label: False, predicted label: False, score of being positive class: -3.478797, and probability of beling positive class: 0.02992158.
-            //   Actual label: True, predicted label: True, score of being positive class: 3.191896, and probability of beling positive class: 0.9605282.
-            //   Actual label: False, predicted label: False, score of being positive class: -3.400863, and probability of beling positive class: 0.03226851.
-            //   Actual label: True, predicted label: True, score of being positive class: 4.06056, and probability of beling positive class: 0.9830528.";
+            //   Actual label: True, predicted label: True, score of being positive class: 1.115094, and probability of being positive class: 0.7530775.
+            //   Actual label: False, predicted label: False, score of being positive class: -3.478797, and probability of being positive class: 0.02992158.
+            //   Actual label: True, predicted label: True, score of being positive class: 3.191896, and probability of being positive class: 0.9605282.
+            //   Actual label: False, predicted label: False, score of being positive class: -3.400863, and probability of being positive class: 0.03226851.
+            //   Actual label: True, predicted label: True, score of being positive class: 4.06056, and probability of being positive class: 0.9830528.";
 
 string ExpectedOutput = @"// Expected output:
             //   Accuracy: 0.99

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachineWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachineWithOptions.cs
@@ -104,11 +104,11 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             }
 
             // Expected output:
-            //   Actual label: True, predicted label: True, score of being positive class: 1.115094, and probability of beling positive class: 0.7530775.
-            //   Actual label: False, predicted label: False, score of being positive class: -3.478797, and probability of beling positive class: 0.02992158.
-            //   Actual label: True, predicted label: True, score of being positive class: 3.191896, and probability of beling positive class: 0.9605282.
-            //   Actual label: False, predicted label: False, score of being positive class: -3.400863, and probability of beling positive class: 0.03226851.
-            //   Actual label: True, predicted label: True, score of being positive class: 4.06056, and probability of beling positive class: 0.9830528.
+            //   Actual label: True, predicted label: True, score of being positive class: 1.115094, and probability of being positive class: 0.7530775.
+            //   Actual label: False, predicted label: False, score of being positive class: -3.478797, and probability of being positive class: 0.02992158.
+            //   Actual label: True, predicted label: True, score of being positive class: 3.191896, and probability of being positive class: 0.9605282.
+            //   Actual label: False, predicted label: False, score of being positive class: -3.400863, and probability of being positive class: 0.03226851.
+            //   Actual label: True, predicted label: True, score of being positive class: 4.06056, and probability of being positive class: 0.9830528.
         }
 
         // Number of features per field.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachineWithOptions.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachineWithOptions.tt
@@ -32,11 +32,11 @@ string TrainerOptions = @"FieldAwareFactorizationMachineTrainer.Options
             }";
 
 string ExpectedOutputPerInstance= @"// Expected output:
-            //   Actual label: True, predicted label: True, score of being positive class: 1.115094, and probability of beling positive class: 0.7530775.
-            //   Actual label: False, predicted label: False, score of being positive class: -3.478797, and probability of beling positive class: 0.02992158.
-            //   Actual label: True, predicted label: True, score of being positive class: 3.191896, and probability of beling positive class: 0.9605282.
-            //   Actual label: False, predicted label: False, score of being positive class: -3.400863, and probability of beling positive class: 0.03226851.
-            //   Actual label: True, predicted label: True, score of being positive class: 4.06056, and probability of beling positive class: 0.9830528.";
+            //   Actual label: True, predicted label: True, score of being positive class: 1.115094, and probability of being positive class: 0.7530775.
+            //   Actual label: False, predicted label: False, score of being positive class: -3.478797, and probability of being positive class: 0.02992158.
+            //   Actual label: True, predicted label: True, score of being positive class: 3.191896, and probability of being positive class: 0.9605282.
+            //   Actual label: False, predicted label: False, score of being positive class: -3.400863, and probability of being positive class: 0.03226851.
+            //   Actual label: True, predicted label: True, score of being positive class: 4.06056, and probability of being positive class: 0.9830528.";
 
 string ExpectedOutput = @"// Expected output:
             //   Accuracy: 0.99

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/MultipleFeatureColumnsBinaryClassification.ttinclude
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/MultipleFeatureColumnsBinaryClassification.ttinclude
@@ -93,7 +93,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             [VectorType(featureLength)]
             public float[] Field1 { get; set; }
 
-            // Features from the thrid field. 
+            // Features from the third field. 
             [VectorType(featureLength)]
             public float[] Field2 { get; set; }
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/ImageClassification/ResnetV2101TransferLearningTrainTestSplit.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/ImageClassification/ResnetV2101TransferLearningTrainTestSplit.cs
@@ -339,7 +339,7 @@ namespace Samples.Dynamic
             public string Label;
         }
 
-        // ImageData class holding the imagepath and label.
+        // ImageData class holding the image path and label.
         public class ImageData
         {
             [LoadColumn(0)]

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/PermutationFeatureImportanceLoadFromDisk.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/PermutationFeatureImportanceLoadFromDisk.cs
@@ -57,7 +57,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Now let's look at which features are most important to the model
             // overall. Get the feature indices sorted by their impact on
-            // microaccuracy.
+            // micro-accuracy.
             var sortedIndices = permutationMetrics
                 .Select((metrics, index) => new { index, metrics.MicroAccuracy })
                 .OrderByDescending(feature => Math.Abs(feature.MicroAccuracy.Mean))

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Recommendation/MatrixFactorization.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Recommendation/MatrixFactorization.cs
@@ -71,7 +71,7 @@ namespace Samples.Dynamic.Trainers.Recommendation
             //   Mean Absolute Error: 0.67:
             //   Mean Squared Error: 0.79
             //   Root Mean Squared Error: 0.89
-            //   RSquared: 0.61 (closer to 1 is better. The worest case is 0)
+            //   RSquared: 0.61 (closer to 1 is better. The worst case is 0)
         }
 
         // The following variables are used to define the shape of the example

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Recommendation/MatrixFactorization.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Recommendation/MatrixFactorization.tt
@@ -27,5 +27,5 @@ string ExpectedOutput = @"// Expected output:
             //   Mean Absolute Error: 0.67:
             //   Mean Squared Error: 0.79
             //   Root Mean Squared Error: 0.89
-            //   RSquared: 0.61 (closer to 1 is better. The worest case is 0)";
+            //   RSquared: 0.61 (closer to 1 is better. The worst case is 0)";
 #>

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Recommendation/MatrixFactorizationWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Recommendation/MatrixFactorizationWithOptions.cs
@@ -34,13 +34,13 @@ namespace Samples.Dynamic.Trainers.Recommendation
             // Define trainer options.
             var options = new MatrixFactorizationTrainer.Options
             {
-                // Specify IDataView colum which stores matrix column indexes. 
+                // Specify IDataView column which stores matrix column indexes. 
                 MatrixColumnIndexColumnName = nameof(MatrixElement.MatrixColumnIndex
                     ),
 
-                // Specify IDataView colum which stores matrix row indexes. 
+                // Specify IDataView column which stores matrix row indexes. 
                 MatrixRowIndexColumnName = nameof(MatrixElement.MatrixRowIndex),
-                // Specify IDataView colum which stores matrix elements' values. 
+                // Specify IDataView column which stores matrix elements' values. 
                 LabelColumnName = nameof(MatrixElement.Value),
                 // Time of going through the entire data set once.
                 NumberOfIterations = 10,
@@ -95,7 +95,7 @@ namespace Samples.Dynamic.Trainers.Recommendation
             //   Mean Absolute Error: 0.18
             //   Mean Squared Error: 0.05
             //   Root Mean Squared Error: 0.23
-            //   RSquared: 0.97 (closer to 1 is better. The worest case is 0)
+            //   RSquared: 0.97 (closer to 1 is better. The worst case is 0)
         }
 
         // The following variables are used to define the shape of the example

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Recommendation/MatrixFactorizationWithOptions.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Recommendation/MatrixFactorizationWithOptions.tt
@@ -13,13 +13,13 @@ string ExtraUsing = "using Microsoft.ML.Trainers;";
 string Trainer = "MatrixFactorization";
 string TrainerOptions = @"MatrixFactorizationTrainer.Options
             {
-                // Specify IDataView colum which stores matrix column indexes. 
+                // Specify IDataView column which stores matrix column indexes. 
                 MatrixColumnIndexColumnName = nameof(MatrixElement.MatrixColumnIndex
                     ),
 
-                // Specify IDataView colum which stores matrix row indexes. 
+                // Specify IDataView column which stores matrix row indexes. 
                 MatrixRowIndexColumnName = nameof(MatrixElement.MatrixRowIndex),
-                // Specify IDataView colum which stores matrix elements' values. 
+                // Specify IDataView column which stores matrix elements' values. 
                 LabelColumnName = nameof(MatrixElement.Value),
                 // Time of going through the entire data set once.
                 NumberOfIterations = 10,
@@ -46,5 +46,5 @@ string ExpectedOutput = @"// Expected output:
             //   Mean Absolute Error: 0.18
             //   Mean Squared Error: 0.05
             //   Root Mean Squared Error: 0.23
-            //   RSquared: 0.97 (closer to 1 is better. The worest case is 0)";
+            //   RSquared: 0.97 (closer to 1 is better. The worst case is 0)";
 #>

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/FastForest.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/FastForest.cs
@@ -66,7 +66,7 @@ namespace Samples.Dynamic.Trainers.Regression
             //   Mean Absolute Error: 0.06
             //   Mean Squared Error: 0.00
             //   Root Mean Squared Error: 0.07
-            //   RSquared: 0.96 (closer to 1 is better. The worest case is 0)
+            //   RSquared: 0.96 (closer to 1 is better. The worst case is 0)
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/FastForest.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/FastForest.tt
@@ -24,5 +24,5 @@ string ExpectedOutput = @"// Expected output:
             //   Mean Absolute Error: 0.06
             //   Mean Squared Error: 0.00
             //   Root Mean Squared Error: 0.07
-            //   RSquared: 0.96 (closer to 1 is better. The worest case is 0)";
+            //   RSquared: 0.96 (closer to 1 is better. The worst case is 0)";
 #>

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/FastForestWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/FastForestWithOptions.cs
@@ -79,7 +79,7 @@ namespace Samples.Dynamic.Trainers.Regression
             //   Mean Absolute Error: 0.06
             //   Mean Squared Error: 0.01
             //   Root Mean Squared Error: 0.07
-            //   RSquared: 0.95 (closer to 1 is better. The worest case is 0)
+            //   RSquared: 0.95 (closer to 1 is better. The worst case is 0)
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/FastForestWithOptions.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/FastForestWithOptions.tt
@@ -31,5 +31,5 @@ string ExpectedOutput = @"// Expected output:
             //   Mean Absolute Error: 0.06
             //   Mean Squared Error: 0.01
             //   Root Mean Squared Error: 0.07
-            //   RSquared: 0.95 (closer to 1 is better. The worest case is 0)";
+            //   RSquared: 0.95 (closer to 1 is better. The worst case is 0)";
 #>

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/FastTree.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/FastTree.cs
@@ -66,7 +66,7 @@ namespace Samples.Dynamic.Trainers.Regression
             //   Mean Absolute Error: 0.03
             //   Mean Squared Error: 0.00
             //   Root Mean Squared Error: 0.03
-            //   RSquared: 0.99 (closer to 1 is better. The worest case is 0)
+            //   RSquared: 0.99 (closer to 1 is better. The worst case is 0)
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/FastTree.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/FastTree.tt
@@ -23,6 +23,6 @@ string ExpectedOutput = @"// Expected output:
             //   Mean Absolute Error: 0.03
             //   Mean Squared Error: 0.00
             //   Root Mean Squared Error: 0.03
-            //   RSquared: 0.99 (closer to 1 is better. The worest case is 0)";
+            //   RSquared: 0.99 (closer to 1 is better. The worst case is 0)";
 
 #>

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/FastTreeTweedie.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/FastTreeTweedie.cs
@@ -66,7 +66,7 @@ namespace Samples.Dynamic.Trainers.Regression
             //   Mean Absolute Error: 0.04
             //   Mean Squared Error: 0.00
             //   Root Mean Squared Error: 0.06
-            //   RSquared: 0.96 (closer to 1 is better. The worest case is 0)
+            //   RSquared: 0.96 (closer to 1 is better. The worst case is 0)
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/FastTreeTweedie.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/FastTreeTweedie.tt
@@ -23,6 +23,6 @@ string ExpectedOutput = @"// Expected output:
             //   Mean Absolute Error: 0.04
             //   Mean Squared Error: 0.00
             //   Root Mean Squared Error: 0.06
-            //   RSquared: 0.96 (closer to 1 is better. The worest case is 0)";
+            //   RSquared: 0.96 (closer to 1 is better. The worst case is 0)";
 
 #>

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/FastTreeTweedieWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/FastTreeTweedieWithOptions.cs
@@ -81,7 +81,7 @@ namespace Samples.Dynamic.Trainers.Regression
             //   Mean Absolute Error: 0.04
             //   Mean Squared Error: 0.00
             //   Root Mean Squared Error: 0.05
-            //   RSquared: 0.98 (closer to 1 is better. The worest case is 0)
+            //   RSquared: 0.98 (closer to 1 is better. The worst case is 0)
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/FastTreeTweedieWithOptions.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/FastTreeTweedieWithOptions.tt
@@ -33,5 +33,5 @@ string ExpectedOutput = @"// Expected output:
             //   Mean Absolute Error: 0.04
             //   Mean Squared Error: 0.00
             //   Root Mean Squared Error: 0.05
-            //   RSquared: 0.98 (closer to 1 is better. The worest case is 0)";
+            //   RSquared: 0.98 (closer to 1 is better. The worst case is 0)";
 #>

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/FastTreeWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/FastTreeWithOptions.cs
@@ -82,7 +82,7 @@ namespace Samples.Dynamic.Trainers.Regression
             //   Mean Absolute Error: 0.03
             //   Mean Squared Error: 0.00
             //   Root Mean Squared Error: 0.03
-            //   RSquared: 0.99 (closer to 1 is better. The worest case is 0)
+            //   RSquared: 0.99 (closer to 1 is better. The worst case is 0)
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/FastTreeWithOptions.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/FastTreeWithOptions.tt
@@ -34,5 +34,5 @@ string ExpectedOutput = @"// Expected output:
             //   Mean Absolute Error: 0.03
             //   Mean Squared Error: 0.00
             //   Root Mean Squared Error: 0.03
-            //   RSquared: 0.99 (closer to 1 is better. The worest case is 0)";
+            //   RSquared: 0.99 (closer to 1 is better. The worst case is 0)";
 #>

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/Gam.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/Gam.cs
@@ -66,7 +66,7 @@ namespace Samples.Dynamic.Trainers.Regression
             //   Mean Absolute Error: 0.03
             //   Mean Squared Error: 0.00
             //   Root Mean Squared Error: 0.03
-            //   RSquared: 0.99 (closer to 1 is better. The worest case is 0)
+            //   RSquared: 0.99 (closer to 1 is better. The worst case is 0)
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/Gam.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/Gam.tt
@@ -24,5 +24,5 @@ string ExpectedOutput = @"// Expected output:
             //   Mean Absolute Error: 0.03
             //   Mean Squared Error: 0.00
             //   Root Mean Squared Error: 0.03
-            //   RSquared: 0.99 (closer to 1 is better. The worest case is 0)";
+            //   RSquared: 0.99 (closer to 1 is better. The worst case is 0)";
 #>

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/GamWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/GamWithOptions.cs
@@ -77,7 +77,7 @@ namespace Samples.Dynamic.Trainers.Regression
             //   Mean Absolute Error: 0.04
             //   Mean Squared Error: 0.01
             //   Root Mean Squared Error: 0.05
-            //   RSquared: 0.98 (closer to 1 is better. The worest case is 0)
+            //   RSquared: 0.98 (closer to 1 is better. The worst case is 0)
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/LbfgsPoissonRegression.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/LbfgsPoissonRegression.cs
@@ -64,7 +64,7 @@ namespace Samples.Dynamic.Trainers.Regression
             //   Mean Absolute Error: 0.07
             //   Mean Squared Error: 0.01
             //   Root Mean Squared Error: 0.08
-            //   RSquared: 0.93 (closer to 1 is better. The worest case is 0)
+            //   RSquared: 0.93 (closer to 1 is better. The worst case is 0)
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/LbfgsPoissonRegression.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/LbfgsPoissonRegression.tt
@@ -21,5 +21,5 @@ string ExpectedOutput = @"// Expected output:
             //   Mean Absolute Error: 0.07
             //   Mean Squared Error: 0.01
             //   Root Mean Squared Error: 0.08
-            //   RSquared: 0.93 (closer to 1 is better. The worest case is 0)";
+            //   RSquared: 0.93 (closer to 1 is better. The worst case is 0)";
 #>

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/LbfgsPoissonRegressionWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/LbfgsPoissonRegressionWithOptions.cs
@@ -78,7 +78,7 @@ namespace Samples.Dynamic.Trainers.Regression
             //   Mean Absolute Error: 0.10
             //   Mean Squared Error: 0.01
             //   Root Mean Squared Error: 0.11
-            //   RSquared: 0.89 (closer to 1 is better. The worest case is 0)
+            //   RSquared: 0.89 (closer to 1 is better. The worst case is 0)
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/LbfgsPoissonRegressionWithOptions.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/LbfgsPoissonRegressionWithOptions.tt
@@ -30,5 +30,5 @@ string ExpectedOutput = @"// Expected output:
             //   Mean Absolute Error: 0.10
             //   Mean Squared Error: 0.01
             //   Root Mean Squared Error: 0.11
-            //   RSquared: 0.89 (closer to 1 is better. The worest case is 0)";
+            //   RSquared: 0.89 (closer to 1 is better. The worst case is 0)";
 #>

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/LightGbm.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/LightGbm.cs
@@ -67,7 +67,7 @@ namespace Samples.Dynamic.Trainers.Regression
             //   Mean Absolute Error: 0.10
             //   Mean Squared Error: 0.01
             //   Root Mean Squared Error: 0.11
-            //   RSquared: 0.89 (closer to 1 is better. The worest case is 0)
+            //   RSquared: 0.89 (closer to 1 is better. The worst case is 0)
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/LightGbm.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/LightGbm.tt
@@ -24,5 +24,5 @@ string ExpectedOutput = @"// Expected output:
             //   Mean Absolute Error: 0.10
             //   Mean Squared Error: 0.01
             //   Root Mean Squared Error: 0.11
-            //   RSquared: 0.89 (closer to 1 is better. The worest case is 0)";
+            //   RSquared: 0.89 (closer to 1 is better. The worst case is 0)";
 #>

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/LightGbmWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/LightGbmWithOptions.cs
@@ -86,7 +86,7 @@ namespace Samples.Dynamic.Trainers.Regression
             //   Mean Absolute Error: 0.04
             //   Mean Squared Error: 0.00
             //   Root Mean Squared Error: 0.06
-            //   RSquared: 0.97 (closer to 1 is better. The worest case is 0)
+            //   RSquared: 0.97 (closer to 1 is better. The worst case is 0)
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/LightGbmWithOptions.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/LightGbmWithOptions.tt
@@ -38,5 +38,5 @@ string ExpectedOutput = @"// Expected output:
             //   Mean Absolute Error: 0.04
             //   Mean Squared Error: 0.00
             //   Root Mean Squared Error: 0.06
-            //   RSquared: 0.97 (closer to 1 is better. The worest case is 0)";
+            //   RSquared: 0.97 (closer to 1 is better. The worst case is 0)";
 #>

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/OrdinaryLeastSquares.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/OrdinaryLeastSquares.cs
@@ -63,7 +63,7 @@ namespace Samples.Dynamic.Trainers.Regression
             //   Mean Absolute Error: 0.05
             //   Mean Squared Error: 0.00
             //   Root Mean Squared Error: 0.06
-            //   RSquared: 0.97 (closer to 1 is better. The worest case is 0)
+            //   RSquared: 0.97 (closer to 1 is better. The worst case is 0)
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/OrdinaryLeastSquares.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/OrdinaryLeastSquares.tt
@@ -20,5 +20,5 @@ string ExpectedOutput = @"// Expected output:
             //   Mean Absolute Error: 0.05
             //   Mean Squared Error: 0.00
             //   Root Mean Squared Error: 0.06
-            //   RSquared: 0.97 (closer to 1 is better. The worest case is 0)";
+            //   RSquared: 0.97 (closer to 1 is better. The worst case is 0)";
 #>

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/OrdinaryLeastSquaresWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/OrdinaryLeastSquaresWithOptions.cs
@@ -31,7 +31,7 @@ namespace Samples.Dynamic.Trainers.Regression
                 FeatureColumnName = nameof(DataPoint.Features),
                 // Larger values leads to smaller (closer to zero) model parameters.
                 L2Regularization = 0.1f,
-                // Whether to computate standard error and other statistics of model
+                // Whether to compute standard error and other statistics of model
                 // parameters.
                 CalculateStatistics = false
             };
@@ -75,7 +75,7 @@ namespace Samples.Dynamic.Trainers.Regression
             //   Mean Absolute Error: 0.05
             //   Mean Squared Error: 0.00
             //   Root Mean Squared Error: 0.06
-            //   RSquared: 0.97 (closer to 1 is better. The worest case is 0)
+            //   RSquared: 0.97 (closer to 1 is better. The worst case is 0)
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/OrdinaryLeastSquaresWithOptions.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/OrdinaryLeastSquaresWithOptions.tt
@@ -11,7 +11,7 @@ string TrainerOptions = @"OlsTrainer.Options
                 FeatureColumnName = nameof(DataPoint.Features),
                 // Larger values leads to smaller (closer to zero) model parameters.
                 L2Regularization = 0.1f,
-                // Whether to computate standard error and other statistics of model
+                // Whether to compute standard error and other statistics of model
                 // parameters.
                 CalculateStatistics = false
             }";
@@ -27,5 +27,5 @@ string ExpectedOutput = @"// Expected output:
             //   Mean Absolute Error: 0.05
             //   Mean Squared Error: 0.00
             //   Root Mean Squared Error: 0.06
-            //   RSquared: 0.97 (closer to 1 is better. The worest case is 0)";
+            //   RSquared: 0.97 (closer to 1 is better. The worst case is 0)";
 #>

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/Sdca.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/Sdca.cs
@@ -63,7 +63,7 @@ namespace Samples.Dynamic.Trainers.Regression
             //   Mean Absolute Error: 0.05
             //   Mean Squared Error: 0.00
             //   Root Mean Squared Error: 0.06
-            //   RSquared: 0.97 (closer to 1 is better. The worest case is 0)
+            //   RSquared: 0.97 (closer to 1 is better. The worst case is 0)
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/SdcaWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/SdcaWithOptions.cs
@@ -79,7 +79,7 @@ namespace Samples.Dynamic.Trainers.Regression
             //   Mean Absolute Error: 0.05
             //   Mean Squared Error: 0.00
             //   Root Mean Squared Error: 0.06
-            //   RSquared: 0.97 (closer to 1 is better. The worest case is 0)
+            //   RSquared: 0.97 (closer to 1 is better. The worst case is 0)
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/SdcaWithOptions.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/SdcaWithOptions.tt
@@ -31,5 +31,5 @@ string ExpectedOutput = @"// Expected output:
             //   Mean Absolute Error: 0.05
             //   Mean Squared Error: 0.00
             //   Root Mean Squared Error: 0.06
-            //   RSquared: 0.97 (closer to 1 is better. The worest case is 0)";
+            //   RSquared: 0.97 (closer to 1 is better. The worst case is 0)";
 #>

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/Conversion/Hash.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/Conversion/Hash.cs
@@ -28,7 +28,7 @@ namespace Samples.Dynamic
             // results in new columns. The first transform hashes the string column
             // and the second transform hashes the integer column.
             //
-            // Hashing is not a reversible operation, so there is no way to retrive
+            // Hashing is not a reversible operation, so there is no way to retrieve
             // the original value from the hashed value. Sometimes, for debugging,
             // or model explainability, users will need to know what values in the
             // original columns generated the values in the hashed columns, since
@@ -70,7 +70,7 @@ namespace Samples.Dynamic
 
             // For the Category column, where we set the maximumNumberOfInverts
             // parameter, the names of the original categories, and their
-            // correspondance with the generated hash values is preserved in the
+            // correspondence with the generated hash values is preserved in the
             // Annotations in the format of indices and values.the indices array
             // will have the hashed values, and the corresponding element,
             // position -wise, in the values array will contain the original value. 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/Conversion/HashWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/Conversion/HashWithOptions.cs
@@ -30,7 +30,7 @@ namespace Samples.Dynamic
             // results in new columns. The first transform hashes the string column
             // and the second transform hashes the integer column.
             //
-            // Hashing is not a reversible operation, so there is no way to retrive
+            // Hashing is not a reversible operation, so there is no way to retrieve
             // the original value from the hashed value. Sometimes, for debugging,
             // or model explainability, users will need to know what values in the
             // original columns generated the values in the hashed columns, since
@@ -84,7 +84,7 @@ namespace Samples.Dynamic
 
             // For the Category column, where we set the maximumNumberOfInverts
             // parameter, the names of the original categories, and their
-            // correspondance with the generated hash values is preserved in the
+            // correspondence with the generated hash values is preserved in the
             // Annotations in the format of indices and values.the indices array
             // will have the hashed values, and the corresponding element,
             // position -wise, in the values array will contain the original value. 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/Conversion/KeyToValueToKey.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/Conversion/KeyToValueToKey.cs
@@ -80,7 +80,7 @@ namespace Samples.Dynamic
             //  8,2,9,7,6,4
             //  3,10,0,0,0
             //  3,10,0,0,0,8
-            // Retrieve the original values, by appending the KeyToValue etimator to
+            // Retrieve the original values, by appending the KeyToValue estimator to
             // the existing pipelines to convert the keys back to the strings.
             var pipeline = defaultPipeline.Append(mlContext.Transforms.Conversion
                 .MapKeyToValue(nameof(TransformedData.Keys)));

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/Conversion/MapKeyToValueMultiColumn.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/Conversion/MapKeyToValueMultiColumn.cs
@@ -38,11 +38,11 @@ namespace Samples.Dynamic
             // Typically predictions would be in a different, validation set. 
             var dataWithPredictions = pipeline.Fit(dataView).Transform(dataView);
 
-            // At this point, the Label colum is tranformed from strings, to
+            // At this point, the Label column is transformed from strings, to
             // DataViewKeyType and the transformation has added the PredictedLabel
             // column, with same DataViewKeyType as transformed Label column.
             // MapKeyToValue would take columns with DataViewKeyType and convert
-            // them back to thier original values.
+            // them back to their original values.
             var newPipeline = mlContext.Transforms.Conversion.MapKeyToValue(new[]
             {
                 new InputOutputColumnPair("LabelOriginalValue","Label"),

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/Conversion/MapKeyToVector.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/Conversion/MapKeyToVector.cs
@@ -33,7 +33,7 @@ namespace Samples.Dynamic
             // set 1 to corresponding key's value index in that array. After that we
             // concatenate two columns with single int values into vector of ints.
             // Third transform will create vector of keys, where key type is shared
-            // across whole vector. Forth transfrom output data as count vector and
+            // across whole vector. Forth transform output data as count vector and
             // that vector would have size equal to shared key type cardinality and
             // put key counts to corresponding indexes in array. Fifth transform
             // output indicator vector for each key and concatenate them together.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/Conversion/MapValueToKeyMultiColumn.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/Conversion/MapValueToKeyMultiColumn.cs
@@ -62,7 +62,7 @@ namespace Samples.Dynamic
             // transform create it, we could do so by creating an IDataView one
             // column containing the values to map to. If the values in the dataset
             // are not found in the lookup IDataView they will get mapped to the
-            // mising value, 0. The keyData are shared among the columns, therefore
+            // missing value, 0. The keyData are shared among the columns, therefore
             // the keys are not contiguous for the column. Create the lookup map
             // data IEnumerable.  
             var lookupData = new[] {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/LoadImages.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/LoadImages.cs
@@ -66,7 +66,7 @@ namespace Samples.Dynamic
                 .Schema))
             {
                 // Note that it is best to get the getters and values *before*
-                // iteration, so as to faciliate buffer sharing (if applicable),
+                // iteration, so as to facilitate buffer sharing (if applicable),
                 // and column-type validation once, rather than many times.
                 ReadOnlyMemory<char> imagePath = default;
                 ReadOnlyMemory<char> name = default;

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/NormalizeMeanVariance.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/NormalizeMeanVariance.cs
@@ -88,7 +88,7 @@ namespace Samples.Dynamic
 
             var offset = noCdfParams.Offset.Length == 0 ? 0 : noCdfParams.Offset[1];
             var scale = noCdfParams.Scale[1];
-            Console.WriteLine($"Values for slot 1 would be transfromed by " +
+            Console.WriteLine($"Values for slot 1 would be transformed by " +
                 $"applying y = (x - ({offset})) * {scale}");
             // Expected output:
             // The 1-index value in resulting array would be produce by: y = (x - (0)) * 0.8164966

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/Text/ProduceWordBags.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/Text/ProduceWordBags.cs
@@ -26,7 +26,7 @@ namespace Samples.Dynamic
                 new TextData(){ Text = "It does so by first tokenizing " +
                     "text/string into words/tokens then " },
 
-                new TextData(){ Text = "computing n-grams and their neumeric " +
+                new TextData(){ Text = "computing n-grams and their numeric " +
                     "values." },
 
                 new TextData(){ Text = "Each position in the output vector " +
@@ -41,7 +41,7 @@ namespace Samples.Dynamic
                 new TextData(){ Text = "the inverse of the number of documents " +
                     "contain the n-gram (Idf)," },
 
-                new TextData(){ Text = "or compute both and multipy together " +
+                new TextData(){ Text = "or compute both and multiply together " +
                     "(Tf-Idf)." },
             };
 

--- a/test/Microsoft.ML.Benchmarks.Tests/BenchmarksTest.cs
+++ b/test/Microsoft.ML.Benchmarks.Tests/BenchmarksTest.cs
@@ -56,7 +56,7 @@ namespace Microsoft.ML.Benchmarks.Tests
             Assert.True(summary.Reports.Any(), "The \"Summary\" should contain at least one \"BenchmarkReport\" in the \"Reports\" collection");
 
             Assert.True(summary.Reports.All(r => r.BuildResult.IsBuildSuccess),
-                "The following benchmarks are failed to build: " +
+                "The following benchmarks failed to build: " +
                 string.Join(", ", summary.Reports.Where(r => !r.BuildResult.IsBuildSuccess).Select(r => r.BenchmarkCase.DisplayInfo)));
 
             Assert.True(summary.Reports.All(r => r.ExecuteResults != null),

--- a/test/Microsoft.ML.Tests/TrainerEstimators/MatrixFactorizationTests.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/MatrixFactorizationTests.cs
@@ -94,7 +94,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             var rightMatrix = model.Model.RightFactorMatrix;
             Assert.Equal(leftMatrix.Count, model.Model.NumberOfRows * model.Model.ApproximationRank);
             Assert.Equal(rightMatrix.Count, model.Model.NumberOfColumns * model.Model.ApproximationRank);
-            // MF produce different matrixes on different platforms, so at least test thier content on windows.
+            // MF produce different matrices on different platforms, so at least test their content on windows.
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 Assert.Equal(0.33491, leftMatrix[0], 5);
@@ -245,7 +245,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             // Native test. Just check the pipeline runs.
             Assert.True(metrics.MeanSquaredError < 0.1);
 
-            // Create two two entries for making prediction. Of course, the prediction value, Score, is unknown so it's default.
+            // Create two entries for making prediction. Of course, the prediction value, Score, is unknown so it's default.
             var testMatrix = new List<MatrixElementForScore>() {
                 new MatrixElementForScore() { MatrixColumnIndex = 10, MatrixRowIndex = 7, Score = default },
                 new MatrixElementForScore() { MatrixColumnIndex = 3, MatrixRowIndex = 6, Score = default } };
@@ -394,7 +394,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
         // using standard collaborative filtering, all your predictions would
         // be 1! One-class matrix factorization assumes unspecified matrix
         // entries are all 0 (or a small constant value selected by the user)
-        // so that the trainined model can assign purchased itemas higher
+        // so that the trained model can assign purchased items higher
         // scores than those not purchased.
         private const int _oneClassMatrixColumnCount = 2;
         private const int _oneClassMatrixRowCount = 3;


### PR DESCRIPTION
Fix grammatical typos. Utilized [Visual Studio Spell Checker](https://marketplace.visualstudio.com/items?itemName=EWoodruff.VisualStudioSpellCheckerVS2017andLater) to quickly find and implement typo fixes.