### PR TITLE
fix nightly-build

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -21,10 +21,12 @@ jobs:
         _configuration: Debug-netcoreapp3_0
         _config_short: DI
         _includeBenchmarkData: false
+        _targetFramework: netcoreapp3.0
       Release_Build:
         _configuration: Release-netcoreapp3_0
         _config_short: RI
         _includeBenchmarkData: true
+        _targetFramework: netcoreapp3.0
     innerLoop: true
     pool:
       name: Hosted Ubuntu 1604
@@ -55,10 +57,12 @@ jobs:
         _configuration: Debug-netcoreapp3_0
         _config_short: DI
         _includeBenchmarkData: false
+        _targetFramework: netcoreapp3.0
       Release_Build:
         _configuration: Release-netcoreapp3_0
         _config_short: RI
         _includeBenchmarkData: true
+        _targetFramework: netcoreapp3.0
     innerLoop: true
     pool:
       name: Hosted VS2017
@@ -80,10 +84,12 @@ jobs:
         _configuration: Debug-netfx
         _config_short: DFX
         _includeBenchmarkData: false
+        _targetFramework: win-x64
       Release_Build:
         _configuration: Release-netfx
         _config_short: RFX
         _includeBenchmarkData: false
+        _targetFramework: win-x64
     innerLoop: true
     pool:
       name: Hosted VS2017

--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -23,7 +23,7 @@ jobs:
       dotnetPath: $(Build.SourcesDirectory)/Tools/dotnetcli/dotnet
       nugetFeed: https://pkgs.dev.azure.com/dnceng/public/_packaging/MachineLearning/nuget/v3/index.json
       nightlyBuildProjPath: $(Build.SourcesDirectory)/test/Microsoft.ML.NightlyBuild.Tests/Microsoft.ML.NightlyBuild.Tests.csproj
-      nightlyBuildRunPath: (Build.SourcesDirectory)/bin/AnyCPU.(_configuration)/Microsoft.ML.NightlyBuild.Tests/netcoreapp2.1
+      nightlyBuildRunPath: (Build.SourcesDirectory)/bin/AnyCPU.(_configuration)/Microsoft.ML.NightlyBuild.Tests/(_targetFramework)
       packageUpdaterProjPath: $(Build.SourcesDirectory)/test/Microsoft.ML.NugetPackageVersionUpdater/Microsoft.ML.NugetPackageVersionUpdater.csproj
       versionFilePath: $(Build.SourcesDirectory)/test/Microsoft.ML.NugetPackageVersionUpdater/latest_versions.txt
     strategy:
@@ -33,10 +33,12 @@ jobs:
             _configuration: Debug
             _config_short: D
             _includeBenchmarkData: false
+            _targetFramework: netcoreapp2.1
           Release_Build:
             _configuration: Release
             _config_short: R
             _includeBenchmarkData: true
+            _targetFramework: netcoreapp2.1
         ${{ if ne(parameters.customMatrixes, '') }}:
           ${{ insert }}: ${{ parameters.customMatrixes }}
     


### PR DESCRIPTION
related to https://github.com/dotnet/machinelearning/pull/4859.

centos is building with netcore3.0 not netcore2.1, add targetFramework parameter to distinct that


