### PR TITLE
Added slot names support for OnnxTransformer

### DIFF
--- a/src/Microsoft.ML.OnnxTransformer/OnnxUtils.cs
+++ b/src/Microsoft.ML.OnnxTransformer/OnnxUtils.cs
@@ -11,6 +11,7 @@ using Microsoft.ML.Model.OnnxConverter;
 using Microsoft.ML.OnnxRuntime;
 using Microsoft.ML.OnnxRuntime.Tensors;
 using Microsoft.ML.Runtime;
+using static Microsoft.ML.Model.OnnxConverter.OnnxCSharpToProtoWrapper;
 using OnnxShape = System.Collections.Generic.List<int>;
 
 namespace Microsoft.ML.Transforms.Onnx
@@ -157,6 +158,8 @@ namespace Microsoft.ML.Transforms.Onnx
         /// </summary>
         internal OnnxModelInfo ModelInfo { get; }
 
+        internal GraphProto Graph { get; }
+
         /// <summary>
         /// Constructs OnnxModel object from file.
         /// </summary>
@@ -217,6 +220,8 @@ namespace Microsoft.ML.Transforms.Onnx
 
             // Create a view to the used ONNX model from ONNXRuntime's perspective.
             ModelInfo = new OnnxModelInfo(inputInfos, outputInfos, overrideableInitializers);
