### PR TITLE
Fix for KeytoValue transformer

### DIFF
--- a/src/Microsoft.ML.Data/Transforms/KeyToValue.cs
+++ b/src/Microsoft.ML.Data/Transforms/KeyToValue.cs
@@ -565,12 +565,11 @@ namespace Microsoft.ML.Transforms
                 {
                     var info = _parent.ColumnPairs[iinfo];
                     var inputColumnName = info.inputColumnName;
-
                     if (!ctx.ContainsColumn(inputColumnName))
                         continue;
-
+                    string srcVariableName = ctx.GetVariableName(inputColumnName);
                     var dstVariableName = ctx.AddIntermediateVariable(_types[iinfo], info.outputColumnName, true);
-                    if (!_kvMaps[iinfo].SaveOnnx(ctx, inputColumnName, dstVariableName))
+                    if (!_kvMaps[iinfo].SaveOnnx(ctx, srcVariableName, dstVariableName))
                     {
                         ctx.RemoveColumn(inputColumnName, true);
                     }

--- a/src/Microsoft.ML.Data/Transforms/KeyToValue.cs
+++ b/src/Microsoft.ML.Data/Transforms/KeyToValue.cs
@@ -565,6 +565,7 @@ namespace Microsoft.ML.Transforms
                 {
                     var info = _parent.ColumnPairs[iinfo];
                     var inputColumnName = info.inputColumnName;
+
                     if (!ctx.ContainsColumn(inputColumnName))
                         continue;
                     string srcVariableName = ctx.GetVariableName(inputColumnName);


### PR DESCRIPTION
Fix a small bug where the source variable name of an ONNX graph was mistakenly always the input variable name, which is not always the case. Other ONNX transformers don't explicitly test for this functionality, so I didn't add a test case. 