### PR TITLE
Disabling TestOldSavingAndLoading() and TestDnnImageFeaturizer()

### DIFF
--- a/test/Microsoft.ML.OnnxTransformerTest/DnnImageFeaturizerTest.cs
+++ b/test/Microsoft.ML.OnnxTransformerTest/DnnImageFeaturizerTest.cs
@@ -54,6 +54,8 @@ namespace Microsoft.ML.Tests
         }
 
         [OnnxFact]
+        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
+        [Trait("Category", "SkipInCI")]
         public void TestDnnImageFeaturizer()
         {
             var samplevector = GetSampleArrayData();
@@ -125,6 +127,8 @@ namespace Microsoft.ML.Tests
 
         // Onnx is only supported on x64 Windows
         [OnnxFact]
+        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
+        [Trait("Category", "SkipInCI")]
         public void TestOldSavingAndLoading()
         {
             var samplevector = GetSampleArrayData();


### PR DESCRIPTION
Temporarily disabling 2 ONNX tests: TestOldSavingAndLoading() and TestDnnImageFeaturizer()