### PR TITLE
set library path for centos and ubuntu

### DIFF
--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -48,7 +48,7 @@ jobs:
     - ${{ if eq(parameters.pool.name, 'Hosted macOS High Sierra') }}:
       - script: brew update && brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/f5b1ac99a7fba27c19cee0bc4f036775c889b359/Formula/libomp.rb && brew unlink python@2 && brew install mono-libgdiplus gettext && brew link gettext --force && brew link libomp --force
         displayName: Install build dependencies
-    - ${{ if and( eq(parameters.nightlyBuild, 'true'), eq(parameters.name, 'Ubuntu_x64_NetCoreApp21')) }}:
+    - ${{ if and( eq(parameters.nightlyBuild, 'true'), eq(parameters.pool.name, 'Hosted Ubuntu 1604')) }}:
       - bash: echo "##vso[task.setvariable variable=LD_LIBRARY_PATH]$(nightlyBuildRunPath):$LD_LIBRARY_PATH"
         displayName: Set LD_LIBRARY_PATH for Ubuntu to locate Native shared library in current running path
     - script: ${{ parameters.buildScript }} -$(_configuration) -buildArch=${{ parameters.architecture }}


### PR DESCRIPTION
set library path for centos as well as we are observing below error from NightlyBuild pipeline for CentOS:

X Microsoft.ML.Functional.Tests.Training.ContinueTrainingSymbolicStochasticGradientDescent [121ms]
  Error Message:
   System.DllNotFoundException : Unable to load shared library 'SymSgdNative' or one of its dependencies. In order to help diagnose loading problems, consider setting the LD_DEBUG environment variable: libSymSgdNative: cannot open shared object file: No such file or directory
  Stack Trace:
     at Microsoft.ML.Trainers.SymbolicSgdLogisticRegressionBinaryTrainer.Native.LearnAll(Int32 totalNumInstances, Int32* instSizes, Int32** instIndices, Single** instValues, Single* labels, Boolean tuneLR, Single& lr, Single l2Const, Single piw, Single* weightVector, Single& bias, Int32 numFeatres, Int32 numPasses, Int32 numThreads, Boolean tuneNumLocIter, Int32& numLocIter, Single tolerance, Boolean needShuffle, Boolean shouldInitialize, State* state, ChannelCallBack info)
   at Microsoft.ML.Trainers.SymbolicSgdLogisticRegressionBinaryTrainer.Native.LearnAll(InputDataManager inputDataManager, Boolean tuneLR, Single& lr, Single l2Const, Single piw, Span`1 weightVector, Single& bias, Int32 numFeatres, Int32 numPasses, Int32 numThreads, Boolean tuneNumLocIter, Int32& numLocIter, Single tolerance, Boolean needShuffle, Boolean shouldInitialize, GCHandle stateGCHandle, ChannelCallBack info)
   at Microsoft.ML.Trainers.SymbolicSgdLogisticRegressionBinaryTrainer.TrainCore(IChannel ch, RoleMappedData data, LinearModelParameters predictor, Int32 weightSetCount)
   at Microsoft.ML.Trainers.SymbolicSgdLogisticRegressionBinaryTrainer.TrainModelCore(TrainContext context)
   at Microsoft.ML.Trainers.TrainerEstimatorBase`2.TrainTransformer(IDataView trainSet, IDataView validationSet, IPredictor initPredictor)
   at Microsoft.ML.Trainers.TrainerEstimatorBase`2.Fit(IDataView input)
   at Microsoft.ML.Functional.Tests.Training.ContinueTrainingSymbolicStochasticGradientDescent() in /__w/1/s/test/Microsoft.ML.Functional.Tests/Training.cs:line 420

https://dev.azure.com/dnceng/public/_build/results?buildId=527464&view=logs&j=c83e03a9-ccae-58c2-be03-4a20d31c7f0e&t=c2d1124c-8b3e-5953-2f5c-b9febb7524be
