### PR TITLE
fix netfx test not running issue

### DIFF
--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -23,7 +23,7 @@
     <VSTestLogger>trx</VSTestLogger>
     <VSTestResultsDirectory>$(OutputPath)</VSTestResultsDirectory>
     <AssemblyOriginatorKeyFile>$(ToolsDir)Test.snk</AssemblyOriginatorKeyFile>
-    <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
+    <CopyLocalLockFileAssemblies Condition="'$(TargetFramework)' == 'netcoreapp3.0'">false</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
related to PR: https://github.com/dotnet/machinelearning/pull/4854

setting CopyLocalLockFileAssemblies to false for netfx cause test not running on CI like below:
https://dev.azure.com/dnceng/public/_build/results?buildId=528701&view=logs&j=32952595-30e7-56fa-9b86-c4579b87f5d1

restrict CopyLocalLockFileAssemblies to false only for netcore 3.0