+
+            Graph = model.Graph;
         }
 
         private List<OnnxVariableInfo> GetOnnxVariablesFromMetadata(IReadOnlyDictionary<string, NodeMetadata> nodeMetadata,
@@ -232,6 +237,10 @@ namespace Microsoft.ML.Transforms.Onnx
                 var meta = pair.Value;
                 var dataViewType = typePool[name];
                 var caster = casterPool?[name];
+
+                if (name.StartsWith("mlnet.") &&
+                    (name.EndsWith(".unusedInput") || name.EndsWith(".unusedOutput")))
+                    continue;
 
                 OnnxVariableInfo info = null;
                 if (shapeDictionary != null && shapeDictionary.ContainsKey(name))

--- a/src/Microsoft.ML.Transforms/Text/NgramTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/NgramTransform.cs
@@ -770,9 +770,6 @@ namespace Microsoft.ML.Transforms.Text
 
             private void SaveAsOnnxCore(OnnxContext ctx, int iinfo, string srcVariableName, string dstVariableName)
             {
-                VBuffer<ReadOnlyMemory<char>> slotNames = default;
-                GetSlotNames(iinfo, 0, ref slotNames);
-
                 var transformInfo = _parent._transformInfos[iinfo];
 
                 // TfIdfVectorizer accepts strings, int32 and int64 tensors.

--- a/test/BaselineOutput/Common/Onnx/BinaryClassification/BreastCancer/OneHotBagPipeline.txt
+++ b/test/BaselineOutput/Common/Onnx/BinaryClassification/BreastCancer/OneHotBagPipeline.txt
@@ -324,8 +324,8 @@
           {
             "name": "target_weights",
             "floats": [
-              0.50476193,
-              -0.97911227
+              0.504761934,
+              -0.979112267
             ],
             "type": "FLOATS"
           }
@@ -430,6 +430,51 @@
       },
       {
         "input": [
+          "mlnet.F2.SlotNames"
+        ],
+        "output": [
+          "mlnet.F2.unusedOutput"
+        ],
+        "name": "mlnet.F2.SlotNames",
+        "opType": "LabelEncoder",
+        "attribute": [
+          {
+            "name": "keys_strings",
+            "strings": [
+              "NA==",
+              "MQ==",
+              "OA==",
+              "MTA=",
+              "Mg==",
+              "Mw==",
+              "Nw==",
+              "NQ==",
+              "Ng==",
+              "OQ=="
+            ],
+            "type": "STRINGS"
+          },
+          {
+            "name": "values_int64s",
+            "ints": [
+              "0",
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9"
+            ],
+            "type": "INTS"
+          }
+        ],
+        "domain": "ai.onnx.ml"
+      },
+      {
+        "input": [
           "Features"
         ],
         "output": [
@@ -437,6 +482,53 @@
         ],
         "name": "Identity2",
         "opType": "Identity"
+      },
+      {
+        "input": [
+          "mlnet.Features.SlotNames"
+        ],
+        "output": [
+          "mlnet.Features.unusedOutput"
+        ],
+        "name": "mlnet.Features.SlotNames",
+        "opType": "LabelEncoder",
+        "attribute": [
+          {
+            "name": "keys_strings",
+            "strings": [
+              "RjE=",
+              "RjIuNA==",
+              "RjIuMQ==",
+              "RjIuOA==",
+              "RjIuMTA=",
+              "RjIuMg==",
+              "RjIuMw==",
+              "RjIuNw==",
+              "RjIuNQ==",
+              "RjIuNg==",
+              "RjIuOQ=="
+            ],
+            "type": "STRINGS"
+          },
+          {
+            "name": "values_int64s",
+            "ints": [
+              "0",
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10"
+            ],
+            "type": "INTS"
+          }
+        ],
+        "domain": "ai.onnx.ml"
       },
       {
         "input": [
@@ -484,6 +576,28 @@
           0
         ],
         "name": "Offset"
+      },
+      {
+        "dims": [
+          "1",
+          "1"
+        ],
+        "dataType": 8,
+        "stringData": [
+          "b25l"
+        ],
+        "name": "mlnet.F2.SlotNames"
+      },
+      {
+        "dims": [
+          "1",
+          "1"
+        ],
+        "dataType": 8,
+        "stringData": [
+          "b25l"
+        ],
+        "name": "mlnet.Features.SlotNames"
       }
     ],
     "input": [
@@ -598,6 +712,24 @@
         }
       },
       {
+        "name": "mlnet.F2.unusedOutput",
+        "type": {
+          "tensorType": {
+            "elemType": 7,
+            "shape": {
+              "dim": [
+                {
+                  "dimValue": "-1"
+                },
+                {
+                  "dimValue": "1"
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
         "name": "Features.output",
         "type": {
           "tensorType": {
@@ -609,6 +741,24 @@
                 },
                 {
                   "dimValue": "11"
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "name": "mlnet.Features.unusedOutput",
+        "type": {
+          "tensorType": {
+            "elemType": 7,
+            "shape": {
+              "dim": [
+                {
+                  "dimValue": "-1"
+                },
+                {
+                  "dimValue": "1"
                 }
               ]
             }

--- a/test/BaselineOutput/Common/Onnx/MultiClassClassification/BreastCancer/MultiClassificationLogisticRegressionSaveModelToOnnxTest.txt
+++ b/test/BaselineOutput/Common/Onnx/MultiClassClassification/BreastCancer/MultiClassificationLogisticRegressionSaveModelToOnnxTest.txt
@@ -322,6 +322,51 @@
         ],
         "name": "Identity2",
         "opType": "Identity"
+      },
+      {
+        "input": [
+          "mlnet.Score.SlotNames"
+        ],
+        "output": [
+          "mlnet.Score.unusedOutput"
+        ],
+        "name": "mlnet.Score.SlotNames",
+        "opType": "LabelEncoder",
+        "attribute": [
+          {
+            "name": "keys_strings",
+            "strings": [
+              "NQ==",
+              "Mw==",
+              "Ng==",
+              "NA==",
+              "OA==",
+              "MQ==",
+              "Mg==",
+              "Nw==",
+              "MTA=",
+              "OQ=="
+            ],
+            "type": "STRINGS"
+          },
+          {
+            "name": "values_int64s",
+            "ints": [
+              "0",
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9"
+            ],
+            "type": "INTS"
+          }
+        ],
+        "domain": "ai.onnx.ml"
       }
     ],
     "name": "model",
@@ -336,6 +381,17 @@
           "1"
         ],
         "name": "ShapeVar"
+      },
+      {
+        "dims": [
+          "1",
+          "1"
+        ],
+        "dataType": 8,
+        "stringData": [
+          "b25l"
+        ],
+        "name": "mlnet.Score.SlotNames"
       }
     ],
     "input": [
@@ -443,6 +499,24 @@
                 },
                 {
                   "dimValue": "10"
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "name": "mlnet.Score.unusedOutput",
+        "type": {
+          "tensorType": {
+            "elemType": 7,
+            "shape": {
+              "dim": [
+                {
+                  "dimValue": "-1"
+                },
+                {
+                  "dimValue": "1"
                 }
               ]
             }


### PR DESCRIPTION
This PR adds support for persisting the SlotNames annotations of a column during onnx export and reading those back in OnnxTransformer and adding the annotations back to the column when the onnx model is read from disk.

Onnx natively does not have support for annotations. To work around this, we store some metadata in some unused portions of the graph. As an example, let us say we have an ML.NET model with an output column NGrams that outputs a vector of NGram counts. This column will have an Annotation in ML.NET named SlotNames. When this model is exported to onnx, we create an additional LabelEncoder node and store the SlotNames in the keys_strings attribute of the LabelEncoder.

The LabelEncoder is created with an input name of `$"mlnet.{column.Name}.unusedInput"`, an output name of $"mlnet.{column.Name}.unusedOutput" and a node name of `$"mlnet.{column.Name}.SlotNames"`. (All the actual output columns of the ML.NET model are suffixed with a `".output"` string)

Then when OnnxTransformer loads the graph it goes through the list of output nodes and creates output columns for each of them in its output schema. For each column it searches the graph for a node named `$"mlnet.{column.Name}.SlotNames"`. If it finds it, it reads the keys_strings attributes from that node and adds those strings as SlotNames annotation to that column. 

This SlotNames data should then be available as annotations on the column in both ML.NET and Nimbus.


