### PR TITLE
enable 2 tests but skip running from x86

### DIFF
--- a/test/Microsoft.ML.OnnxTransformerTest/DnnImageFeaturizerTest.cs
+++ b/test/Microsoft.ML.OnnxTransformerTest/DnnImageFeaturizerTest.cs
@@ -54,10 +54,13 @@ namespace Microsoft.ML.Tests
         }
 
         [OnnxFact]
-        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
-        [Trait("Category", "SkipInCI")]
         public void TestDnnImageFeaturizer()
         {
+            //skip running for x86 as this test using too much memory (over 2GB limit on x86) 
+            //and very like to hit memory related issue when running on CI
+            if (!Environment.Is64BitProcess)
+                return;
+
             var samplevector = GetSampleArrayData();
 
             var dataView = DataViewConstructionUtils.CreateFromList(Env,
@@ -125,12 +128,14 @@ namespace Microsoft.ML.Tests
             }
         }
 
-        // Onnx is only supported on x64 Windows
         [OnnxFact]
-        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
-        [Trait("Category", "SkipInCI")]
         public void TestOldSavingAndLoading()
         {
+            //skip running for x86 as this test using too much memory (over 2GB limit on x86) 
+            //and very like to hit memory related issue when running on CI
+            if (!Environment.Is64BitProcess)
+                return;
+
             var samplevector = GetSampleArrayData();
 
             var dataView = ML.Data.LoadFromEnumerable(

--- a/test/Microsoft.ML.OnnxTransformerTest/DnnImageFeaturizerTest.cs
+++ b/test/Microsoft.ML.OnnxTransformerTest/DnnImageFeaturizerTest.cs
@@ -58,6 +58,7 @@ namespace Microsoft.ML.Tests
         {
             //skip running for x86 as this test using too much memory (over 2GB limit on x86) 
             //and very like to hit memory related issue when running on CI
+            //TODO: optimized memory usage in related code and enable x86 test run
             if (!Environment.Is64BitProcess)
                 return;
 
@@ -133,6 +134,7 @@ namespace Microsoft.ML.Tests
         {
             //skip running for x86 as this test using too much memory (over 2GB limit on x86) 
             //and very like to hit memory related issue when running on CI
+            //TODO: optimized memory usage in related code and enable x86 run
             if (!Environment.Is64BitProcess)
                 return;
 


### PR DESCRIPTION
TestOldSavingAndLoading and TestDnnImageFeaturizer uses too much memory and not suitable to run on x86 (which has 2 GB memory limit by default).

Re-enable these 2 tests if memory usage has been optimized.