### PR TITLE
Re-enabling disabled tests due to wrong nrBins value

### DIFF
--- a/src/Microsoft.ML.Recommender/MatrixFactorizationTrainer.cs
+++ b/src/Microsoft.ML.Recommender/MatrixFactorizationTrainer.cs
@@ -513,7 +513,7 @@ namespace Microsoft.ML.Trainers
 
         private SafeTrainingAndModelBuffer PrepareBuffer()
         {
-            return new SafeTrainingAndModelBuffer(_host, _fun, _k, _threads, Math.Max(20, 2 * _threads),
+            return new SafeTrainingAndModelBuffer(_host, _fun, _k, _threads, _threads == 1 ? 1 : Math.Max(20, 2 * _threads),
                 _iter, _lambda, _eta, _alpha, _c, _doNmf, _quiet, copyData: false);
         }
 

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
@@ -2124,7 +2124,6 @@ namespace Microsoft.ML.RunTests
 
         [LessThanNetCore30OrNotNetCoreFact("netcoreapp3.0 output differs from Baseline")]
         //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
-        [Trait("Category", "SkipInCI")]
         public void EntryPointPipelineEnsembleGetSummary()
         {
             var dataPath = GetDataPath("breast-cancer-withheader.txt");
@@ -6194,7 +6193,6 @@ namespace Microsoft.ML.RunTests
 
         [Fact]
         //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
-        [Trait("Category", "SkipInCI")]
         public void TestOvaMacroWithUncalibratedLearner()
         {
             var dataPath = GetDataPath(@"iris.txt");

--- a/test/Microsoft.ML.Predictor.Tests/TestPredictors.cs
+++ b/test/Microsoft.ML.Predictor.Tests/TestPredictors.cs
@@ -189,7 +189,6 @@ namespace Microsoft.ML.RunTests
         [TestCategory("Logistic Regression")]
         [TestCategory("FastTree")]
         //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
-        [Trait("Category", "SkipInCI")]
         public void MulticlassTreeFeaturizedLRTest()
         {
             RunMTAThread(() =>


### PR DESCRIPTION
Fixed case with erroneous SafeTrainingAndModelBuffer.nrBins value, where if _threads = 1, nrBins should also equal 1. This way, when thread count is 1, there is no need to divide the training matrix into multiple blocks as 1 will do fine. As a result, we can re-enable the following disabled tests:

- MatrixFactorizationSimpleTrainAndPredict
- MulticlassTreeFeaturizedLRTest
- TestOvaMacroWithUncalibratedLearner
- EntryPointPipelineEnsembleGetSummary