### PR TITLE
not copy nuget package to build output to save disk space

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -61,8 +61,7 @@ jobs:
         _includeBenchmarkData: true
     innerLoop: true
     pool:
-      name: NetCorePublic-Pool
-      queue: buildpool.windows.10.amd64.vs2017.open
+      name: Hosted VS2017
 
 - template: /build/ci/job-template.yml
   parameters:

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -23,6 +23,7 @@
     <VSTestLogger>trx</VSTestLogger>
     <VSTestResultsDirectory>$(OutputPath)</VSTestResultsDirectory>
     <AssemblyOriginatorKeyFile>$(ToolsDir)Test.snk</AssemblyOriginatorKeyFile>
+    <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
dotnet core 3.0 build use too much disk space (more than 16GB) and cause build failure on CI, this is  caused by below line of code from build tools (\Tools\dotnetcli\sdk\3.0.100\Sdks\Microsoft.NET.Sdk\targets\Microsoft.PackageDependencyResolution.targets):


<!-- Don't copy local for netstandard projects. -->
    <CopyLocalLockFileAssemblies Condition="'$(CopyLocalLockFileAssemblies)' == '' and
                                            '$(TargetFrameworkIdentifier)' == '.NETStandard'">false</CopyLocalLockFileAssemblies>

    <!-- Don't copy local for netcoreapp projects before 3.0 or non-exe and non-component projects. -->
    <CopyLocalLockFileAssemblies Condition="'$(CopyLocalLockFileAssemblies)' == '' and
                                            '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and
                                            ('$(_TargetFrameworkVersionWithoutV)' &lt; '3.0' or
                                             ('$(HasRuntimeOutput)' != 'true' and '$(EnableDynamicLoading)' != 'true'))">false</CopyLocalLockFileAssemblies>

    <!-- All other project types should copy local. -->
    <CopyLocalLockFileAssemblies Condition="'$(CopyLocalLockFileAssemblies)' == ''">true</CopyLocalLockFileAssemblies>


Override CopyLocalLockFileAssemblies setting to false to save disk space.

Also, change windows netcore 3.0 build to use hosted test agent.