### PR TITLE
Typo corrections

### DIFF
--- a/src/Microsoft.ML.AutoML/API/RunDetails/CrossValidationRunDetail.cs
+++ b/src/Microsoft.ML.AutoML/API/RunDetails/CrossValidationRunDetail.cs
@@ -58,7 +58,7 @@ namespace Microsoft.ML.AutoML
         /// <see langword="null"/> if no exception was encountered.
         /// </summary>
         /// <remarks>
-        /// If an exception occurred, it's possible some properties in ths object
+        /// If an exception occurred, it's possible some properties in this object
         /// (like <see cref="Model"/>) could be <see langword="null"/>.
         /// </remarks>
         public Exception Exception { get; private set; }

--- a/src/Microsoft.ML.AutoML/API/RunDetails/RunDetail.cs
+++ b/src/Microsoft.ML.AutoML/API/RunDetails/RunDetail.cs
@@ -42,7 +42,7 @@ namespace Microsoft.ML.AutoML
         /// no exception was encountered.
         /// </summary>
         /// <remarks>
-        /// If an exception occurred, it's possible some properties in ths object
+        /// If an exception occurred, it's possible some properties in this object
         /// (like <see cref="Model"/>) could be <see langword="null"/>.
         /// </remarks>
         public Exception Exception { get; private set; }

--- a/src/Microsoft.ML.AutoML/ColumnInference/ColumnGroupingInference.cs
+++ b/src/Microsoft.ML.AutoML/ColumnInference/ColumnGroupingInference.cs
@@ -12,7 +12,7 @@ using static Microsoft.ML.Data.TextLoader;
 namespace Microsoft.ML.AutoML
 {
     /// <summary>
-    /// This class incapsulates logic for grouping together the inferred columns of the text file based on their type
+    /// This class encapsulates logic for grouping together the inferred columns of the text file based on their type
     /// and purpose, and generating column names.
     /// </summary>
     internal static class ColumnGroupingInference

--- a/src/Microsoft.ML.AutoML/ColumnInference/ColumnTypeInference.cs
+++ b/src/Microsoft.ML.AutoML/ColumnInference/ColumnTypeInference.cs
@@ -12,7 +12,7 @@ using Microsoft.ML.Data.Conversion;
 namespace Microsoft.ML.AutoML
 {
     /// <summary>
-    /// This class incapsulates logic for automatic inference of column types for the text file.
+    /// This class encapsulates logic for automatic inference of column types for the text file.
     /// It also attempts to guess whether there is a header row.
     /// </summary>
     internal static class ColumnTypeInference

--- a/src/Microsoft.ML.AutoML/ColumnInference/TextFileSample.cs
+++ b/src/Microsoft.ML.AutoML/ColumnInference/TextFileSample.cs
@@ -114,7 +114,7 @@ namespace Microsoft.ML.AutoML
             var lineCount = firstChunk.Count(x => x == '\n');
             if (lineCount == 0)
             {
-                throw new ArgumentException("Counldn't identify line breaks. Provided file is not text?");
+                throw new ArgumentException("Couldn't identify line breaks. Provided file is not text?");
             }
 
             long approximateRowCount = (long)(lineCount * fileSize * 1.0 / firstChunk.Length);

--- a/src/Microsoft.ML.AutoML/Experiment/SuggestedPipeline.cs
+++ b/src/Microsoft.ML.AutoML/Experiment/SuggestedPipeline.cs
@@ -11,7 +11,7 @@ namespace Microsoft.ML.AutoML
 {
     /// <summary>
     /// A runnable pipeline. Contains a learner and set of transforms,
-    /// along with a RunSummary if it has already been exectued.
+    /// along with a RunSummary if it has already been executed.
     /// </summary>
     internal class SuggestedPipeline
     {

--- a/src/Microsoft.ML.AutoML/PipelineSuggesters/PipelineSuggester.cs
+++ b/src/Microsoft.ML.AutoML/PipelineSuggesters/PipelineSuggester.cs
@@ -49,7 +49,7 @@ namespace Microsoft.ML.AutoML
             // sort top trainers by # of times they've been run, from lowest to highest
             var orderedTopTrainers = OrderTrainersByNumTrials(history, topTrainers);
 
-            // keep as hashset of previously visited pipelines
+            // keep as hash set of previously visited pipelines
             var visitedPipelines = new HashSet<SuggestedPipeline>(history.Select(h => h.Pipeline));
 
             // iterate over top trainers (from least run to most run),
@@ -186,7 +186,7 @@ namespace Microsoft.ML.AutoML
 
         /// <summary>
         /// Samples new hyperparameters for the trainer, and sets them.
-        /// Returns true if success (new hyperparams were suggested and set). Else, returns false.
+        /// Returns true if success (new hyperparameters were suggested and set). Else, returns false.
         /// </summary>
         private static bool SampleHyperparameters(MLContext context, SuggestedTrainer trainer, IEnumerable<SuggestedPipelineRunDetail> history, bool isMaximizingMetric)
         {
@@ -207,7 +207,7 @@ namespace Microsoft.ML.AutoML
                 return false;
             }
 
-            // associate proposed param set with trainer, so that smart hyperparam
+            // associate proposed parameter set with trainer, so that smart hyperparameter
             // sweepers (like KDO) can map them back.
             trainer.SetHyperparamValues(proposedParamSet);
 

--- a/src/Microsoft.ML.AutoML/Sweepers/Parameters.cs
+++ b/src/Microsoft.ML.AutoML/Sweepers/Parameters.cs
@@ -17,7 +17,7 @@ namespace Microsoft.ML.AutoML
 
     internal abstract class NumericParamArguments : BaseParamArguments
     {
-        // Number of steps for grid runthrough.
+        // Number of steps for grid run-through.
         public int NumSteps;
 
         // Amount of increment between steps (multiplicative if log).

--- a/src/Microsoft.ML.AutoML/Sweepers/SmacSweeper.cs
+++ b/src/Microsoft.ML.AutoML/Sweepers/SmacSweeper.cs
@@ -13,7 +13,7 @@ using Float = System.Single;
 namespace Microsoft.ML.AutoML
 {
     //REVIEW: Figure out better way to do this. could introduce a base class for all smart sweepers,
-    //encapsulating common functionality. This seems like a good plan to persue.
+    //encapsulating common functionality. This seems like a good plan to pursue.
     internal sealed class SmacSweeper : ISweeper
     {
         public sealed class Arguments
@@ -140,12 +140,12 @@ namespace Microsoft.ML.AutoML
 
         /// <summary>
         /// Generates a set of candidate configurations to sweep through, based on a combination of random and local
-        /// search, as outlined in Hutter et al - Sequential Model-Based Optimization for General Algorithm Conﬁguration.
+        /// search, as outlined in Hutter et al. - Sequential Model-Based Optimization for General Algorithm Conﬁguration.
         /// Makes use of class private members which determine how many candidates are returned. This number will include
         /// random configurations interleaved (per the paper), and thus will be double the specified value.
         /// </summary>
         /// <param name="numOfCandidates">Number of candidate solutions to return.</param>
-        /// <param name="previousRuns">History of previously evaluated points, with their emprical performance values.</param>
+        /// <param name="previousRuns">History of previously evaluated points, with their empirical performance values.</param>
         /// <param name="forest">Trained random forest ensemble. Used in evaluating the candidates.</param>
         /// <returns>An array of ParamaterSets which are the candidate configurations to sweep.</returns>
         private ParameterSet[] GenerateCandidateConfigurations(int numOfCandidates, IEnumerable<IRunResult> previousRuns, FastForestRegressionModelParameters forest)
@@ -251,8 +251,8 @@ namespace Microsoft.ML.AutoML
         }
 
         /// <summary>
-        /// Computes a single-mutation neighborhood (one param at a time) for a given configuration. For
-        /// numeric parameters, samples K mutations (i.e., creates K neighbors based on that paramater).
+        /// Computes a single-mutation neighborhood (one parameter at a time) for a given configuration. For
+        /// numeric parameters, samples K mutations (i.e., creates K neighbors based on that parameter).
         /// </summary>
         /// <param name="parent">Starting configuration.</param>
         /// <returns>A set of configurations that each differ from parent in exactly one parameter.</returns>

--- a/src/Microsoft.ML.AutoML/Utils/UserInputValidationUtil.cs
+++ b/src/Microsoft.ML.AutoML/Utils/UserInputValidationUtil.cs
@@ -191,7 +191,7 @@ namespace Microsoft.ML.AutoML
 
             // Validate that every active column in the train data corresponds to an active column in the validation data.
             // (Indirectly, since we asserted above that the train and validation data have the same number of active columns, this also
-            // esnures the reverse -- that every active column in the validation data corresponds to an active column in the train data.)
+            // ensures the reverse -- that every active column in the validation data corresponds to an active column in the train data.)
             foreach (var trainCol in trainData.Schema)
             {
                 if (trainCol.IsHidden)
@@ -202,7 +202,7 @@ namespace Microsoft.ML.AutoML
                 var validCol = validationData.Schema.GetColumnOrNull(trainCol.Name);
                 if (validCol == null)
                 {
-                    throw new ArgumentException($"{schemaMismatchError} Column '{trainCol.Name}' exsits in train data, but not in validation data.", nameof(validationData));
+                    throw new ArgumentException($"{schemaMismatchError} Column '{trainCol.Name}' exists in train data, but not in validation data.", nameof(validationData));
                 }
 
                 if (trainCol.Type != validCol.Value.Type)

--- a/src/Microsoft.ML.Core/BestFriendAttribute.cs
+++ b/src/Microsoft.ML.Core/BestFriendAttribute.cs
@@ -16,7 +16,7 @@ namespace Microsoft.ML
     /// Intended to be applied to types and members with internal scope to indicate that friend access of this
     /// internal item is OK from another assembly. This restriction applies only to assemblies that declare the
     /// <see cref="WantsToBeBestFriendsAttribute"/> assembly level attribute. Note that this attribute is not
-    /// transferrable: an internal member with this attribute does not somehow make a containing internal type
+    /// transferable: an internal member with this attribute does not somehow make a containing internal type
     /// accessible. Conversely, neither does marking an internal type make any unmarked internal members accessible.
     /// </summary>
     [BestFriend]

--- a/src/Microsoft.ML.Core/CommandLine/ArgumentType.cs
+++ b/src/Microsoft.ML.Core/CommandLine/ArgumentType.cs
@@ -26,7 +26,7 @@ namespace Microsoft.ML.CommandLine
         Unique = 0x02,
 
         /// <summary>
-        /// Inidicates that the argument may be specified more than once.
+        /// Indicates that the argument may be specified more than once.
         /// Only valid if the argument is a collection
         /// </summary>
         Multiple = 0x04,

--- a/src/Microsoft.ML.Core/CommandLine/CmdLexer.cs
+++ b/src/Microsoft.ML.Core/CommandLine/CmdLexer.cs
@@ -220,7 +220,7 @@ namespace Microsoft.ML.CommandLine
             while (_curs.ChNext() == '\\')
                 cv++;
 
-            // This assumes that slash is escaped iff it preceeds a special character
+            // This assumes that slash is escaped iff it precedes a special character
             switch (_curs.ChCur)
             {
                 case '"':

--- a/src/Microsoft.ML.Core/CommandLine/CmdParser.cs
+++ b/src/Microsoft.ML.Core/CommandLine/CmdParser.cs
@@ -97,7 +97,7 @@ namespace Microsoft.ML.CommandLine
     //        }
     //    }
     //
-    //    So you could call this aplication with the following command line to count
+    //    So you could call this application with the following command line to count
     //    lines in the foo and bar files:
     //
     //        wc.exe /lines /files:foo /files:bar
@@ -115,14 +115,14 @@ namespace Microsoft.ML.CommandLine
     //        @<file>                             Read response file for more options
     //
     //    That was pretty easy. However, you really want to omit the "/files:" for the
-    //    list of files. The details of field parsing can be controled using custom
-    //    attributes. The attributes which control parsing behaviour are:
+    //    list of files. The details of field parsing can be controlled using custom
+    //    attributes. The attributes which control parsing behavior are:
     //
     //    ArgumentAttribute
     //        - controls short name, long name, required, allow duplicates, default value
     //        and help text
     //    DefaultArgumentAttribute
-    //        - allows omition of the "/name".
+    //        - allows omission of the "/name".
     //        - This attribute is allowed on only one field in the argument class.
     //
     //    So for the wc.exe program we want this:
@@ -180,7 +180,7 @@ namespace Microsoft.ML.CommandLine
     /// <summary>
     /// Parser for command line arguments.
     ///
-    /// The parser specification is infered from the instance fields of the object
+    /// The parser specification is inferred from the instance fields of the object
     /// specified as the destination of the parse.
     /// Valid argument types are: int, uint, string, bool, enums
     /// Also argument types of Array of the above types are also valid.
@@ -209,9 +209,9 @@ namespace Microsoft.ML.CommandLine
         private readonly IHost _host;
 
         /// <summary>
-        /// Parses a command line. This assumes that the exe name has been stripped off.
+        /// Parses a command line. This assumes that the .exe name has been stripped off.
         /// Errors are output on Console.Error.
-        /// Use ArgumentAttributes to control parsing behaviour.
+        /// Use ArgumentAttributes to control parsing behavior.
         /// </summary>
         /// <param name="env"> The host environment</param>
         /// <param name="settings">The command line</param>
@@ -223,8 +223,8 @@ namespace Microsoft.ML.CommandLine
         }
 
         /// <summary>
-        /// Parses a command line. This assumes that the exe name has been stripped off.
-        /// Use ArgumentAttributes to control parsing behaviour.
+        /// Parses a command line. This assumes that the .exe name has been stripped off.
+        /// Use ArgumentAttributes to control parsing behavior.
         /// </summary>
         /// <param name="env"> The host environment</param>
         /// <param name="settings">The command line</param>
@@ -268,7 +268,7 @@ namespace Microsoft.ML.CommandLine
 
         /// <summary>
         /// Parses a command line. This assumes that the exe name has been stripped off.
-        /// Use ArgumentAttributes to control parsing behaviour.
+        /// Use ArgumentAttributes to control parsing behavior.
         /// </summary>
         /// <param name="env"> The host environment</param>
         /// <param name="settings">The command line</param>
@@ -403,7 +403,7 @@ namespace Microsoft.ML.CommandLine
 
         /// <summary>
         /// Returns a Usage string for command line argument parsing.
-        /// Use ArgumentAttributes to control parsing behaviour.
+        /// Use ArgumentAttributes to control parsing behavior.
         /// </summary>
         /// <param name="env"> The host environment. </param>
         /// <param name="type"> The type of the arguments to display usage for. </param>

--- a/src/Microsoft.ML.Core/ComponentModel/ComponentCatalog.cs
+++ b/src/Microsoft.ML.Core/ComponentModel/ComponentCatalog.cs
@@ -62,7 +62,7 @@ namespace Microsoft.ML.Runtime
     }
 
     /// <summary>
-    /// This catalogs instantiatable components (aka, loadable classes). Components are registered via
+    /// This catalogs instantiable components (aka, loadable classes). Components are registered via
     /// a descendant of <see cref="LoadableClassAttributeBase"/>, identifying the names and signature types under which the component
     /// type should be registered. Signatures are delegate types that return void and specify that parameter
     /// types for component instantiation. Each component may also specify an "arguments object" that should
@@ -87,7 +87,7 @@ namespace Microsoft.ML.Runtime
         }
 
         /// <summary>
-        /// Provides information on an instantiatable component, aka, loadable class.
+        /// Provides information on an instantiable component, aka, loadable class.
         /// </summary>
         [BestFriend]
         internal sealed class LoadableClassInfo
@@ -259,7 +259,7 @@ namespace Microsoft.ML.Runtime
             /// <summary>
             /// Create an instance, given the arguments object and arguments to the signature delegate.
             /// The args should be non-null iff ArgType is non-null. The length of the extra array should
-            /// match the number of paramters for the signature delgate. When that number is zero, extra
+            /// match the number of parameters for the signature delegate. When that number is zero, extra
             /// may be null.
             /// </summary>
             public object CreateInstance(IHostEnvironment env, object args, object[] extra)
@@ -280,7 +280,7 @@ namespace Microsoft.ML.Runtime
             /// <summary>
             /// Create an instance, given the arguments object and arguments to the signature delegate.
             /// The args should be non-null iff ArgType is non-null. The length of the extra array should
-            /// match the number of paramters for the signature delgate. When that number is zero, extra
+            /// match the number of parameters for the signature delegate. When that number is zero, extra
             /// may be null.
             /// </summary>
             public TRes CreateInstance<TRes>(IHostEnvironment env, object args, object[] extra)
@@ -714,7 +714,7 @@ namespace Microsoft.ML.Runtime
         }
 
         /// <summary>
-        /// Return an array containing information for all instantiatable components.
+        /// Return an array containing information for all instantiable components.
         /// If provided, the given set of assemblies is loaded first.
         /// </summary>
         [BestFriend]
@@ -724,7 +724,7 @@ namespace Microsoft.ML.Runtime
         }
 
         /// <summary>
-        /// Return an array containing information for instantiatable components with the given
+        /// Return an array containing information for instantiable components with the given
         /// signature and base type. If provided, the given set of assemblies is loaded first.
         /// </summary>
         [BestFriend]

--- a/src/Microsoft.ML.Core/Data/LinkedRootCursorBase.cs
+++ b/src/Microsoft.ML.Core/Data/LinkedRootCursorBase.cs
@@ -20,7 +20,7 @@ namespace Microsoft.ML.Data
         /// Returns the root cursor of the input. It should be used to perform <see cref="DataViewRowCursor.MoveNext"/>
         /// operations, but with the distinction, as compared to <see cref="SynchronizedCursorBase"/>, that this is not
         /// a simple passthrough, but rather very implementation specific. For example, a common usage of this class is
-        /// on filter cursor implemetnations, where how that input cursor is consumed is very implementation specific.
+        /// on filter cursor implementations, where how that input cursor is consumed is very implementation specific.
         /// That is why this is <see langword="protected"/>, not <see langword="private"/>.
         /// </summary>
         protected DataViewRowCursor Root { get; }

--- a/src/Microsoft.ML.Core/Data/ModelLoadContext.cs
+++ b/src/Microsoft.ML.Core/Data/ModelLoadContext.cs
@@ -26,7 +26,7 @@ namespace Microsoft.ML
         public readonly RepositoryReader Repository;
 
         /// <summary>
-        /// When in repository mode, this is the direcory we're reading from. Null means the root
+        /// When in repository mode, this is the directory we're reading from. Null means the root
         /// of the repository. It is always null in single-stream mode.
         /// </summary>
         public readonly string Directory;

--- a/src/Microsoft.ML.Core/EntryPoints/ModuleArgs.cs
+++ b/src/Microsoft.ML.Core/EntryPoints/ModuleArgs.cs
@@ -122,7 +122,7 @@ namespace Microsoft.ML.EntryPoints
             public string Desc { get; set; }
 
             /// <summary>
-            /// The rank order of the output. Because .NET reflection returns members in an unspecfied order, this
+            /// The rank order of the output. Because .NET reflection returns members in an unspecified order, this
             /// is the only way to ensure consistency.
             /// </summary>
             public Double SortOrder { get; set; }

--- a/src/Microsoft.ML.Core/Prediction/IPredictor.cs
+++ b/src/Microsoft.ML.Core/Prediction/IPredictor.cs
@@ -6,7 +6,7 @@ namespace Microsoft.ML
 {
     /// <summary>
     /// Type of prediction task. Note that this is a legacy structure and usage of this should generally be
-    /// discouraged in future projects. Its presence suggests that there are priviledged and supported
+    /// discouraged in future projects. Its presence suggests that there are privileged and supported
     /// tasks, and anything outside of this is unsupported. This runs rather contrary to the idea of this
     /// being an expandable framework, and it is inappropriately limiting. For legacy pipelines based on
     /// <see cref="ITrainer"/> and <see cref="IPredictor"/> it is still useful, but for things based on

--- a/src/Microsoft.ML.Core/Utilities/Contracts.cs
+++ b/src/Microsoft.ML.Core/Utilities/Contracts.cs
@@ -119,7 +119,7 @@ namespace Microsoft.ML.Runtime
         /// Exceptions whose message communicates potentially sensitive information should be
         /// marked using this method, before they are thrown. Note that if the exception already
         /// had this flag set, the message will be flagged with the bitwise or of the existing
-        /// flag, alongside the passed in sensivity.
+        /// flag, alongside the passed in sensitivity.
         /// </summary>
         public static TException MarkSensitive<TException>(this TException ex, MessageSensitivity sensitivity)
             where TException : Exception
@@ -155,7 +155,7 @@ namespace Microsoft.ML.Runtime
 #if !CPUMATH_INFRASTRUCTURE
         /// <summary>
         /// This is an internal convenience implementation of an exception context to make marking
-        /// exceptions with a specific sensitivity flag a bit less onorous. The alternative to a scheme
+        /// exceptions with a specific sensitivity flag a bit less onerous. The alternative to a scheme
         /// like this, where messages are marked through use of <see cref="Process{TException}(TException)"/>,
         /// would be that every check and exception method in this file would need some "peer" where
         /// sensitivity was set. Since there are so many, we have this method instead. I'm not sure if
@@ -171,7 +171,7 @@ namespace Microsoft.ML.Runtime
             public readonly IExceptionContext Inner;
 
             /// <summary>
-            /// Exceptions will be marked with this. If <see cref="Inner"/> happens to mark it with a sensivity
+            /// Exceptions will be marked with this. If <see cref="Inner"/> happens to mark it with a sensitivity
             /// flag, then the result will not only be this value, but the bitwise or of this with the existing
             /// value.
             /// </summary>
@@ -276,7 +276,7 @@ namespace Microsoft.ML.Runtime
         // REVIEW: Change ExceptUser*** to use a custom exception type.
 
         /// <summary>
-        /// For signalling bad user input.
+        /// For signaling bad user input.
         /// </summary>
         public static Exception ExceptUserArg(string name)
             => Process(new ArgumentOutOfRangeException(name));
@@ -292,7 +292,7 @@ namespace Microsoft.ML.Runtime
             => Process(new ArgumentOutOfRangeException(name, GetMsg(msg, args)), ctx);
 
         /// <summary>
-        /// For signalling bad function parameters.
+        /// For signaling bad function parameters.
         /// </summary>
         public static Exception ExceptParam(string paramName)
             => Process(new ArgumentOutOfRangeException(paramName));
@@ -316,7 +316,7 @@ namespace Microsoft.ML.Runtime
             => Process(new ArgumentOutOfRangeException(paramName, value, GetMsg(msg, args)), ctx);
 
         /// <summary>
-        /// For signalling null function parameters.
+        /// For signaling null function parameters.
         /// </summary>
         public static Exception ExceptValue(string paramName)
             => Process(new ArgumentNullException(paramName));
@@ -331,10 +331,10 @@ namespace Microsoft.ML.Runtime
         public static Exception ExceptValue(this IExceptionContext ctx, string paramName, string msg, params object[] args)
             => Process(new ArgumentNullException(paramName, GetMsg(msg, args)), ctx);
 
-        // For signalling null or empty function parameters (strings, arrays, collections, etc).
+        // For signaling null or empty function parameters (strings, arrays, collections, etc).
 
         /// <summary>
-        /// For signalling null or empty function parameters (strings, arrays, collections, etc).
+        /// For signaling null or empty function parameters (strings, arrays, collections, etc).
         /// </summary>
         public static Exception ExceptEmpty(string paramName)
             => Process(new ArgumentOutOfRangeException(paramName, string.Format("{0} cannot be null or empty", paramName)));
@@ -350,7 +350,7 @@ namespace Microsoft.ML.Runtime
             => Process(new ArgumentOutOfRangeException(paramName, GetMsg(msg, args)), ctx);
 
         /// <summary>
-        /// For signalling null, empty or white-space function parameters (strings, arrays, collections, etc).
+        /// For signaling null, empty or white-space function parameters (strings, arrays, collections, etc).
         /// </summary>
         public static Exception ExceptWhiteSpace(string paramName)
             => Process(new ArgumentOutOfRangeException(paramName, string.Format("{0} cannot be null or white space", paramName)));
@@ -362,7 +362,7 @@ namespace Microsoft.ML.Runtime
             => Process(new ArgumentOutOfRangeException(paramName, msg), ctx);
 
         /// <summary>
-        /// For signalling errors in decoding information, whether while reading from a file,
+        /// For signaling errors in decoding information, whether while reading from a file,
         /// parsing user input, etc.
         /// </summary>
         /// <returns></returns>
@@ -388,7 +388,7 @@ namespace Microsoft.ML.Runtime
             => Process(new FormatException(GetMsg(msg, args), inner), ctx);
 
         /// <summary>
-        /// For signalling IO failures.
+        /// For signaling IO failures.
         /// </summary>
         public static Exception ExceptIO()
             => Process(new IOException());
@@ -412,7 +412,7 @@ namespace Microsoft.ML.Runtime
             => Process(new IOException(GetMsg(msg, args), inner), ctx);
 
         /// <summary>
-        /// For signalling functionality that is not YET implemented.
+        /// For signaling functionality that is not YET implemented.
         /// </summary>
         public static Exception ExceptNotImpl()
             => Process(new NotImplementedException());
@@ -428,7 +428,7 @@ namespace Microsoft.ML.Runtime
             => Process(new NotImplementedException(GetMsg(msg, args)), ctx);
 
         /// <summary>
-        /// For signalling functionality that is not implemented by design.
+        /// For signaling functionality that is not implemented by design.
         /// </summary>
         public static Exception ExceptNotSupp()
             => Process(new NotSupportedException());
@@ -444,7 +444,7 @@ namespace Microsoft.ML.Runtime
             => Process(new NotSupportedException(GetMsg(msg, args)), ctx);
 
         /// <summary>
-        /// For signalling schema validation issues.
+        /// For signaling schema validation issues.
         /// </summary>
         public static Exception ExceptSchemaMismatch(string paramName, string columnRole, string columnName)
             => Process(new ArgumentOutOfRangeException(paramName, MakeSchemaMismatchMsg(columnRole, columnName)));
@@ -745,12 +745,12 @@ namespace Microsoft.ML.Runtime
         }
 #if !CPUMATH_INFRASTRUCTURE
         /// <summary>
-        /// Check state of the host and throw exception if host marked to stop all exection.
+        /// Check state of the host and throw exception if host marked to stop all execution.
         /// </summary>
         public static void CheckAlive(this IHostEnvironment env)
         {
             if (env is ICancelable cancelableEnv && cancelableEnv.IsCanceled)
-                throw Process(new OperationCanceledException("Operation was cancelled."), env);
+                throw Process(new OperationCanceledException("Operation was canceled."), env);
         }
 #endif
         /// <summary>

--- a/src/Microsoft.ML.Core/Utilities/HashArray.cs
+++ b/src/Microsoft.ML.Core/Utilities/HashArray.cs
@@ -277,7 +277,7 @@ namespace Microsoft.ML.Internal.Utilities
             {
                 int newSize = 2 * oldSize;
 
-                // Allow the hashtables to grow to maximum possible size (~2G elements) before encoutering capacity overflow.
+                // Allow the hashtables to grow to maximum possible size (~2G elements) before encountering capacity overflow.
                 // Note that this check works even when _items.Length overflowed thanks to the (uint) cast .
                 if ((uint)newSize >= MaxPrimeArrayLength)
                     return MaxPrimeArrayLength;

--- a/src/Microsoft.ML.Core/Utilities/Hashing.cs
+++ b/src/Microsoft.ML.Core/Utilities/Hashing.cs
@@ -25,11 +25,11 @@ namespace Microsoft.ML.Internal.Utilities
         }
 
         /// <summary>
-        /// Creates a combined hash of possibly heterogenously typed values.
+        /// Creates a combined hash of possibly heterogeneously typed values.
         /// </summary>
         /// <param name="startHash">The leading hash, incorporated into the final hash</param>
         /// <param name="os">A variable list of objects, where null is a valid value</param>
-        /// <returns>The combined hash incorpoating a starting hash, and the hash codes
+        /// <returns>The combined hash incorporating a starting hash, and the hash codes
         /// of all input values</returns>
         public static int CombinedHash(int startHash, params object[] os)
         {
@@ -39,12 +39,12 @@ namespace Microsoft.ML.Internal.Utilities
         }
 
         /// <summary>
-        /// Creates a combined hash of multiple homogenously typed non-null values.
+        /// Creates a combined hash of multiple homogeneous typed non-null values.
         /// </summary>
         /// <typeparam name="T">The type of items to hash</typeparam>
         /// <param name="startHash">The leading hash, incorporated into the final hash</param>
         /// <param name="os">A variable list of non-null values</param>
-        /// <returns>The combined hash incorpoating a starting hash, and the hash codes
+        /// <returns>The combined hash incorporating a starting hash, and the hash codes
         /// of all input values</returns>
         public static int CombinedHash<T>(int startHash, params T[] os)
         {

--- a/src/Microsoft.ML.Core/Utilities/SummaryStatistics.cs
+++ b/src/Microsoft.ML.Core/Utilities/SummaryStatistics.cs
@@ -97,7 +97,7 @@ namespace Microsoft.ML.Internal.Utilities
         /// </summary>
         /// <param name="v">The value</param>
         /// <param name="w">The weight given to this value</param>
-        /// <param name="c">Amount of appereance of this value</param>
+        /// <param name="c">Amount of appearance of this value</param>
         public virtual void Add(double v, double w = 1.0, long c = 1)
         {
             double temp = w + Count;
@@ -317,7 +317,7 @@ namespace Microsoft.ML.Internal.Utilities
         /// </summary>
         /// <param name="v">The value</param>
         /// <param name="w">The weight given to this value</param>
-        /// <param name="c">Amount of appereance of this value</param>
+        /// <param name="c">Amount of appearance of this value</param>
         public override void Add(double v, double w = 1.0, long c = 1)
         {
             double temp = w + Count;

--- a/src/Microsoft.ML.Core/Utilities/SupervisedBinFinder.cs
+++ b/src/Microsoft.ML.Core/Utilities/SupervisedBinFinder.cs
@@ -12,7 +12,7 @@ namespace Microsoft.ML.Internal.Utilities
     /// <summary>
     /// This class performs discretization of (value, label) pairs into bins in a way that minimizes
     /// the target function "minimum description length".
-    /// The algorithm is outlineed in an article
+    /// The algorithm is outlined in an article
     /// "Multi-Interval Discretization of Continuous-Valued Attributes for Classification Learning"
     /// [Fayyad, Usama M.; Irani, Keki B. (1993)] https://ijcai.org/Past%20Proceedings/IJCAI-93-VOL2/PDF/022.pdf
     ///

--- a/src/Microsoft.ML.Core/Utilities/ThreadUtils.cs
+++ b/src/Microsoft.ML.Core/Utilities/ThreadUtils.cs
@@ -167,7 +167,7 @@ namespace Microsoft.ML.Internal.Utilities
     /// would be engineered without this class, except they will wrap their contents in a try-catch
     /// block to push any exceptions (hopefully none) into this marshaller, using <see cref="Set"/>.
     /// Further, any potentially blocking operation of the thread workers must be changed to use
-    /// <see cref="Token"/> as the cancellation token (this token is cancelled iff <see cref="Set"/>
+    /// <see cref="Token"/> as the cancellation token (this token is canceled iff <see cref="Set"/>
     /// is ever called). The controlling thread, whatever that may be, once it is either sure
     /// <see cref="Set"/> has been called (possibly by receiving the cancellation) or is sure somehow
     /// that the workers have finished by its own means, will call <see cref="ThrowIfSet"/> to throw
@@ -184,7 +184,7 @@ namespace Microsoft.ML.Internal.Utilities
         private Exception _ex;
 
         /// <summary>
-        /// A cancellation token, whose source will be cancelled if <see cref="Set"/> is ever called.
+        /// A cancellation token, whose source will be canceled if <see cref="Set"/> is ever called.
         /// Any thread blocking operation of a family of thread workers using this structure
         /// must use this cancellation token, or else there is a strong possibility for threads
         /// to stop responding if an exception is thrown at any point.

--- a/src/Microsoft.ML.Core/Utilities/VBufferUtils.cs
+++ b/src/Microsoft.ML.Core/Utilities/VBufferUtils.cs
@@ -102,7 +102,7 @@ namespace Microsoft.ML.Internal.Utilities
 
         /// <summary>
         /// Applies the <paramref name="visitor "/>to each corresponding pair of elements
-        /// where the item is emplicitly defined in the vector. By explicitly defined,
+        /// where the item is implicitly defined in the vector. By explicitly defined,
         /// we mean that for a given index <c>i</c>, both vectors have an entry in
         /// <see cref="VBuffer{T}.GetValues"/> corresponding to that index.
         /// </summary>

--- a/src/Microsoft.ML.CpuMath/AlignedMatrix.cs
+++ b/src/Microsoft.ML.CpuMath/AlignedMatrix.cs
@@ -248,7 +248,7 @@ namespace Microsoft.ML.Internal.CpuMath
 
         // Since FloatAlign is a power of two, shifting by Shift = log_2(FloatAlign) is the same as multiplying/dividing by FloatAlign.
         protected readonly int Shift;
-        // Since FloatAlign is a power of two, bitwise and with Mask = FloatAlign - 1 will be the same as moding by FloatAlign.
+        // Since FloatAlign is a power of two, bitwise and with Mask = FloatAlign - 1 will be the same as modding by FloatAlign.
         protected readonly int Mask;
 
         // Logical length of runs (RunLen) and number of runs (RunCnt).
@@ -280,7 +280,7 @@ namespace Microsoft.ML.Internal.CpuMath
         public abstract int RowCountPhy { get; }
 
         /// <summary>
-        /// The pysical number of columns
+        /// The physical number of columns
         /// </summary>
         public abstract int ColCountPhy { get; }
 

--- a/src/Microsoft.ML.CpuMath/ProbabilityFunctions.cs
+++ b/src/Microsoft.ML.CpuMath/ProbabilityFunctions.cs
@@ -116,7 +116,7 @@ namespace Microsoft.ML.Internal.CpuMath
         /// p value. It is used in establishing confidence intervals.
         /// </summary>
         /// <param name="p">The input p value, so in the range 0 to 1.</param>
-        /// <returns>One intepretation is, the value at which the standard normal CDF evaluates to p.</returns>
+        /// <returns>One interpretation is, the value at which the standard normal CDF evaluates to p.</returns>
         public static double Probit(double p)
         {
             Contracts.CheckParam(0 <= p && p <= 1, nameof(p), "Input probability should be in range 0 to 1.");

--- a/src/Microsoft.ML.Data/Data/Conversion.cs
+++ b/src/Microsoft.ML.Data/Data/Conversion.cs
@@ -39,7 +39,7 @@ namespace Microsoft.ML.Data.Conversion
     /// This type exists to provide efficient delegates for conversion between standard ColumnTypes,
     /// as discussed in the IDataView Type System Specification. This is a singleton class.
     /// Some conversions are "standard" conversions, conforming to the details in the spec.
-    /// Others are auxilliary conversions. The use of auxilliary conversions should be limited to
+    /// Others are auxiliary conversions. The use of auxiliary conversions should be limited to
     /// situations that genuinely require them and have been well designed in the particular context.
     /// For example, this contains non-standard conversions from the standard primitive types to
     /// text (and StringBuilder). These are needed by the standard TextSaver, which handles
@@ -396,7 +396,7 @@ namespace Microsoft.ML.Data.Conversion
             identity = false;
             if (typeSrc is KeyDataViewType keySrc)
             {
-                // Key types are only convertable to compatible key types or unsigned integer
+                // Key types are only convertible to compatible key types or unsigned integer
                 // types that are large enough.
                 if (typeDst is KeyDataViewType keyDst)
                 {

--- a/src/Microsoft.ML.Data/Data/DataViewTypeManager.cs
+++ b/src/Microsoft.ML.Data/Data/DataViewTypeManager.cs
@@ -141,7 +141,7 @@ namespace Microsoft.ML.Data
         /// <param name="type">Native type in C#.</param>
         /// <param name="dataViewType">The corresponding type of <paramref name="type"/> in ML.NET's type system.</param>
         /// <param name="typeAttributes">The <see cref="Attribute"/>s attached to <paramref name="type"/>.</param>
-        [Obsolete("This API is depricated, please use the new form of Register which takes in a single DataViewTypeAttribute instead.", false)]
+        [Obsolete("This API is deprecated, please use the new form of Register which takes in a single DataViewTypeAttribute instead.", false)]
         public static void Register(DataViewType dataViewType, Type type, IEnumerable<Attribute> typeAttributes)
         {
             DataViewTypeAttribute typeAttr = null;

--- a/src/Microsoft.ML.Data/Data/DataViewUtils.cs
+++ b/src/Microsoft.ML.Data/Data/DataViewUtils.cs
@@ -369,7 +369,7 @@ namespace Microsoft.ML.Data
                     // so they all handle their disposal internal to the thread.
                     workers[t] = Utils.RunOnBackgroundThread(() =>
                     {
-                            // This will be the last batch sent in the finally. If iteration procedes without
+                            // This will be the last batch sent in the finally. If iteration proceeds without
                             // error, it will remain null, and be sent as a sentinel. If iteration results in
                             // an exception that we catch, the exception catching block will set this to an
                             // exception bearing block, and that will be passed along as the last block instead.

--- a/src/Microsoft.ML.Data/Data/IRowSeekable.cs
+++ b/src/Microsoft.ML.Data/Data/IRowSeekable.cs
@@ -6,7 +6,7 @@ using System;
 
 namespace Microsoft.ML.Data
 {
-    // REVIEW: Would it be a better apporach to add something akin to CanSeek,
+    // REVIEW: Would it be a better approach to add something akin to CanSeek,
     // as we have a CanShuffle? The idea is trying to make IRowSeekable propagate along certain transforms.
     /// <summary>
     /// Represents a data view that supports random access to a specific row.

--- a/src/Microsoft.ML.Data/Data/SchemaAnnotationsExtensions.cs
+++ b/src/Microsoft.ML.Data/Data/SchemaAnnotationsExtensions.cs
@@ -63,7 +63,7 @@ namespace Microsoft.ML.Data
         }
 
         /// <summary>
-        /// Stores the key values of the input colum into the provided buffer, if this is of key type and whose
+        /// Stores the key values of the input column into the provided buffer, if this is of key type and whose
         /// key values are of <see cref="VectorDataViewType.ItemType"/> whose <see cref="DataViewType.RawType"/> matches
         /// <typeparamref name="TValue"/>. If there is no matching key valued annotation this will throw an exception.
         /// </summary>

--- a/src/Microsoft.ML.Data/Data/SchemaDefinition.cs
+++ b/src/Microsoft.ML.Data/Data/SchemaDefinition.cs
@@ -246,7 +246,7 @@ namespace Microsoft.ML.Data
             /// <summary>
             /// Add annotation to the column.
             /// </summary>
-            /// <typeparam name="T">Type of annotation being added. Types suported as entries in columns
+            /// <typeparam name="T">Type of annotation being added. Types sported as entries in columns
             /// are also supported as entries in Annotations. Multiple annotations may be added to one column.
             /// </typeparam>
             /// <param name="kind">The string identifier of the annotation.</param>
@@ -396,7 +396,7 @@ namespace Microsoft.ML.Data
                 var mappingNameAttr = memberInfo.GetCustomAttribute<ColumnNameAttribute>();
                 string name = mappingNameAttr?.Name ?? memberInfo.Name;
                 // Disallow duplicate names, because the field enumeration order is not actually
-                // well defined, so we are not gauranteed to have consistent "hiding" from run to
+                // well defined, so we are not guaranteed to have consistent "hiding" from run to
                 // run, across different .NET versions.
                 if (!colNames.Add(name))
                     throw Contracts.ExceptParam(nameof(userType), "Duplicate column name '{0}' detected, this is disallowed", name);

--- a/src/Microsoft.ML.Data/DataLoadSave/Binary/BinaryLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Binary/BinaryLoader.cs
@@ -2016,7 +2016,7 @@ namespace Microsoft.ML.Data.IO
                         // effort to recycle buffers since it would be exceptionally difficult
                         // to do so. All threads are already unblocked, one of them with the
                         // source exception that kicked off this process, the remaining with
-                        // other later exceptions or the operation cancelled exception. So we
+                        // other later exceptions or the operation canceled exception. So we
                         // are free to join. Still, given the exceptional nature, we won't
                         // wait forever to do it.
                         const int timeOut = 100;

--- a/src/Microsoft.ML.Data/DataLoadSave/Binary/BinarySaver.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Binary/BinarySaver.cs
@@ -36,7 +36,7 @@ namespace Microsoft.ML.Data.IO
             [Argument(ArgumentType.LastOccurrenceWins, HelpText = "The block-size heuristic will choose no more than this many rows to have per block, can be set to null to indicate that there is no inherent limit", ShortName = "rpb")]
             public int? MaxRowsPerBlock = 1 << 13; // ~8 thousand.
 
-            [Argument(ArgumentType.LastOccurrenceWins, HelpText = "The block-size heuristic will attempt to have about this many bytes across all columns per block, can be set to null to accept the inidcated max-rows-per-block as the number of rows per block", ShortName = "bpb")]
+            [Argument(ArgumentType.LastOccurrenceWins, HelpText = "The block-size heuristic will attempt to have about this many bytes across all columns per block, can be set to null to accept the indicated max-rows-per-block as the number of rows per block", ShortName = "bpb")]
             public long? MaxBytesPerBlock = 80 << 20; // ~80 megabytes.
 
             [Argument(ArgumentType.LastOccurrenceWins, HelpText = "If true, this forces a deterministic block order during writing", ShortName = "det")]
@@ -696,7 +696,7 @@ namespace Microsoft.ML.Data.IO
                 if (!_silent)
                     ch.Info("Wrote {0} rows across {1} columns in {2}", _rowCount, activeColumns.Length, sw.Elapsed);
                 // When we dispose the exception marshaller, this will set the cancellation token when we internally
-                // dispose the cancellation token source, so one way or another those threads are being cancelled, even
+                // dispose the cancellation token source, so one way or another those threads are being canceled, even
                 // if an exception is thrown in the main body of this function.
             }
         }

--- a/src/Microsoft.ML.Data/DataLoadSave/Binary/Codecs.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Binary/Codecs.cs
@@ -387,7 +387,7 @@ namespace Microsoft.ML.Data.IO
                         value = _text.AsMemory().Slice(start, (b & LengthMask) - start);
                     else
                     {
-                        //For backward compatiblity when NA values existed, treat them
+                        //For backward compatibility when NA values existed, treat them
                         //as empty string.
                         value = ReadOnlyMemory<char>.Empty;
                     }

--- a/src/Microsoft.ML.Data/DataLoadSave/Binary/IValueCodec.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Binary/IValueCodec.cs
@@ -11,7 +11,7 @@ namespace Microsoft.ML.Data.IO
     /// A value codec encapsulates implementations capable of writing and reading data of some
     /// type to and from streams. The idea is that one creates a codec using <c>TryGetCodec</c>
     /// on the appropriate <c>ColumnType</c>, then opens multiple writers to write blocks of data
-    /// to some stream. The idea is that each writer or reader is called on some "managable chunk"
+    /// to some stream. The idea is that each writer or reader is called on some "manageable chunk"
     /// of data.
     ///
     /// Codecs should be thread safe, though the readers and writers they spawn do not need to

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderParser.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderParser.cs
@@ -225,7 +225,7 @@ namespace Microsoft.ML.Data
 
             public abstract void Reset(int irow, int size);
 
-            // Passed by-ref for effeciency, not so it can be modified.
+            // Passed by-ref for efficiency, not so it can be modified.
             public abstract bool Consume(int irow, int index, ref ReadOnlyMemory<char> text);
 
             public abstract Delegate GetGetter();

--- a/src/Microsoft.ML.Data/DataLoadSave/TransformWrapper.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/TransformWrapper.cs
@@ -9,7 +9,7 @@ namespace Microsoft.ML.Data
 {
     /// <summary>
     /// This is a shim class to present the legacy <see cref="IDataTransform"/> interface as an <see cref="ITransformer"/>.
-    /// Note that there are some important differences in usages that make this shimming somewhat non-seemless, so the goal
+    /// Note that there are some important differences in usages that make this shimming somewhat non-seamless, so the goal
     /// would be gradual removal of this as we do away with <see cref="IDataTransform"/> based code.
     /// </summary>
     [BestFriend]

--- a/src/Microsoft.ML.Data/DataLoadSave/Transpose/TransposeLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Transpose/TransposeLoader.cs
@@ -35,7 +35,7 @@ namespace Microsoft.ML.Data.IO
     {
         public sealed class Arguments
         {
-            [Argument(ArgumentType.LastOccurrenceWins, HelpText = "The number of worker decompressor threads to use", ShortName = "t")]
+            [Argument(ArgumentType.LastOccurrenceWins, HelpText = "The number of worker decompresser threads to use", ShortName = "t")]
             public int? Threads;
         }
 

--- a/src/Microsoft.ML.Data/DataView/DataViewConstructionUtils.cs
+++ b/src/Microsoft.ML.Data/DataView/DataViewConstructionUtils.cs
@@ -238,7 +238,7 @@ namespace Microsoft.ML.Data
                 else if (colType is VectorDataViewType vectorType)
                 {
                     // VBuffer<T> -> VBuffer<T>
-                    // REVIEW: Do we care about accomodating VBuffer<string> -> ReadOnlyMemory<char>?
+                    // REVIEW: Do we care about accommodating VBuffer<string> -> ReadOnlyMemory<char>?
                     Host.Assert(outputType.IsGenericType);
                     Host.Assert(outputType.GetGenericTypeDefinition() == typeof(VBuffer<>));
                     Host.Assert(outputType.GetGenericArguments()[0] == vectorType.ItemType.RawType);

--- a/src/Microsoft.ML.Data/DataView/TypedCursor.cs
+++ b/src/Microsoft.ML.Data/DataView/TypedCursor.cs
@@ -294,7 +294,7 @@ namespace Microsoft.ML.Data
                 else if (colType is VectorDataViewType vectorType)
                 {
                     // VBuffer<T> -> VBuffer<T>
-                    // REVIEW: Do we care about accomodating VBuffer<string> -> VBuffer<ReadOnlyMemory<char>>?
+                    // REVIEW: Do we care about accommodating VBuffer<string> -> VBuffer<ReadOnlyMemory<char>>?
                     Ch.Assert(fieldType.IsGenericType);
                     Ch.Assert(fieldType.GetGenericTypeDefinition() == typeof(VBuffer<>));
                     Ch.Assert(fieldType.GetGenericArguments()[0] == vectorType.ItemType.RawType);

--- a/src/Microsoft.ML.Data/DebuggerExtensions.cs
+++ b/src/Microsoft.ML.Data/DebuggerExtensions.cs
@@ -34,7 +34,7 @@ namespace Microsoft.ML
         /// <summary>
         /// Preview an effect of the <paramref name="estimator"/> on a given <paramref name="data"/>.
         /// </summary>
-        /// <param name="estimator">The estimnator which effect we are previewing</param>
+        /// <param name="estimator">The estimator which effect we are previewing</param>
         /// <param name="data">The data view to use for preview</param>
         /// <param name="maxRows">Maximum number of rows to show in preview</param>
         /// <param name="maxTrainingRows">Maximum number of rows to fit the estimator</param>

--- a/src/Microsoft.ML.Data/Depricated/Vector/VBufferMathUtils.cs
+++ b/src/Microsoft.ML.Data/Depricated/Vector/VBufferMathUtils.cs
@@ -157,7 +157,7 @@ namespace Microsoft.ML.Numeric
             VBufferUtils.ApplyWith(in src, ref dst, (int i, float v1, ref float v2) => v2 += v1);
         }
 
-        // REVIEW: Rename all instances of AddMult to AddScale, as soon as convesion concerns are no more.
+        // REVIEW: Rename all instances of AddMult to AddScale, as soon as conversion concerns are no more.
         /// <summary>
         /// Perform in-place scaled vector addition
         /// <c><paramref name="dst"/> += <paramref name="c"/> * <paramref name="src"/></c>.
@@ -261,7 +261,7 @@ namespace Microsoft.ML.Numeric
             // REVIEW: Perhaps implementing an ApplyInto with an offset would be more
             // appropriate, as well as more general, considering that this case is less important.
 
-            // dst is sparse. I expect this will see limited practical use, since accumulants
+            // dst is sparse. I expect this will see limited practical use, since accumulates
             // are often better off going into a dense vector in all applications of interest to us.
             // Correspondingly, this implementation will be functional, but not optimized.
             var dstIndices = dst.GetIndices();

--- a/src/Microsoft.ML.Data/EntryPoints/EntryPointNode.cs
+++ b/src/Microsoft.ML.Data/EntryPoints/EntryPointNode.cs
@@ -180,7 +180,7 @@ namespace Microsoft.ML.EntryPoints
         {
             Contracts.CheckValue(variableType, nameof(variableType));
 
-            // Option types should not be used to consturct graph.
+            // Option types should not be used to construct graph.
             if (variableType.IsGenericType && variableType.GetGenericTypeDefinition() == typeof(Optional<>))
                 return false;
 

--- a/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
+++ b/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
@@ -156,7 +156,7 @@ namespace Microsoft.ML.Data
         }
 
         /// <summary>
-        /// Find the optional auxilliary score column to use. If <paramref name="name"/> is specified, that is used.
+        /// Find the optional auxiliary score column to use. If <paramref name="name"/> is specified, that is used.
         /// Otherwise, if <paramref name="colScore"/> is part of a score set, this looks in the score set for a column
         /// with the given <paramref name="valueKind"/>. If none is found, it returns <see langword="null"/>.
         /// </summary>

--- a/src/Microsoft.ML.Data/Evaluators/MamlEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MamlEvaluator.cs
@@ -127,7 +127,7 @@ namespace Microsoft.ML.Data
 
         /// <summary>
         /// All the input columns needed by an evaluator should be added here.
-        /// The base class ipmlementation gets the score column, the label column (if exists) and the weight column (if exists).
+        /// The base class implementation gets the score column, the label column (if exists) and the weight column (if exists).
         /// Override if additional columns are needed.
         /// </summary>
         [BestFriend]

--- a/src/Microsoft.ML.Data/Evaluators/MultiOutputRegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MultiOutputRegressionEvaluator.cs
@@ -617,7 +617,7 @@ namespace Microsoft.ML.Data
             [Argument(ArgumentType.Multiple, HelpText = "Loss function", ShortName = "loss")]
             public ISupportRegressionLossFactory LossFunction = new SquaredLossFactory();
 
-            [Argument(ArgumentType.AtMostOnce, HelpText = "Supress labels and scores in per-instance outputs?", ShortName = "noScores")]
+            [Argument(ArgumentType.AtMostOnce, HelpText = "Suppress labels and scores in per-instance outputs?", ShortName = "noScores")]
             public bool SupressScoresAndLabels = false;
         }
 

--- a/src/Microsoft.ML.Data/Evaluators/MultiOutputRegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MultiOutputRegressionEvaluator.cs
@@ -618,11 +618,11 @@ namespace Microsoft.ML.Data
             public ISupportRegressionLossFactory LossFunction = new SquaredLossFactory();
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "Suppress labels and scores in per-instance outputs?", ShortName = "noScores")]
-            public bool SupressScoresAndLabels = false;
+            public bool SuppressScoresAndLabels = false;
         }
 
         private readonly MultiOutputRegressionEvaluator _evaluator;
-        private readonly bool _supressScoresAndLabels;
+        private readonly bool _suppressScoresAndLabels;
 
         private protected override IEvaluator Evaluator => _evaluator;
 
@@ -631,7 +631,7 @@ namespace Microsoft.ML.Data
         {
             Host.CheckUserArg(args.LossFunction != null, nameof(args.LossFunction), "Loss function must be specified");
 
-            _supressScoresAndLabels = args.SupressScoresAndLabels;
+            _suppressScoresAndLabels = args.SuppressScoresAndLabels;
             var evalArgs = new MultiOutputRegressionEvaluator.Arguments();
             evalArgs.LossFunction = args.LossFunction;
             _evaluator = new MultiOutputRegressionEvaluator(Host, evalArgs);
@@ -643,7 +643,7 @@ namespace Microsoft.ML.Data
             Host.CheckParam(schema.Label != null, nameof(schema), "Schema must contain a label column");
 
             // The multi output regression evaluator outputs the label and score column if requested by the user.
-            if (!_supressScoresAndLabels)
+            if (!_suppressScoresAndLabels)
             {
                 yield return schema.Label.Value.Name;
 

--- a/src/Microsoft.ML.Data/Model/Pfa/SavePfaCommand.cs
+++ b/src/Microsoft.ML.Data/Model/Pfa/SavePfaCommand.cs
@@ -130,7 +130,7 @@ namespace Microsoft.ML.Model.Pfa
                 rawPred = null;
                 trainSchema = null;
                 Host.CheckUserArg(ImplOptions.LoadPredictor != true, nameof(ImplOptions.LoadPredictor),
-                    "Cannot be set to true unless " + nameof(ImplOptions.InputModelFile) + " is also specifified.");
+                    "Cannot be set to true unless " + nameof(ImplOptions.InputModelFile) + " is also specified.");
             }
             else
                 LoadModelObjects(ch, _loadPredictor, out rawPred, true, out trainSchema, out loader);

--- a/src/Microsoft.ML.Data/Prediction/Calibrator.cs
+++ b/src/Microsoft.ML.Data/Prediction/Calibrator.cs
@@ -823,7 +823,7 @@ namespace Microsoft.ML.Calibrators
                 calibrator.GetType()
             };
 
-            // Call the appropiate constructor of the created generic type passing on the previously loaded predictor and calibrator
+            // Call the appropriate constructor of the created generic type passing on the previously loaded predictor and calibrator
             var genericCtor = constructed.GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, null, constructorArgs, null);
             object genericInstance = genericCtor.Invoke(new object[] { env, ctx, predictor, calibrator });
 

--- a/src/Microsoft.ML.Data/Prediction/IPredictionTransformer.cs
+++ b/src/Microsoft.ML.Data/Prediction/IPredictionTransformer.cs
@@ -9,7 +9,7 @@ namespace Microsoft.ML
 {
     /// <summary>
     /// An interface for all the transformer that can transform data based on the <see cref="IPredictor"/> field.
-    /// The implemendations of this interface either have no feature column, or have more than one feature column, and cannot implement the
+    /// The implementations of this interface either have no feature column, or have more than one feature column, and cannot implement the
     /// <see cref="ISingleFeaturePredictionTransformer{TModel}"/>, which most of the ML.Net tranformer implement.
     /// </summary>
     /// <typeparam name="TModel">The <see cref="IPredictor"/> or <see cref="ICalibrator"/> used for the data transformation.</typeparam>

--- a/src/Microsoft.ML.Data/Scorers/SchemaBindablePredictorWrapper.cs
+++ b/src/Microsoft.ML.Data/Scorers/SchemaBindablePredictorWrapper.cs
@@ -426,7 +426,7 @@ namespace Microsoft.ML.Data
 
             var mapper = ValueMapper as ISingleCanSaveOnnx;
             Contracts.CheckValue(mapper, nameof(mapper));
-            Contracts.Assert(Utils.Size(outputNames) == 3); // Predicted Label, Score and Probablity.
+            Contracts.Assert(Utils.Size(outputNames) == 3); // Predicted Label, Score and Probability.
 
             // Prior doesn't have a feature column and uses the training label column to determine predicted labels
             if (!schema.Feature.HasValue)

--- a/src/Microsoft.ML.Data/Scorers/ScoreSchemaFactory.cs
+++ b/src/Microsoft.ML.Data/Scorers/ScoreSchemaFactory.cs
@@ -112,7 +112,7 @@ namespace Microsoft.ML.Data
         /// <param name="scoreColumnKindValue">A metadata value of score column. It's the value associated with key
         /// <see cref="AnnotationUtils.Kinds.ScoreColumnKind"/>.</param>
         /// <param name="keyNames">Sequence predictor usually generates integer outputs. This field tells the tags of all possible output values.
-        /// For example, output integer 0 cound be mapped to "Sell" and 0 to "Buy" when predicting stock trend.</param>
+        /// For example, output integer 0 could be mapped to "Sell" and 0 to "Buy" when predicting stock trend.</param>
         /// <returns><see cref="DataViewSchema"/> of sequence predictor's output.</returns>
         public static DataViewSchema CreateSequencePredictionSchema(DataViewType scoreType, string scoreColumnKindValue, VBuffer<ReadOnlyMemory<char>> keyNames=default)
         {

--- a/src/Microsoft.ML.Data/TrainCatalog.cs
+++ b/src/Microsoft.ML.Data/TrainCatalog.cs
@@ -264,7 +264,7 @@ namespace Microsoft.ML
         /// <typeparam name="TModel">The type of the model parameters.</typeparam>
         /// <param name="model">Existing model to modify threshold.</param>
         /// <param name="threshold">New threshold.</param>
-        /// <returns>New model with modified threashold.</returns>
+        /// <returns>New model with modified threshold.</returns>
         public BinaryPredictionTransformer<TModel> ChangeModelThreshold<TModel>(BinaryPredictionTransformer<TModel> model, float threshold)
              where TModel : class
         {

--- a/src/Microsoft.ML.Data/Transforms/ColumnBindingsBase.cs
+++ b/src/Microsoft.ML.Data/Transforms/ColumnBindingsBase.cs
@@ -244,7 +244,7 @@ namespace Microsoft.ML.Data
     /// Base class that abstracts passing input columns through (with possibly different indices) and adding
     /// InfoCount additional columns. If an added column has the same name as a non-hidden input column, it hides
     /// the input column, and is placed immediately after the input column. Otherwise, the added column is placed
-    /// at the end. By default, newly added columns have no annotations (but this can be overriden).
+    /// at the end. By default, newly added columns have no annotations (but this can be overridden).
     /// </summary>
     [BestFriend]
     internal abstract class ColumnBindingsBase

--- a/src/Microsoft.ML.Data/Transforms/ColumnSelecting.cs
+++ b/src/Microsoft.ML.Data/Transforms/ColumnSelecting.cs
@@ -260,7 +260,7 @@ namespace Microsoft.ML.Transforms
         }
 
         /// <summary>
-        /// Back-compatibilty function that handles loading the DropColumns Transform.
+        /// Back-compatibility function that handles loading the DropColumns Transform.
         /// </summary>
         private static ColumnSelectingTransformer LoadDropColumnsTransform(IHostEnvironment env, ModelLoadContext ctx, IDataView input)
         {
@@ -298,7 +298,7 @@ namespace Microsoft.ML.Transforms
         }
 
         /// <summary>
-        /// Back-compatibilty that is handling the HiddenColumnOption from ChooseColumns.
+        /// Back-compatibility that is handling the HiddenColumnOption from ChooseColumns.
         /// </summary>
         private enum HiddenColumnOption : byte
         {

--- a/src/Microsoft.ML.Data/Transforms/FeatureContributionCalculationTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/FeatureContributionCalculationTransformer.cs
@@ -72,7 +72,7 @@ namespace Microsoft.ML.Transforms
 
         /// <summary>
         /// Feature Contribution Calculation computes model-specific contribution scores for each feature.
-        /// Note that this functionality is not supported by all the models. See <see cref="FeatureContributionCalculatingTransformer"/> for a list of the suported models.
+        /// Note that this functionality is not supported by all the models. See <see cref="FeatureContributionCalculatingTransformer"/> for a list of the sported models.
         /// </summary>
         /// <param name="env">The environment to use.</param>
         /// <param name="modelParameters">Trained model parameters that support Feature Contribution Calculation and which will be used for scoring.</param>
@@ -305,7 +305,7 @@ namespace Microsoft.ML.Transforms
 
         /// <summary>
         /// Feature Contribution Calculation computes model-specific contribution scores for each feature.
-        /// Note that this functionality is not supported by all the models. See <see cref="FeatureContributionCalculatingTransformer"/> for a list of the suported models.
+        /// Note that this functionality is not supported by all the models. See <see cref="FeatureContributionCalculatingTransformer"/> for a list of the sported models.
         /// </summary>
         /// <param name="env">The environment to use.</param>
         /// <param name="model">A <see cref="ISingleFeaturePredictionTransformer{TModel}"/> that supports Feature Contribution Calculation,

--- a/src/Microsoft.ML.Data/Transforms/Hashing.cs
+++ b/src/Microsoft.ML.Data/Transforms/Hashing.cs
@@ -170,7 +170,7 @@ namespace Microsoft.ML.Transforms
             foreach (var column in _columns)
             {
                 if (column.MaximumNumberOfInverts != 0)
-                    throw Host.ExceptParam(nameof(columns), $"Found colunm with {nameof(column.MaximumNumberOfInverts)} set to non zero value, please use { nameof(HashingEstimator)} instead");
+                    throw Host.ExceptParam(nameof(columns), $"Found column with {nameof(column.MaximumNumberOfInverts)} set to non zero value, please use { nameof(HashingEstimator)} instead");
             }
         }
 
@@ -451,7 +451,7 @@ namespace Microsoft.ML.Transforms
         /// implementor was a class, or if the hasher implementation was just passed in with a delegate, or
         /// the hashing logic was encapsulated as the abstract method of some class.
         ///
-        /// In a prior time, there were methods for all possible combinations of types, scalarness, vector
+        /// In a prior time, there were methods for all possible combinations of types, scalar-ness, vector
         /// sparsity/density, whether the hash was sparsity preserving or not, whether it was ordered or not.
         /// This resulted in an explosion of methods that made the hash transform code somewhat hard to maintain.
         /// On the other hand, the methods were fast, since they were effectively (by brute enumeration) completely

--- a/src/Microsoft.ML.Data/Transforms/InvertHashUtils.cs
+++ b/src/Microsoft.ML.Data/Transforms/InvertHashUtils.cs
@@ -40,7 +40,7 @@ namespace Microsoft.ML.Data
             Contracts.Assert(type.RawType == typeof(T));
             var conv = Conversion.Conversions.Instance;
 
-            // First: if not key, then get the standard string converison.
+            // First: if not key, then get the standard string conversion.
             if (!(type is KeyDataViewType keyType))
                 return conv.GetStringConversion<T>(type);
 

--- a/src/Microsoft.ML.Data/Transforms/SkipTakeFilter.cs
+++ b/src/Microsoft.ML.Data/Transforms/SkipTakeFilter.cs
@@ -272,7 +272,7 @@ namespace Microsoft.ML.Transforms
                         return false;
                     }
 
-                    // Move foward _skip + 1 rows to get to the "first" row of the input.
+                    // Move forward _skip + 1 rows to get to the "first" row of the input.
                     for (long i = 0; i <= _skip; ++i)
                     {
                         if (!Root.MoveNext())

--- a/src/Microsoft.ML.Data/Transforms/SlotsDroppingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/SlotsDroppingTransformer.cs
@@ -853,7 +853,7 @@ namespace Microsoft.ML.Transforms
                         {
                             VBuffer<int> dst = default(VBuffer<int>);
                             GetCategoricalSlotRangesCore(iinfo, _slotDropper[iinfo].SlotsMin, _slotDropper[iinfo].SlotsMax, _categoricalRanges[iinfo], ref dst);
-                            // REVIEW: cache dst as opposed to caculating it again.
+                            // REVIEW: cache dst as opposed to calculating it again.
                             if (dst.Length > 0)
                             {
                                 Contracts.Assert(dst.Length % 2 == 0);

--- a/src/Microsoft.ML.Data/Utils/ApiUtils.cs
+++ b/src/Microsoft.ML.Data/Utils/ApiUtils.cs
@@ -126,7 +126,7 @@ namespace Microsoft.ML
         /// <summary>
         /// Each of the specialized 'poke' methods sets the appropriate field value of an instance of T
         /// to the provided value. So, the call is 'peek(userObject, providedValue)' and the logic is
-        /// indentical to 'userObject.##FIELD## = providedValue', where ##FIELD## is defined per poke method.
+        /// identical to 'userObject.##FIELD## = providedValue', where ##FIELD## is defined per poke method.
         /// </summary>
         internal static Delegate GeneratePoke<TOwn, TRow>(InternalSchemaDefinition.Column column)
         {

--- a/src/Microsoft.ML.DataView/IDataView.cs
+++ b/src/Microsoft.ML.DataView/IDataView.cs
@@ -103,7 +103,7 @@ namespace Microsoft.ML
         /// This provides a means for reconciling multiple rows that have been produced generally from
         /// <see cref="IDataView.GetRowCursorSet(IEnumerable{DataViewSchema.Column}, int, Random)"/>. When getting a set, there is a need
         /// to, while allowing parallel processing to proceed, always have an aim that the original order should be
-        /// reconverable. Note, whether or not a user cares about that original order in ones specific application is
+        /// recoverable. Note, whether or not a user cares about that original order in ones specific application is
         /// another story altogether (most callers of this as a practical matter do not, otherwise they would not call
         /// it), but at least in principle it should be possible to reconstruct the original order one would get from an
         /// identically configured <see cref="IDataView.GetRowCursor(IEnumerable{DataViewSchema.Column}, Random)"/>. So: for any cursor
@@ -135,7 +135,7 @@ namespace Microsoft.ML
         /// considered part of the data per se. So, to take the example of a data view specifically, a single data view
         /// must render consistent IDs across all cursorings, but there is no suggestion at all that if the "same" data
         /// were presented in a different data view (as by, say, being transformed, cached, saved, or whatever), that
-        /// the IDs between the two different data views would have any discernable relationship.</summary>
+        /// the IDs between the two different data views would have any discernible relationship.</summary>
         public abstract ValueGetter<DataViewRowId> GetIdGetter();
 
         /// <summary>

--- a/src/Microsoft.ML.DataView/VBuffer.cs
+++ b/src/Microsoft.ML.DataView/VBuffer.cs
@@ -364,7 +364,7 @@ namespace Microsoft.ML.Data
         ///
         /// For that reason, a single completely isolated lookup, since constructing <see cref="ReadOnlySpan{T}"/> as
         /// <see cref="GetValues"/> does is not a free operation, it may be more efficient to use this method. However
-        /// if one is doing a more involved computation involving many operations, it may be faster to utiltize
+        /// if one is doing a more involved computation involving many operations, it may be faster to utilize
         /// <see cref="GetValues"/> and, if appropriate, <see cref="GetIndices"/> directly.
         /// </remarks>
         /// <param name="index">The index, which must be a non-negative number less than <see cref="Length"/>.</param>

--- a/src/Microsoft.ML.DnnImageFeaturizer.AlexNet/AlexNetExtension.cs
+++ b/src/Microsoft.ML.DnnImageFeaturizer.AlexNet/AlexNetExtension.cs
@@ -31,7 +31,7 @@ namespace Microsoft.ML
         /// <summary>
         /// This allows a custom model location to be specified. This is useful is a custom model is specified,
         /// or if the model is desired to be placed or shipped separately in a different folder from the main application. Note that because Onnx models
-        /// must be in a directory all by themsleves for the OnnxTransformer to work, this method appends a AlexNetOnnx/AlexNetPrepOnnx subdirectory
+        /// must be in a directory all by themselves for the OnnxTransformer to work, this method appends a AlexNetOnnx/AlexNetPrepOnnx subdirectory
         /// to the passed in directory to prevent having to make that directory manually each time.
         /// </summary>
         public static EstimatorChain<ColumnCopyingTransformer> AlexNet(this DnnImageModelSelector dnnModelContext, IHostEnvironment env, string outputColumnName, string inputColumnName, string modelDir)

--- a/src/Microsoft.ML.DnnImageFeaturizer.ResNet101/ResNet101Extension.cs
+++ b/src/Microsoft.ML.DnnImageFeaturizer.ResNet101/ResNet101Extension.cs
@@ -31,7 +31,7 @@ namespace Microsoft.ML
         /// <summary>
         /// This allows a custom model location to be specified. This is useful is a custom model is specified,
         /// or if the model is desired to be placed or shipped separately in a different folder from the main application. Note that because Onnx models
-        /// must be in a directory all by themsleves for the OnnxTransformer to work, this method appends a ResNet101Onnx/ResNetPrepOnnx subdirectory
+        /// must be in a directory all by themselves for the OnnxTransformer to work, this method appends a ResNet101Onnx/ResNetPrepOnnx subdirectory
         /// to the passed in directory to prevent having to make that directory manually each time.
         /// </summary>
         public static EstimatorChain<ColumnCopyingTransformer> ResNet101(this DnnImageModelSelector dnnModelContext, IHostEnvironment env, string outputColumnName, string inputColumnName, string modelDir)

--- a/src/Microsoft.ML.DnnImageFeaturizer.ResNet50/ResNet50Extension.cs
+++ b/src/Microsoft.ML.DnnImageFeaturizer.ResNet50/ResNet50Extension.cs
@@ -31,7 +31,7 @@ namespace Microsoft.ML
         /// <summary>
         /// This allows a custom model location to be specified. This is useful is a custom model is specified,
         /// or if the model is desired to be placed or shipped separately in a different folder from the main application. Note that because Onnx models
-        /// must be in a directory all by themsleves for the OnnxTransformer to work, this method appends a ResNet50Onnx/ResNetPrepOnnx subdirectory
+        /// must be in a directory all by themselves for the OnnxTransformer to work, this method appends a ResNet50Onnx/ResNetPrepOnnx subdirectory
         /// to the passed in directory to prevent having to make that directory manually each time.
         /// </summary>
         public static EstimatorChain<ColumnCopyingTransformer> ResNet50(this DnnImageModelSelector dnnModelContext, IHostEnvironment env, string outputColumnName, string inputColumnName, string modelDir)

--- a/src/Microsoft.ML.Ensemble/Trainer/Multiclass/MulticlassDataPartitionEnsembleTrainer.cs
+++ b/src/Microsoft.ML.Ensemble/Trainer/Multiclass/MulticlassDataPartitionEnsembleTrainer.cs
@@ -58,10 +58,10 @@ namespace Microsoft.ML.Trainers.Ensemble
             {
                 BasePredictors = new[]
                 {
-                    // Note that this illustrates a fundamnetal problem with the mixture of `ITrainer` and `ITrainerEstimator`
+                    // Note that this illustrates a fundamental problem with the mixture of `ITrainer` and `ITrainerEstimator`
                     // present in this class. The options to the estimator have no way of being communicated to the `ITrainer`
-                    // implementation, so there is a fundamnetal disconnect if someone chooses to ever use the *estimator* with
-                    // non-default column names. Unfortuantely no method of resolving this temporary strikes me as being any
+                    // implementation, so there is a fundamental disconnect if someone chooses to ever use the *estimator* with
+                    // non-default column names. Unfortunately no method of resolving this temporary strikes me as being any
                     // less laborious than the proper fix, which is that this "meta" component should itself be a trainer
                     // estimator, as opposed to a regular trainer.
                     ComponentFactoryUtils.CreateFromFunction(env => new LbfgsMaximumEntropyMulticlassTrainer(env, LabelColumnName, FeatureColumnName))

--- a/src/Microsoft.ML.EntryPoints/JsonUtils/JsonManifestUtils.cs
+++ b/src/Microsoft.ML.EntryPoints/JsonUtils/JsonManifestUtils.cs
@@ -166,7 +166,7 @@ namespace Microsoft.ML.EntryPoints
                 // unit tests to compare manifest are passing. For the same reason
                 // duplicate name skipped are always in the same correct order.
                 // Same name field can bubble up from base class even though
-                // its overidden / hidden, skip it.
+                // its overridden / hidden, skip it.
                 if (collectedFields.Contains(name))
                     continue;
                 var jo = new JObject();

--- a/src/Microsoft.ML.EntryPoints/ModelOperations.cs
+++ b/src/Microsoft.ML.EntryPoints/ModelOperations.cs
@@ -138,7 +138,7 @@ namespace Microsoft.ML.EntryPoints
             host.CheckNonEmpty(input.ModelArray, nameof(input.ModelArray));
             // Something tells me we should put normalization as part of macro expansion, but since i get
             // subgraph instead of learner it's a bit tricky to get learner and decide should we add
-            // normalization node or not, plus everywhere in code we leave that reposnsibility to TransformModel.
+            // normalization node or not, plus everywhere in code we leave that responsibility to TransformModel.
             var normalizedView = input.ModelArray[0].TransformModel.Apply(host, input.TrainingData);
             using (var ch = host.Start("CombineOvaModels"))
             {

--- a/src/Microsoft.ML.FastTree/Dataset/Dataset.cs
+++ b/src/Microsoft.ML.FastTree/Dataset/Dataset.cs
@@ -552,7 +552,7 @@ namespace Microsoft.ML.Trainers.FastTree
             /// Writes a binary representation of this class to a byte buffer, at a given position.
             /// The position is incremented to the end of the representation
             /// </summary>
-            /// <param name="buffer">a byte array where the binary represenaion is written</param>
+            /// <param name="buffer">a byte array where the binary representation is written</param>
             /// <param name="position">the position in the byte array</param>
             public void ToByteArray(byte[] buffer, ref int position)
             {

--- a/src/Microsoft.ML.FastTree/Dataset/DenseIntArray.cs
+++ b/src/Microsoft.ML.FastTree/Dataset/DenseIntArray.cs
@@ -168,7 +168,7 @@ namespace Microsoft.ML.Trainers.FastTree
         /// Writes a binary representation of this class to a byte buffer, at a given position.
         /// The position is incremented to the end of the representation
         /// </summary>
-        /// <param name="buffer">a byte array where the binary represenaion is written</param>
+        /// <param name="buffer">a byte array where the binary representation is written</param>
         /// <param name="position">the position in the byte array</param>
         public override void ToByteArray(byte[] buffer, ref int position)
         {
@@ -279,7 +279,7 @@ namespace Microsoft.ML.Trainers.FastTree
         /// Writes a binary representation of this class to a byte buffer, at a given position.
         /// The position is incremented to the end of the representation
         /// </summary>
-        /// <param name="buffer">a byte array where the binary represenaion is written</param>
+        /// <param name="buffer">a byte array where the binary representation is written</param>
         /// <param name="position">the position in the byte array</param>
         public override void ToByteArray(byte[] buffer, ref int position)
         {
@@ -417,7 +417,7 @@ namespace Microsoft.ML.Trainers.FastTree
         /// Writes a binary representation of this class to a byte buffer, at a given position.
         /// The position is incremented to the end of the representation
         /// </summary>
-        /// <param name="buffer">a byte array where the binary represenaion is written</param>
+        /// <param name="buffer">a byte array where the binary representation is written</param>
         /// <param name="position">the position in the byte array</param>
         public override void ToByteArray(byte[] buffer, ref int position)
         {
@@ -519,7 +519,7 @@ namespace Microsoft.ML.Trainers.FastTree
         /// Writes a binary representation of this class to a byte buffer, at a given position.
         /// The position is incremented to the end of the representation
         /// </summary>
-        /// <param name="buffer">a byte array where the binary represenaion is written</param>
+        /// <param name="buffer">a byte array where the binary representation is written</param>
         /// <param name="position">the position in the byte array</param>
         public override void ToByteArray(byte[] buffer, ref int position)
         {
@@ -626,7 +626,7 @@ namespace Microsoft.ML.Trainers.FastTree
         /// Writes a binary representation of this class to a byte buffer, at a given position.
         /// The position is incremented to the end of the representation
         /// </summary>
-        /// <param name="buffer">a byte array where the binary represenaion is written</param>
+        /// <param name="buffer">a byte array where the binary representation is written</param>
         /// <param name="position">the position in the byte array</param>
         public override void ToByteArray(byte[] buffer, ref int position)
         {
@@ -710,7 +710,7 @@ namespace Microsoft.ML.Trainers.FastTree
         /// Writes a binary representation of this class to a byte buffer, at a given position.
         /// The position is incremented to the end of the representation
         /// </summary>
-        /// <param name="buffer">a byte array where the binary represenaion is written</param>
+        /// <param name="buffer">a byte array where the binary representation is written</param>
         /// <param name="position">the position in the byte array</param>
         public override void ToByteArray(byte[] buffer, ref int position)
         {

--- a/src/Microsoft.ML.FastTree/Dataset/Feature.cs
+++ b/src/Microsoft.ML.FastTree/Dataset/Feature.cs
@@ -127,7 +127,7 @@ namespace Microsoft.ML.Trainers.FastTree
         /// Writes a binary representation of this class to a byte buffer, at a given position.
         /// The position is incremented to the end of the representation
         /// </summary>
-        /// <param name="buffer">a byte array where the binary represenaion is written</param>
+        /// <param name="buffer">a byte array where the binary representation is written</param>
         /// <param name="position">the position in the byte array</param>
         public virtual void ToByteArray(byte[] buffer, ref int position)
         {
@@ -252,7 +252,7 @@ namespace Microsoft.ML.Trainers.FastTree
         /// Writes a binary representation of this class to a byte buffer, at a given position.
         /// The position is incremented to the end of the representation
         /// </summary>
-        /// <param name="buffer">a byte array where the binary represenaion is written</param>
+        /// <param name="buffer">a byte array where the binary representation is written</param>
         /// <param name="position">the position in the byte array</param>
         public override void ToByteArray(byte[] buffer, ref int position)
         {

--- a/src/Microsoft.ML.FastTree/Dataset/FeatureFlock.cs
+++ b/src/Microsoft.ML.FastTree/Dataset/FeatureFlock.cs
@@ -1100,7 +1100,7 @@ namespace Microsoft.ML.Trainers.FastTree
 
     /// <summary>
     /// A base class for a feature flock that wraps a single <see cref="IntArray"/> that contains multiple
-    /// feature values using a concatentation of the non-zero ranges of each feature, and also in some way
+    /// feature values using a concatenation of the non-zero ranges of each feature, and also in some way
     /// that doing a <see cref="IntArray.Sumup"/> will accumulate sufficient statistics correctly for all
     /// except the first (zero) bin.
     /// </summary>

--- a/src/Microsoft.ML.FastTree/Dataset/RepeatIntArray.cs
+++ b/src/Microsoft.ML.FastTree/Dataset/RepeatIntArray.cs
@@ -91,7 +91,7 @@ namespace Microsoft.ML.Trainers.FastTree
         /// Writes a binary representation of this class to a byte buffer, at a given position.
         /// The position is incremented to the end of the representation
         /// </summary>
-        /// <param name="buffer">a byte array where the binary represenaion is written</param>
+        /// <param name="buffer">a byte array where the binary representation is written</param>
         /// <param name="position">the position in the byte array</param>
         public override void ToByteArray(byte[] buffer, ref int position)
         {

--- a/src/Microsoft.ML.FastTree/Dataset/SegmentIntArray.cs
+++ b/src/Microsoft.ML.FastTree/Dataset/SegmentIntArray.cs
@@ -134,7 +134,7 @@ namespace Microsoft.ML.Trainers.FastTree
         /// Finds the bits necessary for the optimal variable bit encoding of this
         /// array. If we are also finding the actual optimal path, it can only work
         ///
-        /// This is a considerably less efficienct managed analogue to the
+        /// This is a considerably less efficiency managed analogue to the
         /// C_SegmentFindOptimalPath and C_SegmentFindOptimalCost functions.
         /// It is used by the class only when not using the unmanaged library.
         /// </summary>

--- a/src/Microsoft.ML.FastTree/Dataset/SparseIntArray.cs
+++ b/src/Microsoft.ML.FastTree/Dataset/SparseIntArray.cs
@@ -235,7 +235,7 @@ namespace Microsoft.ML.Trainers.FastTree
         /// Writes a binary representation of this class to a byte buffer, at a given position.
         /// The position is incremented to the end of the representation
         /// </summary>
-        /// <param name="buffer">a byte array where the binary represenaion is written</param>
+        /// <param name="buffer">a byte array where the binary representation is written</param>
         /// <param name="position">the position in the byte array</param>
         public override void ToByteArray(byte[] buffer, ref int position)
         {

--- a/src/Microsoft.ML.FastTree/FastTree.cs
+++ b/src/Microsoft.ML.FastTree/FastTree.cs
@@ -1165,7 +1165,7 @@ namespace Microsoft.ML.Trainers.FastTree
 #endif
                 double[] bub = BinUpperBounds[fi];
                 ch.Assert(bub.Length == 2);
-                //REVIEW: leaving out check for the value to reduced memory consuption and going with
+                //REVIEW: leaving out check for the value to reduced memory consumption and going with
                 //leap of faith based on what the user told.
                 binnedValues[i] = hotFeatureStarts[subfeature] + 1;
                 hotCount++;

--- a/src/Microsoft.ML.FastTree/FastTreeArguments.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeArguments.cs
@@ -363,7 +363,7 @@ namespace Microsoft.ML.Trainers.FastTree
         // 3. grad Sampling Rate in Objective Function
         // 4. tree learner
         // 5. bagging provider
-        // 6. emsemble compressor
+        // 6. ensemble compressor
         /// <summary>
         /// The seed of the random number generator.
         /// </summary>

--- a/src/Microsoft.ML.FastTree/FastTreeClassification.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeClassification.cs
@@ -251,7 +251,7 @@ namespace Microsoft.ML.Trainers.FastTree
         private protected override void PrepareLabels(IChannel ch)
         {
             _trainSetLabels = GetClassificationLabelsFromRatings(TrainSet).ToArray(TrainSet.NumDocs);
-            //Here we set regression labels to what is in bin file if the values were not overriden with floats
+            //Here we set regression labels to what is in bin file if the values were not overridden with floats
         }
 
         private protected override Test ConstructTestForTrainingData()
@@ -292,7 +292,7 @@ namespace Microsoft.ML.Trainers.FastTree
                 }
                 else
                 {
-                    //use tollerant stopping condition
+                    //use tolerant stopping condition
                     PruningTest = new TestWindowWithTolerance(ValidTest, 0, FastTreeTrainerOptions.PruningWindowSize, FastTreeTrainerOptions.PruningThreshold);
                 }
             }

--- a/src/Microsoft.ML.FastTree/FastTreeRanking.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeRanking.cs
@@ -242,7 +242,7 @@ namespace Microsoft.ML.Trainers.FastTree
 
             if (FastTreeTrainerOptions.PrintTestGraph)
             {
-                // If FirstTestHistory is null (which means the tests were not intialized due to /tf==infinity)
+                // If FirstTestHistory is null (which means the tests were not initialized due to /tf==infinity)
                 // We need initialize first set for graph printing
                 // Adding to a tests would result in printing the results after final iteration
                 if (_firstTestSetHistory == null)
@@ -760,7 +760,7 @@ namespace Microsoft.ML.Trainers.FastTree
 
                     if (_groupIdToTopLabel[groupIndex] != -1)
                     {
-                        // this is the second+ occurance of a result
+                        // this is the second+ occurrence of a result
                         // of the same duplicate group, so:
                         // - disconsider when applying the cost function
                         //
@@ -894,7 +894,7 @@ namespace Microsoft.ML.Trainers.FastTree
                             }
                         }
 
-                        // Continous cost function and shifted NDCG require a re-sort and recomputation of maxDCG
+                        // Continuous cost function and shifted NDCG require a re-sort and recomputation of maxDCG
                         // (Change of scores in the former and scores and labels in the latter)
                         if (!_useDcg && (_costFunctionParam == 'c' || _useShiftedNdcg))
                         {

--- a/src/Microsoft.ML.FastTree/FastTreeRegression.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeRegression.cs
@@ -261,7 +261,7 @@ namespace Microsoft.ML.Trainers.FastTree
 
             if (FastTreeTrainerOptions.PrintTestGraph)
             {
-                // If FirstTestHistory is null (which means the tests were not intialized due to /tf==infinity),
+                // If FirstTestHistory is null (which means the tests were not initialized due to /tf==infinity),
                 // we need initialize first set for graph printing.
                 // Adding to a tests would result in printing the results after final iteration.
                 if (_firstTestSetHistory == null)
@@ -386,7 +386,7 @@ namespace Microsoft.ML.Trainers.FastTree
 
             // We only print non-zero train&valid graph if earlyStoppingTruncation!=0.
             // In case /es is not set, we print 0 for train and valid graph NDCG.
-            // Let's keeping this behaviour for backward compatibility with previous FR version.
+            // Let's keeping this behavior for backward compatibility with previous FR version.
             // Ideally /graphtv should enforce non-zero /es in the commandline validation.
             if (_trainRegressionTest != null)
                 trainRegression = _trainRegressionTest.ComputeTests().Last().FinalValue;

--- a/src/Microsoft.ML.FastTree/FastTreeTweedie.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeTweedie.cs
@@ -240,7 +240,7 @@ namespace Microsoft.ML.Trainers.FastTree
 
             if (FastTreeTrainerOptions.PrintTestGraph)
             {
-                // If FirstTestHistory is null (which means the tests were not intialized due to /tf==infinity),
+                // If FirstTestHistory is null (which means the tests were not initialized due to /tf==infinity),
                 // we need initialize first set for graph printing.
                 // Adding to a tests would result in printing the results after final iteration.
                 if (_firstTestSetHistory == null)
@@ -322,7 +322,7 @@ namespace Microsoft.ML.Trainers.FastTree
 
             // We only print non-zero train&valid graph if earlyStoppingTruncation!=0.
             // In case /es is not set, we print 0 for train and valid graph NDCG.
-            // Let's keeping this behaviour for backward compatibility with previous FR version.
+            // Let's keeping this behavior for backward compatibility with previous FR version.
             // Ideally /graphtv should enforce non-zero /es in the commandline validation.
             if (_trainRegressionTest != null)
                 trainRegression = _trainRegressionTest.ComputeTests().Last().FinalValue;

--- a/src/Microsoft.ML.FastTree/GamModelParameters.cs
+++ b/src/Microsoft.ML.FastTree/GamModelParameters.cs
@@ -19,7 +19,7 @@ using Microsoft.ML.Trainers.FastTree;
 using Microsoft.ML.Transforms;
 
 [assembly: LoadableClass(typeof(GamModelParametersBase.VisualizationCommand), typeof(GamModelParametersBase.VisualizationCommand.Arguments), typeof(SignatureCommand),
-    "GAM Vizualization Command", GamModelParametersBase.VisualizationCommand.LoadName, "gamviz", DocName = "command/GamViz.md")]
+    "GAM Visualization Command", GamModelParametersBase.VisualizationCommand.LoadName, "gamviz", DocName = "command/GamViz.md")]
 
 namespace Microsoft.ML.Trainers.FastTree
 {

--- a/src/Microsoft.ML.FastTree/GamTrainer.cs
+++ b/src/Microsoft.ML.FastTree/GamTrainer.cs
@@ -277,7 +277,7 @@ namespace Microsoft.ML.Trainers.FastTree
         private void TrainCore(IChannel ch)
         {
             Contracts.CheckValue(ch, nameof(ch));
-            // REVIEW:Get rid of this lock then we completly remove all static classes from Gam such as BlockingThreadPool.
+            // REVIEW:Get rid of this lock then we completely remove all static classes from Gam such as BlockingThreadPool.
             lock (FastTreeShared.TrainLock)
             {
                 using (Timer.Time(TimerEvent.TotalInitialization))

--- a/src/Microsoft.ML.FastTree/RandomForestClassification.cs
+++ b/src/Microsoft.ML.FastTree/RandomForestClassification.cs
@@ -62,7 +62,7 @@ namespace Microsoft.ML.Trainers.FastTree
             return new VersionInfo(
                 modelSignature: "FFORE BC",
                 // verWrittenCur: 0x00010001, Initial
-                // verWrittenCur: 0x00010002, // InstanceWeights are part of QuantileRegression Tree to support weighted intances
+                // verWrittenCur: 0x00010002, // InstanceWeights are part of QuantileRegression Tree to support weighted instances
                 // verWrittenCur: 0x00010003, // _numFeatures serialized
                 // verWrittenCur: 0x00010004, // Ini content out of predictor
                 // verWrittenCur: 0x00010005, // Add _defaultValueForMissing

--- a/src/Microsoft.ML.FastTree/RandomForestRegression.cs
+++ b/src/Microsoft.ML.FastTree/RandomForestRegression.cs
@@ -67,7 +67,7 @@ namespace Microsoft.ML.Trainers.FastTree
             /// </summary>
             public float GetQuantile(float p)
             {
-                Contracts.CheckParam(0 <= p && p <= 1, nameof(p), "Probablity argument for Quantile function should be between 0 to 1 inclusive");
+                Contracts.CheckParam(0 <= p && p <= 1, nameof(p), "Probability argument for Quantile function should be between 0 to 1 inclusive");
 
                 if (_data.Length == 0)
                     return float.NaN;
@@ -153,7 +153,7 @@ namespace Microsoft.ML.Trainers.FastTree
             return new VersionInfo(
                 modelSignature: "FFORE RE",
                 // verWrittenCur: 0x00010001, Initial
-                // verWrittenCur: 0x00010002, // InstanceWeights are part of QuantileRegression Tree to support weighted intances
+                // verWrittenCur: 0x00010002, // InstanceWeights are part of QuantileRegression Tree to support weighted instances
                 // verWrittenCur: 0x00010003, // _numFeatures serialized
                 // verWrittenCur: 0x00010004, // Ini content out of predictor
                 // verWrittenCur: 0x00010005, // Add _defaultValueForMissing

--- a/src/Microsoft.ML.FastTree/SumupPerformanceCommand.cs
+++ b/src/Microsoft.ML.FastTree/SumupPerformanceCommand.cs
@@ -109,7 +109,7 @@ namespace Microsoft.ML.Trainers.FastTree
 
         private IEnumerable<int> CreateSparse(IChannel ch, Random rgen)
         {
-            ch.CheckUserArg(0 <= _param && _param < 1, nameof(Arguments.Parameter), "For sparse ararys");
+            ch.CheckUserArg(0 <= _param && _param < 1, nameof(Arguments.Parameter), "For sparse arrays");
             // The parameter is the level of sparsity. Use the geometric distribution to determine the number of
             // Geometric distribution (with 0 support) would be Math.
             double denom = Math.Log(1 - _param);

--- a/src/Microsoft.ML.FastTree/Training/Applications/ObjectiveFunction.cs
+++ b/src/Microsoft.ML.FastTree/Training/Applications/ObjectiveFunction.cs
@@ -59,7 +59,7 @@ namespace Microsoft.ML.Trainers.FastTree
             using (Timer.Time(TimerEvent.ObjectiveFunctionGetDerivatives))
             {
                 // REVIEW: This partitioning doesn't look optimal.
-                // Probably make sence to investigate better ways of splitting data?
+                // Probably make sense to investigate better ways of splitting data?
                 var actions = new Action[(int)Math.Ceiling((double)Dataset.NumQueries / QueryThreadChunkSize)];
                 var actionIndex = 0;
                 var queue = new ConcurrentQueue<int>(Enumerable.Range(0, BlockingThreadPool.NumThreads));

--- a/src/Microsoft.ML.FastTree/Training/DcgCalculator.cs
+++ b/src/Microsoft.ML.FastTree/Training/DcgCalculator.cs
@@ -252,7 +252,7 @@ namespace Microsoft.ML.Trainers.FastTree
 
         /// <summary>
         /// Efficient computation of average NDCG@1 for the entire dataset
-        /// Note that it is virtual and MPI provides faster implemetations for MPI
+        /// Note that it is virtual and MPI provides faster implementations for MPI
         /// </summary>
         /// <param name="dataset">the dataset</param>
         /// <param name="labels"></param>
@@ -367,7 +367,7 @@ namespace Microsoft.ML.Trainers.FastTree
 
             int chunkSize = 1 + dataset.NumQueries / BlockingThreadPool.NumThreads;   // Minimizes the number of repeat computations in sparse array to have each thread take as big a chunk as possible
             // REVIEW: This partitioning doesn't look optimal.
-            // Probably make sence to investigate better ways of splitting data?
+            // Probably make sense to investigate better ways of splitting data?
             var actions = new Action[(int)Math.Ceiling(1.0 * dataset.NumQueries / chunkSize)];
             var actionIndex = 0;
             for (int q = 0; q < dataset.NumQueries; q += chunkSize)
@@ -506,7 +506,7 @@ namespace Microsoft.ML.Trainers.FastTree
 
             int chunkSize = 1 + dataset.NumQueries / BlockingThreadPool.NumThreads;   // Minimizes the number of repeat computations in sparse array to have each thread take as big a chunk as possible
             // REVIEW: This partitioning doesn't look optimal.
-            // Probably make sence to investigate better ways of splitting data?
+            // Probably make sense to investigate better ways of splitting data?
             var actions = new Action[(int)Math.Ceiling(1.0 * dataset.NumQueries / chunkSize)];
             var actionIndex = 0;
             for (int q = 0; q < dataset.NumQueries; q += chunkSize)

--- a/src/Microsoft.ML.FastTree/Training/DocumentPartitioning.cs
+++ b/src/Microsoft.ML.FastTree/Training/DocumentPartitioning.cs
@@ -67,7 +67,7 @@ namespace Microsoft.ML.Trainers.FastTree
                     ++numChunks;
                 var perChunkDocumentLists = new List<int>[numChunks][];
                 // REVIEW: This partitioning doesn't look optimal.
-                // Probably make sence to investigate better ways of splitting data?
+                // Probably make sense to investigate better ways of splitting data?
                 var actions = new Action[(int)Math.Ceiling(1.0 * dataset.NumDocs / innerLoopSize)];
                 var actionIndex = 0;
                 for (int docStart = 0; docStart < dataset.NumDocs; docStart += innerLoopSize)
@@ -239,7 +239,7 @@ namespace Microsoft.ML.Trainers.FastTree
         /// </summary>
         /// <param name="leaf">the leaf being split</param>
         /// <param name="bins">Split feature flock's bin</param>
-        /// <param name="categoricalIndices">Catgeorical feature indices</param>
+        /// <param name="categoricalIndices">Categorical feature indices</param>
         /// <param name="gtChildIndex">Index of child node that contains documents whose split
         /// feature value is greater than the split threshold</param>
         public unsafe void Split(int leaf, IntArray bins, HashSet<int> categoricalIndices, int gtChildIndex)

--- a/src/Microsoft.ML.FastTree/Training/EarlyStoppingCriteria.cs
+++ b/src/Microsoft.ML.FastTree/Training/EarlyStoppingCriteria.cs
@@ -145,7 +145,7 @@ namespace Microsoft.ML.Trainers.FastTree
             Threshold = threshold;
         }
 
-        // Used in command line tool to construct lodable class.
+        // Used in command line tool to construct loadable class.
         private TolerantEarlyStoppingRule(Options options, bool lowerIsBetter)
             : base(lowerIsBetter)
         {
@@ -304,7 +304,7 @@ namespace Microsoft.ML.Trainers.FastTree
 
         /// <summary>
         /// Create a rule which may terminate the training process in case of loss of generality. The loss of generality means
-        /// the specified score on validation start increaseing.
+        /// the specified score on validation start increasing.
         /// </summary>
         /// <param name="threshold">The maximum gap (in percentage such as 0.01 for 1% and 0.5 for 50%) between the (current) validation
         /// score and its best historical value.</param>
@@ -315,7 +315,7 @@ namespace Microsoft.ML.Trainers.FastTree
             Threshold = threshold;
         }
 
-        // Used in command line tool to construct lodable class.
+        // Used in command line tool to construct loadable class.
         private GeneralityLossRule(Options options, bool lowerIsBetter)
             : base(lowerIsBetter)
         {
@@ -370,7 +370,7 @@ namespace Microsoft.ML.Trainers.FastTree
         {
         }
 
-        // Used in command line tool to construct lodable class.
+        // Used in command line tool to construct loadable class.
         private LowProgressRule(Options options, bool lowerIsBetter)
             : base(lowerIsBetter, options.Threshold, options.WindowSize)
         {
@@ -427,7 +427,7 @@ namespace Microsoft.ML.Trainers.FastTree
         {
         }
 
-        // Used in command line tool to construct lodable class.
+        // Used in command line tool to construct loadable class.
         private GeneralityToProgressRatioRule(Options options, bool lowerIsBetter)
             : base(lowerIsBetter, options.Threshold, options.WindowSize)
         {

--- a/src/Microsoft.ML.FastTree/Training/OptimizationAlgorithms/AcceleratedGradientDescent.cs
+++ b/src/Microsoft.ML.FastTree/Training/OptimizationAlgorithms/AcceleratedGradientDescent.cs
@@ -36,11 +36,11 @@ namespace Microsoft.ML.Trainers.FastTree
             trainingScores.XK = xk;
 
             if (tree == null)
-                return null; // No tree was actually learnt. Give up.
+                return null; // No tree was actually learned. Give up.
 
             // ... and update the training scores that we omitted from update
             // in AcceleratedGradientDescent.UpdateScores
-            // Here we could use faster way of comuting train scores taking advantage of scores precompited by LineSearch
+            // Here we could use faster way of computing train scores taking advantage of scores precomputed by LineSearch
             // But that would make the code here even more difficult/complex
             trainingScores.AddScores(tree, TreeLearner.Partitioning, 1.0);
 

--- a/src/Microsoft.ML.FastTree/Training/OptimizationAlgorithms/ConjugateGradientDescent.cs
+++ b/src/Microsoft.ML.FastTree/Training/OptimizationAlgorithms/ConjugateGradientDescent.cs
@@ -46,7 +46,7 @@ namespace Microsoft.ML.Trainers.FastTree
             ch.Info("beta: {0}", beta);
             VectorUtils.MutiplyInPlace(previousDk, beta);
             VectorUtils.AddInPlace(previousDk, _currentGradient);
-            _currentDk = previousDk; // Reallay no-op opration
+            _currentDk = previousDk; // Really no-op operation
 
             // We know that LeastSquaresRegressionTreeLearner does not destroy gradients so we can return our reference that we will need in next iter.
             if (TreeLearner is LeastSquaresRegressionTreeLearner)

--- a/src/Microsoft.ML.FastTree/Training/OptimizationAlgorithms/OptimizationAlgorithm.cs
+++ b/src/Microsoft.ML.FastTree/Training/OptimizationAlgorithms/OptimizationAlgorithm.cs
@@ -8,7 +8,7 @@ using Microsoft.ML.Runtime;
 
 namespace Microsoft.ML.Trainers.FastTree
 {
-    //An interface that can be implemnted on
+    //An interface that can be implemented on
     internal interface IFastTrainingScoresUpdate
     {
         ScoreTracker GetUpdatedTrainingScores();

--- a/src/Microsoft.ML.FastTree/Training/RegressionTreeNodeDocuments.cs
+++ b/src/Microsoft.ML.FastTree/Training/RegressionTreeNodeDocuments.cs
@@ -80,7 +80,7 @@ namespace Microsoft.ML.Trainers.FastTree
 
     //RecursiveRegressionTree captures a recursive representation of a tree
     //and inherits from RegressionTreeNodeDocuments (a non-recursive node with documents)
-    //The class in most cases would be contructed with node index of 0 and would create
+    //The class in most cases would be constructed with node index of 0 and would create
     //entire structure of a full tree accessible with LTENode and GTNode
     //
     //Curently only used for smoothing and defines operations defined in recursive fashion

--- a/src/Microsoft.ML.FastTree/Training/ScoreTracker.cs
+++ b/src/Microsoft.ML.FastTree/Training/ScoreTracker.cs
@@ -135,7 +135,7 @@ namespace Microsoft.ML.Trainers.FastTree
             throw Contracts.ExceptNotSupp("This code should not be reachable");
         }
 
-        //Computes AGD specific mutiplier. Given that we have tree number t in ensamble (we count trees starting from 0)
+        //Computes AGD specific mutiplier. Given that we have tree number t in ensemble (we count trees starting from 0)
         //And we have total k trees in ensemble, what should be the multiplier on the tree when sum the ensemble together based on AGD formula being
         //X[k+1] = Y[k] + Tree[k]
         //Y[k+1] = X[k+1] + C[k] * (X[k+1] – X[k])
@@ -159,7 +159,7 @@ namespace Microsoft.ML.Trainers.FastTree
             else if (k == t + 1)
                 result = 1.0;
             else
-                result = TreeMultiplier(t, k - 1) + (k - 1.0 - 1.0) / (k - 1.0 + 2.0) * (TreeMultiplier(t, k - 1) - TreeMultiplier(t, k - 2)); //This is last tree beeing added X[k] = Y[k-1] + 1.0 * T[k]
+                result = TreeMultiplier(t, k - 1) + (k - 1.0 - 1.0) / (k - 1.0 + 2.0) * (TreeMultiplier(t, k - 1) - TreeMultiplier(t, k - 2)); //This is last tree being added X[k] = Y[k-1] + 1.0 * T[k]
             _treeMultiplierMap[t][k] = result;
             return result;
         }
@@ -171,7 +171,7 @@ namespace Microsoft.ML.Trainers.FastTree
 
             int innerLoopSize = 1 + Dataset.NumDocs / BlockingThreadPool.NumThreads;   // +1 is to make sure we don't have a few left over at the end
             // REVIEW: This partitioning doesn't look optimal.
-            // Probably make sence to investigate better ways of splitting data?
+            // Probably make sense to investigate better ways of splitting data?
             var actions = new Action[(int)Math.Ceiling(1.0 * Dataset.NumDocs / innerLoopSize)];
             var actionIndex = 0;
             for (int d = 0; d < Dataset.NumDocs; d += innerLoopSize)

--- a/src/Microsoft.ML.FastTree/Training/Test.cs
+++ b/src/Microsoft.ML.FastTree/Training/Test.cs
@@ -178,7 +178,7 @@ namespace Microsoft.ML.Trainers.FastTree
             return ComputeTests(scores);
         }
 
-        // This is the info string that represnts the cotent in teh most descriptive fashion
+        // This is the info string that represents the content in the most descriptive fashion
         // The main difference between ConsoleString is always printed. The caller is responsible for deciding if InfoString is InfoString needs to be printed or not
         public virtual string FormatInfoString()
         {
@@ -193,7 +193,7 @@ namespace Microsoft.ML.Trainers.FastTree
 
     // A simple class that tracks history of underlying Test.
     // It captures an iteration that peak on a given metric
-    // Each itaratin captures an array of LossFunctions computed by inderlying Test
+    // Each iteration captures an array of LossFunctions computed by underlying Test
     internal class TestHistory : Test
     {
         public readonly Test SimpleTest;
@@ -254,7 +254,7 @@ namespace Microsoft.ML.Trainers.FastTree
 
     // A class that tracks history of underlying Test.
     // Can capture an iteration that peak on a given metric
-    // Each itaratin captures an array of LossFunctions computed by inderlying Test
+    // Each iteration captures an array of LossFunctions computed by underlying Test
     internal class TestWindowWithTolerance : TestHistory
     {
         // Struct to keep information for tolerant early stopping
@@ -286,7 +286,7 @@ namespace Microsoft.ML.Trainers.FastTree
         public double CurrentAverageValue => _currentWindowSum / _windowSize;
 
         // windowSize - number of iterations of average
-        // tolerance - how much off we can be from the best average (0.04 stand that we consider the best itration the average over the window is 4% worse than the best average)
+        // tolerance - how much off we can be from the best average (0.04 stand that we consider the best iteration the average over the window is 4% worse than the best average)
         public TestWindowWithTolerance(Test scenarioWithoutHistory, int lossIndex,
                                        int windowSize, double tolerance)
             : base(scenarioWithoutHistory, lossIndex)
@@ -537,7 +537,7 @@ namespace Microsoft.ML.Trainers.FastTree
             double totalL2Error = 0.0;
             int chunkSize = 1 + Dataset.NumDocs / BlockingThreadPool.NumThreads;   // Minimizes the number of repeat computations in sparse array to have each thread take as big a chunk as possible
             // REVIEW: This partitioning doesn't look optimal.
-            // Probably make sence to investigate better ways of splitting data?
+            // Probably make sense to investigate better ways of splitting data?
             var actions = new Action[(int)Math.Ceiling(1.0 * Dataset.NumDocs / chunkSize)];
             var actionIndex = 0;
             for (int documentStart = 0; documentStart < Dataset.NumDocs; documentStart += chunkSize)
@@ -612,10 +612,10 @@ namespace Microsoft.ML.Trainers.FastTree
         {
             long totalNpos = 0;
             long totalNneg = 0;
-            // Compute number number of positives and number of negative examples
+            // Compute number of positives and number of negative examples
             int chunkSize = 1 + binaryLabels.Length / BlockingThreadPool.NumThreads;   // Minimizes the number of repeat computations in sparse array to have each thread take as big a chunk as possible
             // REVIEW: This partitioning doesn't look optimal.
-            // Probably make sence to investigate better ways of splitting data?
+            // Probably make sense to investigate better ways of splitting data?
             var actions = new Action[(int)Math.Ceiling(1.0 * binaryLabels.Length / chunkSize)];
             var actionIndex = 0;
             for (int documentStart = 0; documentStart < binaryLabels.Length; documentStart += chunkSize)
@@ -655,7 +655,7 @@ namespace Microsoft.ML.Trainers.FastTree
 
             int chunkSize = 1 + Dataset.NumDocs / BlockingThreadPool.NumThreads;   // Minimizes the number of repeat computations in sparse array to have each thread take as big a chunk as possible
             // REVIEW: This partitioning doesn't look optimal.
-            // Probably make sence to investigate better ways of splitting data?
+            // Probably make sense to investigate better ways of splitting data?
             var actions = new Action[(int)Math.Ceiling(1.0 * Dataset.NumDocs / chunkSize)];
             var actionIndex = 0;
             for (int documentStart = 0; documentStart < Dataset.NumDocs; documentStart += chunkSize)

--- a/src/Microsoft.ML.FastTree/Training/TreeLearners/LeastSquaresRegressionTreeLearner.cs
+++ b/src/Microsoft.ML.FastTree/Training/TreeLearners/LeastSquaresRegressionTreeLearner.cs
@@ -444,7 +444,7 @@ namespace Microsoft.ML.Trainers.FastTree
         /// <summary>
         /// After the gain for each feature has been computed, this function chooses the gain maximizing feature
         /// and sets its info in the right places
-        /// This method is overriden in MPI version of the code
+        /// This method is overridden in MPI version of the code
         /// </summary>
         /// <param name="leafSplitCandidates">the FindBestThesholdleafSplitCandidates data structure that contains the best split information</param>
         protected virtual void FindAndSetBestFeatureForLeaf(LeafSplitCandidates leafSplitCandidates)
@@ -611,7 +611,7 @@ namespace Microsoft.ML.Trainers.FastTree
             {
                 if (BsrMaxTreeOutput < 0)
                     return (sumTargets * sumTargets) / count;
-                // For the BSR case, fall through to below with sweight
+                // For the BSR case, fall through to below with sumWeight
                 // receiving the "natural" weight.
                 sumWeights = count;
             }

--- a/src/Microsoft.ML.FastTree/Training/WinLossCalculator.cs
+++ b/src/Microsoft.ML.FastTree/Training/WinLossCalculator.cs
@@ -49,7 +49,7 @@ namespace Microsoft.ML.Trainers.FastTree
 
             int chunkSize = 1 + dataset.NumQueries / BlockingThreadPool.NumThreads;   // Minimizes the number of repeat computations in sparse array to have each thread take as big a chunk as possible
             // REVIEW: This partitioning doesn't look optimal.
-            // Probably make sence to investigate better ways of splitting data?
+            // Probably make sense to investigate better ways of splitting data?
             var actions = new Action[(int)Math.Ceiling(1.0 * dataset.NumQueries / chunkSize)];
             var actionIndex = 0;
             var queue = new ConcurrentQueue<int>(Enumerable.Range(0, BlockingThreadPool.NumThreads));

--- a/src/Microsoft.ML.FastTree/TreeEnsemble/InternalRegressionTree.cs
+++ b/src/Microsoft.ML.FastTree/TreeEnsemble/InternalRegressionTree.cs
@@ -1351,7 +1351,7 @@ namespace Microsoft.ML.Trainers.FastTree
             //  necessary in the rowwise indexer.
             int innerLoopSize = 1 + dataset.NumDocs / BlockingThreadPool.NumThreads;   // +1 is to make sure we don't have a few left over at the end
             // REVIEW: This partitioning doesn't look optimal.
-            // Probably make sence to investigate better ways of splitting data?
+            // Probably make sense to investigate better ways of splitting data?
             var actions = new Action[(int)Math.Ceiling(1.0 * dataset.NumDocs / innerLoopSize)];
             var actionIndex = 0;
             for (int d = 0; d < dataset.NumDocs; d += innerLoopSize)
@@ -1376,7 +1376,7 @@ namespace Microsoft.ML.Trainers.FastTree
             //  necessary in the rowwise indexer.
             int innerLoopSize = 1 + dataset.NumDocs / BlockingThreadPool.NumThreads;   // +1 is to make sure we don't have a few left over at the end
             // REVIEW: This partitioning doesn't look optimal.
-            // Probably make sence to investigate better ways of splitting data?
+            // Probably make sense to investigate better ways of splitting data?
             var actions = new Action[(int)Math.Ceiling(1.0 * dataset.NumDocs / innerLoopSize)];
             var actionIndex = 0;
             for (int d = 0; d < dataset.NumDocs; d += innerLoopSize)
@@ -1399,7 +1399,7 @@ namespace Microsoft.ML.Trainers.FastTree
             //  necessary in the rowwise indexer.
             int innerLoopSize = 1 + docIndices.Length / BlockingThreadPool.NumThreads;   // +1 is to make sure we don't have a few left over at the end
             // REVIEW: This partitioning doesn't look optimal.
-            // Probably make sence to investigate better ways of splitting data?
+            // Probably make sense to investigate better ways of splitting data?
             var actions = new Action[(int)Math.Ceiling(1.0 * docIndices.Length / innerLoopSize)];
             var actionIndex = 0;
             for (int d = 0; d < docIndices.Length; d += innerLoopSize)

--- a/src/Microsoft.ML.FastTree/TreeEnsemble/InternalTreeEnsemble.cs
+++ b/src/Microsoft.ML.FastTree/TreeEnsemble/InternalTreeEnsemble.cs
@@ -292,7 +292,7 @@ namespace Microsoft.ML.Trainers.FastTree
 
             int innerLoopSize = 1 + dataset.NumDocs / BlockingThreadPool.NumThreads;  // minimize number of times we have to skip forward in the sparse arrays
             // REVIEW: This partitioning doesn't look optimal.
-            // Probably make sence to investigate better ways of splitting data?
+            // Probably make sense to investigate better ways of splitting data?
             var actions = new Action[(int)Math.Ceiling(1.0 * dataset.NumDocs / innerLoopSize)];
             var actionIndex = 0;
             for (int d = 0; d < dataset.NumDocs; d += innerLoopSize)

--- a/src/Microsoft.ML.FastTree/Utils/Algorithms.cs
+++ b/src/Microsoft.ML.FastTree/Utils/Algorithms.cs
@@ -123,7 +123,7 @@ namespace Microsoft.ML.Trainers.FastTree
         }
 
         /// <summary>
-        /// Fidns the minimum and the argmin in an array of values
+        /// Finds the minimum and the argmin in an array of values
         /// </summary>
         public static T Min<T>(T[] array, out int argmin) where T : IComparable
         {

--- a/src/Microsoft.ML.FastTree/Utils/PseudorandomFunction.cs
+++ b/src/Microsoft.ML.FastTree/Utils/PseudorandomFunction.cs
@@ -8,7 +8,7 @@ using System.Linq;
 namespace Microsoft.ML.Trainers.FastTree
 {
     /// <summary>
-    /// This class defines a psuedorandom function, mapping a number to
+    /// This class defines a pseudo-random function, mapping a number to
     /// a hard to predict but deterministic other number, through some
     /// nefarious means.
     /// </summary>

--- a/src/Microsoft.ML.FastTree/doc.xml
+++ b/src/Microsoft.ML.FastTree/doc.xml
@@ -6,7 +6,7 @@
         Trains a tree ensemble, or loads it from a file, then maps a numeric feature vector to outputs.
       </summary>
       <remarks>
-        In machine learning​ it is a pretty common and powerful approach to utilize the already trained model in the process of defining features.
+        In machine learning it is a pretty common and powerful approach to utilize the already trained model in the process of defining features.
         <para>One such example would be the use of model&apos;s scores as features to downstream models. For example, we might run clustering on the original features, 
         and use the cluster distances as the new feature set.
         Instead of consuming the model&apos;s output, we could go deeper, and extract the &apos;intermediate outputs&apos; that are used to produce the final score. </para>

--- a/src/Microsoft.ML.Featurizers/Common.cs
+++ b/src/Microsoft.ML.Featurizers/Common.cs
@@ -121,7 +121,7 @@ namespace Microsoft.ML.Featurizers
 
         protected override bool ReleaseHandle()
         {
-            // Not sure what to do with error stuff here.  There shoudln't ever be one though.
+            // Not sure what to do with error stuff here.  There shouldn't ever be one though.
             return _destroySaveDataHandler(handle, _dataSize, out IntPtr errorHandle);
         }
     }
@@ -163,7 +163,7 @@ namespace Microsoft.ML.Featurizers
 
         protected override bool ReleaseHandle()
         {
-            // Not sure what to do with error stuff here.  There shoudln't ever be one though.
+            // Not sure what to do with error stuff here.  There shouldn't ever be one though.
             return DestroyTransformerSaveDataNative(handle, _dataSize, out _);
         }
     }

--- a/src/Microsoft.ML.Featurizers/DateTimeTransformer.cs
+++ b/src/Microsoft.ML.Featurizers/DateTimeTransformer.cs
@@ -37,7 +37,7 @@ namespace Microsoft.ML.Featurizers
     {
         /// <summary>
         /// Create a <see cref="DateTimeEstimator"/>, which splits up the input column specified by <paramref name="inputColumnName"/>
-        /// into all its individual datetime components. Input column must be of type Int64 representing the number of seconds since the unix epoc.
+        /// into all its individual datetime components. Input column must be of type Int64 representing the number of seconds since the unix epoch.
         /// This transformer will append the <paramref name="columnPrefix"/> to all the output columns. If you specify a country,
         /// Holiday details will be looked up for that country as well.
         /// </summary>
@@ -345,7 +345,7 @@ namespace Microsoft.ML.Featurizers
 
             protected override bool ReleaseHandle()
             {
-                // Not sure what to do with error stuff here.  There shoudln't ever be one though.
+                // Not sure what to do with error stuff here.  There shouldn't ever be one though.
                 return _destroyTransformedDataHandler(handle, out IntPtr errorHandle);
             }
         }

--- a/src/Microsoft.ML.Featurizers/TimeSeriesImputer.cs
+++ b/src/Microsoft.ML.Featurizers/TimeSeriesImputer.cs
@@ -41,7 +41,7 @@ namespace Microsoft.ML.Featurizers
 
         /// <summary>
         /// Create a <see cref="TimeSeriesImputerEstimator"/>, Imputes missing rows and column data per grain. Applies the imputation strategy on
-        /// a filtered list of columns in the IDataView. Columns that are are excluded will have the default value for that data type used when a row
+        /// a filtered list of columns in the IDataView. Columns that are excluded will have the default value for that data type used when a row
         /// is imputed. Currently only float/double/string columns are supported for imputation strategies, and an empty string is considered "missing" for the
         /// purpose of this estimator.
         /// </summary>
@@ -52,7 +52,7 @@ namespace Microsoft.ML.Featurizers
         /// If <paramref name="filterMode"/> is <see cref="TimeSeriesImputerEstimator.FilterMode.Include"/> than values in the list are the only columns imputed.</param>
         /// <param name="filterMode">Whether the list <paramref name="filterColumns"/> should include or exclude those columns.</param>
         /// <param name="imputeMode">Mode of imputation for missing values in column. If not passed defaults to forward fill</param>
-        /// <param name="suppressTypeErrors">Supress the errors that would occur if a column and impute mode are imcompatible. If true, will skip the column and use the default value. If false, will stop and throw an error.</param>
+        /// <param name="suppressTypeErrors">Suppress the errors that would occur if a column and impute mode are incompatible. If true, will skip the column and use the default value. If false, will stop and throw an error.</param>
         public static TimeSeriesImputerEstimator ReplaceMissingTimeSeriesValues(this TransformsCatalog catalog, string timeSeriesColumn,
             string[] grainColumns, string[] filterColumns, TimeSeriesImputerEstimator.FilterMode filterMode = TimeSeriesImputerEstimator.FilterMode.Exclude,
             TimeSeriesImputerEstimator.ImputationStrategy imputeMode = TimeSeriesImputerEstimator.ImputationStrategy.ForwardFill,
@@ -119,7 +119,7 @@ namespace Microsoft.ML.Featurizers
             [Argument(ArgumentType.AtMostOnce, HelpText = "Mode for imputing, defaults to ForwardFill if not provided", Name = "ImputeMode", ShortName = "mode", SortOrder = 3)]
             public ImputationStrategy ImputeMode = ImputationStrategy.ForwardFill;
 
-            [Argument(ArgumentType.AtMostOnce, HelpText = "Supress the errors that would occur if a column and impute mode are imcompatible. If true, will skip the column. If false, will stop and throw an error.", Name = "SupressTypeErrors", ShortName = "error", SortOrder = 3)]
+            [Argument(ArgumentType.AtMostOnce, HelpText = "Suppress the errors that would occur if a column and impute mode are incompatible. If true, will skip the column. If false, will stop and throw an error.", Name = "SupressTypeErrors", ShortName = "error", SortOrder = 3)]
             public bool SupressTypeErrors = false;
         }
 

--- a/src/Microsoft.ML.Featurizers/TimeSeriesImputerDataView.cs
+++ b/src/Microsoft.ML.Featurizers/TimeSeriesImputerDataView.cs
@@ -614,7 +614,7 @@ namespace Microsoft.ML.Transforms
 
             protected override bool ReleaseHandle()
             {
-                // Not sure what to do with error stuff here.  There shoudln't ever be one though.
+                // Not sure what to do with error stuff here.  There shouldn't ever be one though.
                 return DestroyTransformedDataNative(handle, _size, out IntPtr errorHandle);
             }
         }

--- a/src/Microsoft.ML.Featurizers/ToStringTransformer.cs
+++ b/src/Microsoft.ML.Featurizers/ToStringTransformer.cs
@@ -75,7 +75,7 @@ namespace Microsoft.ML.Featurizers
     /// The <xref:Microsoft.ML.Transforms.ToStringTransformerEstimator> is a trivial estimator that doesn't need training.
     /// The resulting <xref:Microsoft.ML.Transforms.ToStringTransformer> converts one or more input columns into its appropriate string representation.
     ///
-    /// The ToStringTransformer can be applied to one or more columns, in which case it turns each input type into its appropriate string represenation.
+    /// The ToStringTransformer can be applied to one or more columns, in which case it turns each input type into its appropriate string representation.
     ///
     /// ]]>
     /// </format>
@@ -297,7 +297,7 @@ namespace Microsoft.ML.Featurizers
 
             protected override bool ReleaseHandle()
             {
-                // Not sure what to do with error stuff here.  There shoudln't ever be one though.
+                // Not sure what to do with error stuff here.  There shouldn't ever be one though.
                 return _destroySaveDataHandler(handle, _dataSize, out IntPtr errorHandle);
             }
         }

--- a/src/Microsoft.ML.ImageAnalytics/ExtensionsCatalog.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ExtensionsCatalog.cs
@@ -101,7 +101,7 @@ namespace Microsoft.ML
         /// This estimator operates over <see cref="System.Drawing.Bitmap"/>.</param>
         /// <param name="colorsToExtract">The colors to extract from the image.</param>
         /// <param name="orderOfExtraction">The order in which to extract colors from pixel.</param>
-        /// <param name="interleavePixelColors">Whether to interleave the pixels colors, meaning keep them in the <paramref name="orderOfExtraction"/> order, or leave them in the plannar form:
+        /// <param name="interleavePixelColors">Whether to interleave the pixels colors, meaning keep them in the <paramref name="orderOfExtraction"/> order, or leave them in the planner form:
         /// all the values for one color for all pixels, then all the values for another color, and so on.</param>
         /// <param name="offsetImage">Offset each pixel's color value by this amount. Applied to color value before <paramref name="scaleImage"/>.</param>
         /// <param name="scaleImage">Scale each pixel's color value by this amount. Applied to color value after <paramref name="offsetImage"/>.</param>
@@ -125,7 +125,7 @@ namespace Microsoft.ML
             => new ImagePixelExtractingEstimator(CatalogUtils.GetEnvironment(catalog), outputColumnName, inputColumnName, colorsToExtract, orderOfExtraction, interleavePixelColors, offsetImage, scaleImage, outputAsFloatArray);
 
         /// <summary>
-        /// Create a <see cref="ImagePixelExtractingEstimator"/>, which exctracts pixel values from the data specified in column: <see cref="ImagePixelExtractingEstimator.ColumnOptions.InputColumnName"/>
+        /// Create a <see cref="ImagePixelExtractingEstimator"/>, which extracts pixel values from the data specified in column: <see cref="ImagePixelExtractingEstimator.ColumnOptions.InputColumnName"/>
         /// to a new column: <see cref="ImagePixelExtractingEstimator.ColumnOptions.Name"/>.
         /// </summary>
         /// <param name="catalog">The transform's catalog.</param>
@@ -211,10 +211,10 @@ namespace Microsoft.ML
         /// all the values for one color for all pixels, then all the values for another color and so on.</param>
         /// <param name="scaleImage">The values are scaled by this value before being converted to pixels. Applied to vector value before <paramref name="offsetImage"/>.</param>
         /// <param name="offsetImage">The offset is subtracted before converting the values to pixels. Applied to vector value after <paramref name="scaleImage"/>.</param>
-        /// <param name="defaultAlpha">Default value for alpha color, would be overriden if <paramref name="colorsPresent"/> contains <see cref="ImagePixelExtractingEstimator.ColorBits.Alpha"/>.</param>
-        /// <param name="defaultRed">Default value for red color, would be overriden if <paramref name="colorsPresent"/> contains <see cref="ImagePixelExtractingEstimator.ColorBits.Red"/>.</param>
-        /// <param name="defaultGreen">Default value for grenn color, would be overriden if <paramref name="colorsPresent"/> contains <see cref="ImagePixelExtractingEstimator.ColorBits.Green"/>.</param>
-        /// <param name="defaultBlue">Default value for blue color, would be overriden if <paramref name="colorsPresent"/> contains <see cref="ImagePixelExtractingEstimator.ColorBits.Blue"/>.</param>
+        /// <param name="defaultAlpha">Default value for alpha color, would be overridden if <paramref name="colorsPresent"/> contains <see cref="ImagePixelExtractingEstimator.ColorBits.Alpha"/>.</param>
+        /// <param name="defaultRed">Default value for red color, would be overridden if <paramref name="colorsPresent"/> contains <see cref="ImagePixelExtractingEstimator.ColorBits.Red"/>.</param>
+        /// <param name="defaultGreen">Default value for green color, would be overridden if <paramref name="colorsPresent"/> contains <see cref="ImagePixelExtractingEstimator.ColorBits.Green"/>.</param>
+        /// <param name="defaultBlue">Default value for blue color, would be overridden if <paramref name="colorsPresent"/> contains <see cref="ImagePixelExtractingEstimator.ColorBits.Blue"/>.</param>
         /// <example>
         /// <format type="text/markdown">
         /// <![CDATA[

--- a/src/Microsoft.ML.ImageAnalytics/ImagePixelExtractor.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ImagePixelExtractor.cs
@@ -157,7 +157,7 @@ namespace Microsoft.ML.Transforms.Image
         /// <param name="inputColumnName">Name of column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
         /// <param name="colorsToExtract">What colors to extract.</param>
         /// <param name="orderOfExtraction">In which order to extract colors from pixel.</param>
-        /// <param name="interleavePixelColors">Whether to interleave the pixels colors, meaning keep them in the <paramref name="orderOfExtraction"/> order, or leave them in the plannar form:
+        /// <param name="interleavePixelColors">Whether to interleave the pixels colors, meaning keep them in the <paramref name="orderOfExtraction"/> order, or leave them in the planner form:
         /// all the values for one color for all pixels, then all the values for another color and so on.</param>
         /// <param name="offsetImage">Offset each pixel's color value by this amount. Applied to color value first.</param>
         /// <param name="scaleImage">Scale each pixel's color value by this amount. Applied to color value second.</param>
@@ -496,7 +496,7 @@ namespace Microsoft.ML.Transforms.Image
     /// | Exportable to ONNX | No |
     ///
     /// The resulting <xref:Microsoft.ML.Transforms.Image.ImagePixelExtractingTransformer> creates a new column, named as specified in the output column name parameters, and
-    /// converts image into vector of known size of floats or bytes. Size and data type depends on specified paramaters.
+    /// converts image into vector of known size of floats or bytes. Size and data type depends on specified parameters.
     /// For end-to-end image processing pipelines, and scenarios in your applications, see the
     /// [examples](https://github.com/dotnet/machinelearning-samples/tree/master/samples/csharp/getting-started) in the machinelearning-samples github repository.
     ///
@@ -602,7 +602,7 @@ namespace Microsoft.ML.Transforms.Image
             public readonly float ScaleImage;
 
             /// <summary>
-            /// Whether to interleave the pixels colors, meaning keep them in the <see cref="OrderOfExtraction"/> order, or leave them in the plannar form:
+            /// Whether to interleave the pixels colors, meaning keep them in the <see cref="OrderOfExtraction"/> order, or leave them in the planner form:
             /// all the values for one color for all pixels, then all the values for another color and so on.
             /// </summary>
             public readonly bool InterleavePixelColors;
@@ -650,7 +650,7 @@ namespace Microsoft.ML.Transforms.Image
             /// <param name="inputColumnName">Name of column to transform. If set to <see langword="null"/>, the value of the <paramref name="name"/> will be used as source.</param>
             /// <param name="colorsToExtract">What colors to extract.</param>
             /// <param name="orderOfExtraction">In which order to extract colors from pixel.</param>
-            /// <param name="interleavePixelColors">Whether to interleave the pixels, meaning keep them in the <paramref name="orderOfExtraction"/> order, or leave them in the plannar form:
+            /// <param name="interleavePixelColors">Whether to interleave the pixels, meaning keep them in the <paramref name="orderOfExtraction"/> order, or leave them in the planner form:
             /// all the values for one color for all pixels, then all the values for another color and so on.</param>
             /// <param name="offsetImage">Offset each pixel's color value by this amount. Applied to color value before <paramref name="scaleImage"/>.</param>
             /// <param name="scaleImage">Scale each pixel's color value by this amount. Applied to color value after <paramref name="offsetImage"/>.</param>
@@ -776,7 +776,7 @@ namespace Microsoft.ML.Transforms.Image
         /// <param name="inputColumnName">Name of the input column.</param>
         /// <param name="colorsToExtract">What colors to extract.</param>
         /// <param name="orderOfExtraction">In which order to extract colors from pixel.</param>
-        /// <param name="interleavePixelColors">Whether to interleave the pixels, meaning keep them in the <paramref name="orderOfExtraction"/> order, or leave them in the plannar form:
+        /// <param name="interleavePixelColors">Whether to interleave the pixels, meaning keep them in the <paramref name="orderOfExtraction"/> order, or leave them in the planner form:
         /// all the values for one color for all pixels, then all the values for another color and so on.</param>
         /// <param name="offsetImage">Offset each pixel's color value by this amount. Applied to color value before <paramref name="scaleImage"/>.</param>
         /// <param name="scaleImage">Scale each pixel's color value by this amount. Applied to color value after <paramref name="offsetImage"/>.</param>

--- a/src/Microsoft.ML.ImageAnalytics/VectorToImageTransform.cs
+++ b/src/Microsoft.ML.ImageAnalytics/VectorToImageTransform.cs
@@ -194,10 +194,10 @@ namespace Microsoft.ML.Transforms.Image
         /// for all the pixels of the image. </param>
         /// <param name="scaleImage">Scale each pixel's color value by this amount.</param>
         /// <param name="offsetImage">Offset each pixel's color value by this amount.</param>
-        /// <param name="defaultAlpha">Default value for alpha color, would be overriden if <paramref name="colorsPresent"/> contains <see cref="ImagePixelExtractingEstimator.ColorBits.Alpha"/>.</param>
-        /// <param name="defaultRed">Default value for red color, would be overriden if <paramref name="colorsPresent"/> contains <see cref="ImagePixelExtractingEstimator.ColorBits.Red"/>.</param>
-        /// <param name="defaultGreen">Default value for grenn color, would be overriden if <paramref name="colorsPresent"/> contains <see cref="ImagePixelExtractingEstimator.ColorBits.Green"/>.</param>
-        /// <param name="defaultBlue">Default value for blue color, would be overriden if <paramref name="colorsPresent"/> contains <see cref="ImagePixelExtractingEstimator.ColorBits.Blue"/>.</param>
+        /// <param name="defaultAlpha">Default value for alpha color, would be overridden if <paramref name="colorsPresent"/> contains <see cref="ImagePixelExtractingEstimator.ColorBits.Alpha"/>.</param>
+        /// <param name="defaultRed">Default value for red color, would be overridden if <paramref name="colorsPresent"/> contains <see cref="ImagePixelExtractingEstimator.ColorBits.Red"/>.</param>
+        /// <param name="defaultGreen">Default value for green color, would be overridden if <paramref name="colorsPresent"/> contains <see cref="ImagePixelExtractingEstimator.ColorBits.Green"/>.</param>
+        /// <param name="defaultBlue">Default value for blue color, would be overridden if <paramref name="colorsPresent"/> contains <see cref="ImagePixelExtractingEstimator.ColorBits.Blue"/>.</param>
         internal VectorToImageConvertingTransformer(IHostEnvironment env, string outputColumnName,
             int imageHeight, int imageWidth,
             string inputColumnName = null,
@@ -593,10 +593,10 @@ namespace Microsoft.ML.Transforms.Image
             /// alpha, red, green, blue for all the pixels of the image. </param>
             /// <param name="scaleImage">The values are scaled by this value before being converted to pixels. Applied to vector value before <paramref name="offsetImage"/></param>
             /// <param name="offsetImage">The offset is subtracted before converting the values to pixels. Applied to vector value after <paramref name="scaleImage"/>.</param>
-            /// <param name="defaultAlpha">Default value for alpha color, would be overriden if <paramref name="colorsPresent"/> contains <see cref="ImagePixelExtractingEstimator.ColorBits.Alpha"/>.</param>
-            /// <param name="defaultRed">Default value for red color, would be overriden if <paramref name="colorsPresent"/> contains <see cref="ImagePixelExtractingEstimator.ColorBits.Red"/>.</param>
-            /// <param name="defaultGreen">Default value for grenn color, would be overriden if <paramref name="colorsPresent"/> contains <see cref="ImagePixelExtractingEstimator.ColorBits.Green"/>.</param>
-            /// <param name="defaultBlue">Default value for blue color, would be overriden if <paramref name="colorsPresent"/> contains <see cref="ImagePixelExtractingEstimator.ColorBits.Blue"/>.</param>
+            /// <param name="defaultAlpha">Default value for alpha color, would be overridden if <paramref name="colorsPresent"/> contains <see cref="ImagePixelExtractingEstimator.ColorBits.Alpha"/>.</param>
+            /// <param name="defaultRed">Default value for red color, would be overridden if <paramref name="colorsPresent"/> contains <see cref="ImagePixelExtractingEstimator.ColorBits.Red"/>.</param>
+            /// <param name="defaultGreen">Default value for green color, would be overridden if <paramref name="colorsPresent"/> contains <see cref="ImagePixelExtractingEstimator.ColorBits.Green"/>.</param>
+            /// <param name="defaultBlue">Default value for blue color, would be overridden if <paramref name="colorsPresent"/> contains <see cref="ImagePixelExtractingEstimator.ColorBits.Blue"/>.</param>
             public ColumnOptions(string name,
                 int imageHeight, int imageWidth,
                 string inputColumnName = null,
@@ -697,10 +697,10 @@ namespace Microsoft.ML.Transforms.Image
         /// alpha, red, green, blue for all the pixels of the image. </param>
         /// <param name="scaleImage">The values are scaled by this value before being converted to pixels. Applied to vector value before <paramref name="offsetImage"/>.</param>
         /// <param name="offsetImage">The offset is subtracted before converting the values to pixels. Applied to vector value after <paramref name="scaleImage"/>.</param>
-        /// <param name="defaultAlpha">Default value for alpha color, would be overriden if <paramref name="colorsPresent"/> contains <see cref="ImagePixelExtractingEstimator.ColorBits.Alpha"/>.</param>
-        /// <param name="defaultRed">Default value for red color, would be overriden if <paramref name="colorsPresent"/> contains <see cref="ImagePixelExtractingEstimator.ColorBits.Red"/>.</param>
-        /// <param name="defaultGreen">Default value for grenn color, would be overriden if <paramref name="colorsPresent"/> contains <see cref="ImagePixelExtractingEstimator.ColorBits.Green"/>.</param>
-        /// <param name="defaultBlue">Default value for blue color, would be overriden if <paramref name="colorsPresent"/> contains <see cref="ImagePixelExtractingEstimator.ColorBits.Blue"/>.</param>
+        /// <param name="defaultAlpha">Default value for alpha color, would be overridden if <paramref name="colorsPresent"/> contains <see cref="ImagePixelExtractingEstimator.ColorBits.Alpha"/>.</param>
+        /// <param name="defaultRed">Default value for red color, would be overridden if <paramref name="colorsPresent"/> contains <see cref="ImagePixelExtractingEstimator.ColorBits.Red"/>.</param>
+        /// <param name="defaultGreen">Default value for green color, would be overridden if <paramref name="colorsPresent"/> contains <see cref="ImagePixelExtractingEstimator.ColorBits.Green"/>.</param>
+        /// <param name="defaultBlue">Default value for blue color, would be overridden if <paramref name="colorsPresent"/> contains <see cref="ImagePixelExtractingEstimator.ColorBits.Blue"/>.</param>
         [BestFriend]
         internal VectorToImageConvertingEstimator(IHostEnvironment env,
             int imageHeight,

--- a/src/Microsoft.ML.KMeansClustering/KMeansModelParameters.cs
+++ b/src/Microsoft.ML.KMeansClustering/KMeansModelParameters.cs
@@ -288,7 +288,7 @@ namespace Microsoft.ML.Trainers
 
         bool ISingleCanSaveOnnx.SaveAsOnnx(OnnxContext ctx, string[] outputNames, string featureColumn)
         {
-            // Computation graph of distances to all centriods for a batch of examples. Note that a centriod is just
+            // Computation graph of distances to all centroids for a batch of examples. Note that a centroid is just
             // the center of a cluster. We use [] to denote the dimension of a variable; for example, X [3, 2] means
             // that X is a 3-by-2 tensor. In addition, for a matrix X, X^T denotes its transpose.
             //
@@ -296,11 +296,11 @@ namespace Microsoft.ML.Trainers
             // l: # of examples.
             // n: # of features per input example.
             // X: input examples, l-by-n tensor.
-            // C: centriods, k-by-n tensor.
-            // C^2: 2-norm of all centriod vectors, its shape is [k].
-            // Y: 2-norm of difference between examples and centriods, l-by-k tensor. The value at i-th row and k-th
-            // column row, Y[i,k], is the distance from example i to centrioid k.
-            // L: the id of the nearest centriod for each input example, its shape is [l].
+            // C: centroids, k-by-n tensor.
+            // C^2: 2-norm of all centroid vectors, its shape is [k].
+            // Y: 2-norm of difference between examples and centroids, l-by-k tensor. The value at i-th row and k-th
+            // column row, Y[i,k], is the distance from example i to centroid k.
+            // L: the id of the nearest centroid for each input example, its shape is [l].
             //
             // .------------------------------------------------------.
             // |                                                      |

--- a/src/Microsoft.ML.KMeansClustering/KMeansPlusPlusTrainer.cs
+++ b/src/Microsoft.ML.KMeansClustering/KMeansPlusPlusTrainer.cs
@@ -655,7 +655,7 @@ namespace Microsoft.ML.Trainers
                     "newClusterIdxWithinSample must be between 0..numSamplesPerRound-1");
                 Contracts.Assert((_clusterDistances == null) || (bestOldCluster == -1 ||
                     (0 <= bestOldCluster && bestOldCluster < _clusterDistances.GetLength(1))),
-                    "bestOldCluster must be -1 (not set/not enought room) or between 0..clusterCount-1");
+                    "bestOldCluster must be -1 (not set/not enough room) or between 0..clusterCount-1");
                 // Only use this if the memory was allocated for _clusterDistances and bestOldCluster index is valid.
                 if (_clusterDistances != null && bestOldCluster != -1)
                 {
@@ -773,8 +773,8 @@ namespace Microsoft.ML.Trainers
         /// <summary>
         /// KMeans|| Implementation, see https://theory.stanford.edu/~sergei/papers/vldb12-kmpar.pdf
         /// This algorithm will require:
-        /// - (k * overSampleFactor * rounds * diminsionality * 4) bytes for the final sampled clusters.
-        /// - (k * overSampleFactor * numThreads * diminsionality * 4) bytes for the per-round sampling.
+        /// - (k * overSampleFactor * rounds * dimensionality * 4) bytes for the final sampled clusters.
+        /// - (k * overSampleFactor * numThreads * dimensionality * 4) bytes for the per-round sampling.
         ///
         /// Uses memory in initializationState to cache distances and avoids unnecessary distance computations
         /// akin to YinYang-KMeans paper.
@@ -1576,11 +1576,11 @@ namespace Microsoft.ML.Trainers
         public delegate float WeightFunc(in VBuffer<float> point, int pointRowIndex);
 
         /// <summary>
-        /// Performs a multithreaded version of weighted reservior sampling, returning
+        /// Performs a multithreaded version of weighted reservoir sampling, returning
         /// an array of numSamples, where each sample has been selected from the
         /// data set with a probability of numSamples/N * weight/(sum(weight)). Buffer
         /// is sized to the number of threads plus one and stores the minheaps needed to
-        /// perform the per-thread reservior samples.
+        /// perform the per-thread reservoir samples.
         ///
         /// This method assumes that the numSamples is much smaller than the full dataset as
         /// it expects to be able to sample numSamples * numThreads.

--- a/src/Microsoft.ML.LightGbm/LightGbmTrainerBase.cs
+++ b/src/Microsoft.ML.LightGbm/LightGbmTrainerBase.cs
@@ -44,7 +44,7 @@ namespace Microsoft.ML.Trainers.LightGbm
         public class OptionsBase : TrainerInputBaseWithGroupId
         {
             // Static override name map that maps friendly names to lightGBM arguments.
-            // If an argument is not here, then its name is identicaltto a lightGBM argument
+            // If an argument is not here, then its name is identical to a lightGBM argument
             // and does not require a mapping, for example, Subsample.
             private protected static Dictionary<string, string> NameMapping = new Dictionary<string, string>()
             {
@@ -291,7 +291,7 @@ namespace Microsoft.ML.Trainers.LightGbm
         private protected readonly TOptions LightGbmTrainerOptions;
 
         /// <summary>
-        /// Stores argumments as objects to convert them to invariant string type in the end so that
+        /// Stores arguments as objects to convert them to invariant string type in the end so that
         /// the code is culture agnostic. When retrieving key value from this dictionary as string
         /// please convert to string invariant by string.Format(CultureInfo.InvariantCulture, "{0}", Option[key]).
         /// </summary>

--- a/src/Microsoft.ML.LightGbm/WrappedLightGbmDataset.cs
+++ b/src/Microsoft.ML.LightGbm/WrappedLightGbmDataset.cs
@@ -18,10 +18,10 @@ namespace Microsoft.ML.Trainers.LightGbm
         public WrappedLightGbmInterface.SafeDataSetHandle Handle => _handle;
 
         /// <summary>
-        /// Create a <see cref="Dataset"/> for storing training and prediciton data under LightGBM framework. The main goal of this function
+        /// Create a <see cref="Dataset"/> for storing training and prediction data under LightGBM framework. The main goal of this function
         /// is not marshaling ML.NET data set into LightGBM format but just creates a (unmanaged) container where examples can be pushed into by calling
         /// <see cref="PushRows(float[], int, int, int)"/>. It also pre-allocates memory so the actual size (number of examples and number of features)
-        /// of the data set is required. A sub-sampled version of the original data set is passed in to compute some statictics needed by the training
+        /// of the data set is required. A sub-sampled version of the original data set is passed in to compute some statistics needed by the training
         /// procedure. Note that we use "original" to indicate a property from the unsampled data set.
         /// </summary>
         /// <param name="sampleValuePerColumn">A 2-D array which encodes the sub-sampled data matrix. sampleValuePerColumn[i] stores

--- a/src/Microsoft.ML.Maml/MAML.cs
+++ b/src/Microsoft.ML.Maml/MAML.cs
@@ -71,7 +71,7 @@ namespace Microsoft.ML.Tools
                 {
                     progressCancel.Cancel();
                     progressTrackerTask.Wait();
-                    // If the run completed so quickly that the progress task was cancelled before it even got a chance to start,
+                    // If the run completed so quickly that the progress task was canceled before it even got a chance to start,
                     // we need to gather the checkpoints.
                     env.PrintProgress();
                 }

--- a/src/Microsoft.ML.Mkl.Components/VectorWhitening.cs
+++ b/src/Microsoft.ML.Mkl.Components/VectorWhitening.cs
@@ -398,7 +398,7 @@ namespace Microsoft.ML.Transforms
                 ch.Info("Computing SVD...");
                 var eigValues = new float[ccol]; // Eigenvalues.
                 var unconv = new float[ccol]; // Superdiagonal unconverged values (if any). Not used but seems to be required by MKL.
-                // After the next call, values in U will be ovewritten by left eigenvectors.
+                // After the next call, values in U will be overwritten by left eigenvectors.
                 // Each column in U will be an eigenvector.
                 int r = Mkl.Svd(Layout, Mkl.SvdJob.MinOvr, Mkl.SvdJob.None,
                     ccol, ccol, u, ccol, eigValues, null, ccol, null, ccol, unconv);

--- a/src/Microsoft.ML.OnnxConverter/OnnxMl.cs
+++ b/src/Microsoft.ML.OnnxConverter/OnnxMl.cs
@@ -2848,7 +2848,7 @@ namespace Microsoft.ML.Model.OnnxConverter
             /// For float and complex64 values
             /// Complex64 tensors are encoded as a single array of floats,
             /// with the real components appearing in odd numbered positions,
-            /// and the corresponding imaginary component apparing in the
+            /// and the corresponding imaginary component appearing in the
             /// subsequent even numbered position. (e.g., [1.0 + 2.0i, 3.0 + 4.0i]
             /// is encoded as [1.0, 2.0 ,3.0 ,4.0]
             /// When this field is present, the data_type field MUST be FLOAT or COMPLEX64.
@@ -3019,7 +3019,7 @@ namespace Microsoft.ML.Model.OnnxConverter
             /// For double
             /// Complex128 tensors are encoded as a single array of doubles,
             /// with the real components appearing in odd numbered positions,
-            /// and the corresponding imaginary component apparing in the
+            /// and the corresponding imaginary component appearing in the
             /// subsequent even numbered position. (e.g., [1.0 + 2.0i, 3.0 + 4.0i]
             /// is encoded as [1.0, 2.0 ,3.0 ,4.0]
             /// When this field is present, the data_type field MUST be DOUBLE or COMPLEX128

--- a/src/Microsoft.ML.OnnxConverter/OnnxUtils.cs
+++ b/src/Microsoft.ML.OnnxConverter/OnnxUtils.cs
@@ -380,7 +380,7 @@ namespace Microsoft.ML.Model.OnnxConverter
             // "This is useful for declaring the interfaces that care about the number of dimensions, but not the exact size of each dimension"
             // This file, https://github.com/onnx/onnx/blob/master/onnx/tools/update_model_dims.py, explains that if the dim value is negative
             // than it treats that as a dim_param instead of a dim_value. This allows ML.NET to run 1 row at a time in a streaming fassion,
-            // but allows the ONNX model the flexiblity to be run in batch mode if that is desired.
+            // but allows the ONNX model the flexibility to be run in batch mode if that is desired.
             dimsLocal?.Insert(0, -1);
 
             return new ModelArgs(name, dataType, dimsLocal, dimsParamLocal);

--- a/src/Microsoft.ML.OnnxConverter/SaveOnnxCommand.cs
+++ b/src/Microsoft.ML.OnnxConverter/SaveOnnxCommand.cs
@@ -256,7 +256,7 @@ namespace Microsoft.ML.Model.OnnxConverter
                     rawPred = null;
                     trainSchema = null;
                     Host.CheckUserArg(ImplOptions.LoadPredictor != true, nameof(ImplOptions.LoadPredictor),
-                        "Cannot be set to true unless " + nameof(ImplOptions.InputModelFile) + " is also specifified.");
+                        "Cannot be set to true unless " + nameof(ImplOptions.InputModelFile) + " is also specified.");
                 }
                 else
                     LoadModelObjects(ch, _loadPredictor, out rawPred, true, out trainSchema, out loader);

--- a/src/Microsoft.ML.OnnxTransformer/OnnxTransform.cs
+++ b/src/Microsoft.ML.OnnxTransformer/OnnxTransform.cs
@@ -80,7 +80,7 @@ namespace Microsoft.ML.Transforms.Onnx
             [Argument(ArgumentType.AtMostOnce, HelpText = "GPU device id to run on (e.g. 0,1,..). Null for CPU. Requires CUDA 9.1.", SortOrder = 3)]
             public int? GpuDeviceId = null;
 
-            [Argument(ArgumentType.AtMostOnce, HelpText = "If true, resumes execution on CPU upon GPU error. If false, will raise the GPU execption.", SortOrder = 4)]
+            [Argument(ArgumentType.AtMostOnce, HelpText = "If true, resumes execution on CPU upon GPU error. If false, will raise the GPU exception.", SortOrder = 4)]
             public bool FallbackToCpu = false;
 
             [Argument(ArgumentType.Multiple, HelpText = "Shapes used to overwrite shapes loaded from ONNX file.", SortOrder = 5)]

--- a/src/Microsoft.ML.OnnxTransformer/OnnxUtils.cs
+++ b/src/Microsoft.ML.OnnxTransformer/OnnxUtils.cs
@@ -165,7 +165,7 @@ namespace Microsoft.ML.Transforms.Onnx
         /// </summary>
         /// <param name="modelFile">Model file path.</param>
         /// <param name="gpuDeviceId">GPU device ID to execute on. Null for CPU.</param>
-        /// <param name="fallbackToCpu">If true, resumes CPU execution quitely upon GPU error.</param>
+        /// <param name="fallbackToCpu">If true, resumes CPU execution quietly upon GPU error.</param>
         /// <param name="ownModelFile">If true, the <paramref name="modelFile"/> will be deleted when <see cref="OnnxModel"/> is
         /// no longer needed.</param>
         /// <param name="shapeDictionary"></param>

--- a/src/Microsoft.ML.Parquet/PartitionedFileLoader.cs
+++ b/src/Microsoft.ML.Parquet/PartitionedFileLoader.cs
@@ -712,7 +712,7 @@ namespace Microsoft.ML.Data
             /// </summary>
             /// <param name="path">The directory path to parse for name/value pairs.</param>
             /// <param name="results">The resulting name value pairs.</param>
-            /// <returns>true if the parsing was successfull.</returns>
+            /// <returns>true if the parsing was successful.</returns>
             private bool TryParseValuesFromPath(string path, out List<string> results)
             {
                 Contracts.CheckNonWhiteSpace(path, nameof(path));

--- a/src/Microsoft.ML.Parquet/PartitionedPathParser.cs
+++ b/src/Microsoft.ML.Parquet/PartitionedPathParser.cs
@@ -362,7 +362,7 @@ namespace Microsoft.ML.Data
         /// <param name="dir">The directory name.</param>
         /// <param name="name">The resulting name.</param>
         /// <param name="value">The resulting value.</param>
-        /// <returns>true if the parsing was successfull.</returns>
+        /// <returns>true if the parsing was successful.</returns>
         private static bool TryParseNameValueFromDir(string dir, out string name, out string value)
         {
             const char nameValueSeparator = '=';

--- a/src/Microsoft.ML.StandardTrainers/Standard/MulticlassClassification/PairwiseCouplingTrainer.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/MulticlassClassification/PairwiseCouplingTrainer.cs
@@ -102,7 +102,7 @@ namespace Microsoft.ML.Trainers
         /// </summary>
         /// <param name="env">The <see cref="IHostEnvironment"/> instance.</param>
         /// <param name="binaryEstimator">An instance of a binary <see cref="ITrainerEstimator{TTransformer, TPredictor}"/> used as the base trainer.</param>
-        /// <param name="labelColumnName">The name of the label colum.</param>
+        /// <param name="labelColumnName">The name of the label column.</param>
         /// <param name="imputeMissingLabelsAsNegative">Whether to treat missing labels as having negative labels, instead of keeping them missing.</param>
         /// <param name="calibrator">The calibrator to use for each model instance. If a calibrator is not explicitely provided, it will default to <see cref="PlattCalibratorTrainer"/></param>
         /// <param name="maximumCalibrationExampleCount">Number of instances to train the calibrator.</param>

--- a/src/Microsoft.ML.TimeSeries/IidAnomalyDetectionBase.cs
+++ b/src/Microsoft.ML.TimeSeries/IidAnomalyDetectionBase.cs
@@ -187,7 +187,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
 
                 private protected override double ComputeRawAnomalyScore(ref Single input, FixedSizeQueue<Single> windowedBuffer, long iteration)
                 {
-                    // This transform treats the input sequenence as the raw anomaly score.
+                    // This transform treats the input sequence as the raw anomaly score.
                     return (double)input;
                 }
 

--- a/src/Microsoft.ML.TimeSeries/SlidingWindowTransformBase.cs
+++ b/src/Microsoft.ML.TimeSeries/SlidingWindowTransformBase.cs
@@ -12,7 +12,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
 {
     /// <summary>
     /// SlidingWindowTransformBase outputs a sliding window as a VBuffer from a series of any type.
-    /// The VBuffer contains n consecutives observations delayed or not from the current one.
+    /// The VBuffer contains n consecutive observations delayed or not from the current one.
     /// Let's denote y(t) a timeseries, the transform returns a vector of values for each time t
     /// which corresponds to [y(t-d-l+1), y(t-d-l+2), ..., y(t-l-1), y(t-l)] where d is the size of the window
     /// and l is the delay.

--- a/src/Microsoft.ML.Transforms/MetricStatistics.cs
+++ b/src/Microsoft.ML.Transforms/MetricStatistics.cs
@@ -32,7 +32,7 @@ namespace Microsoft.ML.Data
 
         /// <summary>
         /// Get the count for the number of samples used. Useful for interpreting
-        /// the standard deviation and the stardard error and building confidence intervals.
+        /// the standard deviation and the standard error and building confidence intervals.
         /// </summary>
         public int Count => (int)_statistic.RawCount;
 

--- a/src/Microsoft.ML.Transforms/Text/LdaSingleBox.cs
+++ b/src/Microsoft.ML.Transforms/Text/LdaSingleBox.cs
@@ -306,7 +306,7 @@ namespace Microsoft.ML.TextAnalytics
             // (1) TestOneDoc
             // (2) TestOneDocRestart
             // The second one is the same as the first one except that it will reset
-            // the states of the internal random number generator, so that it yields reproducable results for the same input
+            // the states of the internal random number generator, so that it yields reproducible results for the same input
             LdaInterface.TestOneDocDense(_engine, pVal, termNum, pTopic, pProb, ref numTopicReturn, numBurninIter, reset);
 
             // PREfast suspects that the value of numTopicReturn could be changed in _engine->TestOneDoc, which might result in read overrun in the following loop.

--- a/test/BaselineOutput/Common/EntryPoints/core_manifest.json
+++ b/test/BaselineOutput/Common/EntryPoints/core_manifest.json
@@ -1903,9 +1903,9 @@
           }
         },
         {
-          "Name": "SupressScoresAndLabels",
+          "Name": "SuppressScoresAndLabels",
           "Type": "Bool",
-          "Desc": "Supress labels and scores in per-instance outputs?",
+          "Desc": "Suppress labels and scores in per-instance outputs?",
           "Aliases": [
             "noScores"
           ],

--- a/test/BaselineOutput/Common/EntryPoints/core_manifest.json
+++ b/test/BaselineOutput/Common/EntryPoints/core_manifest.json
@@ -23717,7 +23717,7 @@
         {
           "Name": "SupressTypeErrors",
           "Type": "Bool",
-          "Desc": "Supress the errors that would occur if a column and impute mode are imcompatible. If true, will skip the column. If false, will stop and throw an error.",
+          "Desc": "Suppress the errors that would occur if a column and impute mode are incompatible. If true, will skip the column. If false, will stop and throw an error.",
           "Aliases": [
             "error"
           ],

--- a/test/Microsoft.ML.AutoML.Tests/DatasetUtil.cs
+++ b/test/Microsoft.ML.AutoML.Tests/DatasetUtil.cs
@@ -119,7 +119,7 @@ namespace Microsoft.ML.AutoML.Test
             /*
              * This is only needed as Linux can produce files in a different 
              * order than other OSes. As this is a test case we want to maintain
-             * consistent accuracy across all OSes, so we sort to remove this discrepency.
+             * consistent accuracy across all OSes, so we sort to remove this discrepancy.
              */
             Array.Sort(files);
             foreach (var file in files)

--- a/test/Microsoft.ML.AutoML.Tests/InferredPipelineTests.cs
+++ b/test/Microsoft.ML.AutoML.Tests/InferredPipelineTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.ML.AutoML.Test
             var context = new MLContext(1);
             var columnInfo = new ColumnInformation();
 
-            // test same learners with no hyperparams have the same hash code
+            // test same learners with no hyperparameters have the same hash code
             var trainer1 = new SuggestedTrainer(context, new LightGbmBinaryExtension(), columnInfo);
             var trainer2 = new SuggestedTrainer(context, new LightGbmBinaryExtension(), columnInfo);
             var transforms1 = new List<SuggestedTransform>();
@@ -31,7 +31,7 @@ namespace Microsoft.ML.AutoML.Test
             var inferredPipeline2 = new SuggestedPipeline(transforms2, new List<SuggestedTransform>(), trainer2, context, false);
             Assert.Equal(inferredPipeline1.GetHashCode(), inferredPipeline2.GetHashCode());
 
-            // test same learners with hyperparams set vs empty hyperparams have different hash codes
+            // test same learners with hyperparameters set vs empty hyperparameters have different hash codes
             var hyperparams1 = new ParameterSet(new List<IParameterValue>() { new LongParameterValue("NumberOfLeaves", 2) });
             trainer1 = new SuggestedTrainer(context, new LightGbmBinaryExtension(), columnInfo, hyperparams1);
             trainer2 = new SuggestedTrainer(context, new LightGbmBinaryExtension(), columnInfo);
@@ -39,7 +39,7 @@ namespace Microsoft.ML.AutoML.Test
             inferredPipeline2 = new SuggestedPipeline(transforms2, new List<SuggestedTransform>(), trainer2, context, false);
             Assert.NotEqual(inferredPipeline1.GetHashCode(), inferredPipeline2.GetHashCode());
 
-            // same learners with different hyperparams
+            // same learners with different hyperparameters
             hyperparams1 = new ParameterSet(new List<IParameterValue>() { new LongParameterValue("NumberOfLeaves", 2) });
             var hyperparams2 = new ParameterSet(new List<IParameterValue>() { new LongParameterValue("NumberOfLeaves", 6) });
             trainer1 = new SuggestedTrainer(context, new LightGbmBinaryExtension(), columnInfo, hyperparams1);

--- a/test/Microsoft.ML.AutoML.Tests/TransformInferenceTests.cs
+++ b/test/Microsoft.ML.AutoML.Tests/TransformInferenceTests.cs
@@ -774,7 +774,7 @@ namespace Microsoft.ML.AutoML.Test
             // create a dummy data view from input columns
             var data = DataViewTestFixture.BuildDummyDataView(columns);
 
-            // iterate thru suggested transforms and apply it to a real data view
+            // iterate through suggested transforms and apply it to a real data view
             foreach (var transform in transforms.Select(t => t.Estimator))
             {
                 data = transform.Fit(data).Transform(data);

--- a/test/Microsoft.ML.AutoML.Tests/UserInputValidationTests.cs
+++ b/test/Microsoft.ML.AutoML.Tests/UserInputValidationTests.cs
@@ -122,7 +122,7 @@ namespace Microsoft.ML.AutoML.Test
             {
                 var ex = Assert.Throws<ArgumentException>(() => UserInputValidationUtil.ValidateExperimentExecuteArgs(trainData,
                     new ColumnInformation() { LabelColumnName = "0" }, validData, task));
-                Assert.StartsWith("Training data and validation data schemas do not match. Column '1' exsits in train data, but not in validation data.", ex.Message);
+                Assert.StartsWith("Training data and validation data schemas do not match. Column '1' exists in train data, but not in validation data.", ex.Message);
             }
         }
 
@@ -332,7 +332,7 @@ namespace Microsoft.ML.AutoML.Test
                 new List<KeyValuePair<float, bool>>() { new KeyValuePair<float, bool>(1, true) });
             trainingData = convertLabelToBoolEstimator.Fit(trainingData).Transform(trainingData);
 
-            // Build validaiton data where label column is a Boolean.
+            // Build validation data where label column is a Boolean.
             var validationDataBuilder = new ArrayDataViewBuilder(mlContext);
             validationDataBuilder.AddColumn("Number", NumberDataViewType.Single, 0f);
             validationDataBuilder.AddColumn(DefaultColumnNames.Label, BooleanDataViewType.Instance, false);

--- a/test/Microsoft.ML.Benchmarks/Harness/Configs.cs
+++ b/test/Microsoft.ML.Benchmarks/Harness/Configs.cs
@@ -24,7 +24,7 @@ namespace Microsoft.ML.Benchmarks
                 .With(msbuildArguments)
                 .With(CreateToolchain())); // toolchain is responsible for generating, building and running dedicated executable per benchmark
 
-            Add(new ExtraMetricColumn()); // an extra colum that can display additional metric reported by the benchmarks
+            Add(new ExtraMetricColumn()); // an extra column that can display additional metric reported by the benchmarks
         }
 
         protected virtual Job GetJobDefinition()

--- a/test/Microsoft.ML.Benchmarks/Harness/Metrics.cs
+++ b/test/Microsoft.ML.Benchmarks/Harness/Metrics.cs
@@ -18,7 +18,7 @@ namespace Microsoft.ML.Benchmarks
         protected abstract IEnumerable<Metric> GetMetrics();
 
         /// <summary>
-        ///  this method is executed after running the benchmrks
+        ///  this method is executed after running the benchmarks
         ///  we use it as hack to simply print to console so ExtraMetricColumn can parse the output
         /// </summary>
         [GlobalCleanup]

--- a/test/Microsoft.ML.Benchmarks/Harness/ProjectGenerator.cs
+++ b/test/Microsoft.ML.Benchmarks/Harness/ProjectGenerator.cs
@@ -21,7 +21,7 @@ namespace Microsoft.ML.Benchmarks.Harness
     /// 
     /// this is why this class exists: 
     ///  1. to tell MSBuild to copy the native dependencies to folder with .exe (NativeAssemblyReference)
-    ///  2. to generate a .csproj file that does not exclude Directory.Build.props (default BDN behaviour) which contains custom NuGet feeds that are required for restore step
+    ///  2. to generate a .csproj file that does not exclude Directory.Build.props (default BDN behavior) which contains custom NuGet feeds that are required for restore step
     /// </summary>
     public class ProjectGenerator : CsProjGenerator
     {

--- a/test/Microsoft.ML.Benchmarks/README.md
+++ b/test/Microsoft.ML.Benchmarks/README.md
@@ -8,7 +8,7 @@ This project contains performance benchmarks.
 
     git submodule update --init
 
-**Pre-requisite:** On a clean repo with initalized submodules, `build.cmd` at the root installs the right version of dotnet.exe and builds the solution. You need to build the solution in `Release` with native dependencies. 
+**Pre-requisite:** On a clean repo with initialized submodules, `build.cmd` at the root installs the right version of dotnet.exe and builds the solution. You need to build the solution in `Release` with native dependencies. 
 
     build.cmd -release -buildNative
     
@@ -86,7 +86,7 @@ public class TrainingBenchmark
 ```
 ## Running the `BenchmarksProjectIsNotBroken`  test
 
-If your build is failing in the build machines, in the release configuraiton due to the `BenchmarksProjectIsNotBroken` test failing, 
+If your build is failing in the build machines, in the release configuration due to the `BenchmarksProjectIsNotBroken` test failing, 
 you can debug this test locally by:
 
 1- Building the solution in the release mode locally

--- a/test/Microsoft.ML.CodeAnalyzer.Tests/Code/ContractsCheckTest.cs
+++ b/test/Microsoft.ML.CodeAnalyzer.Tests/Code/ContractsCheckTest.cs
@@ -128,7 +128,7 @@ namespace TestNamespace
                         VerifyCS.Diagnostic(ContractsCheckAnalyzer.NameofDiagnostic.Rule).WithLocation(25, 53).WithArguments("CheckUserArg", "name", "\"sp\""),
                         new DiagnosticResult("CS0122", DiagnosticSeverity.Error).WithLocation("Test1.cs", 752, 24).WithMessage("'ICancelable' is inaccessible due to its protection level"),
                         new DiagnosticResult("CS0122", DiagnosticSeverity.Error).WithLocation("Test1.cs", 752, 67).WithMessage("'ICancelable.IsCanceled' is inaccessible due to its protection level"),
-                        new DiagnosticResult("CS1503", DiagnosticSeverity.Error).WithLocation("Test1.cs", 753, 91).WithMessage("Argument 2: cannot convert from 'Microsoft.ML.Runtime.IHostEnvironment' to 'Microsoft.ML.Runtime.IExceptionContext'"),
+                        new DiagnosticResult("CS1503", DiagnosticSeverity.Error).WithLocation("Test1.cs", 753, 90).WithMessage("Argument 2: cannot convert from 'Microsoft.ML.Runtime.IHostEnvironment' to 'Microsoft.ML.Runtime.IExceptionContext'"),
                     },
                 },
                 FixedState =
@@ -148,7 +148,7 @@ namespace TestNamespace
                         VerifyCS.Diagnostic(ContractsCheckAnalyzer.NameofDiagnostic.Rule).WithLocation(23, 39).WithArguments("CheckValue", "paramName", "\"noMatch\""),
                         new DiagnosticResult("CS0122", DiagnosticSeverity.Error).WithLocation("Test1.cs", 752, 24).WithMessage("'ICancelable' is inaccessible due to its protection level"),
                         new DiagnosticResult("CS0122", DiagnosticSeverity.Error).WithLocation("Test1.cs", 752, 67).WithMessage("'ICancelable.IsCanceled' is inaccessible due to its protection level"),
-                        new DiagnosticResult("CS1503", DiagnosticSeverity.Error).WithLocation("Test1.cs", 753, 91).WithMessage("Argument 2: cannot convert from 'Microsoft.ML.Runtime.IHostEnvironment' to 'Microsoft.ML.Runtime.IExceptionContext'"),
+                        new DiagnosticResult("CS1503", DiagnosticSeverity.Error).WithLocation("Test1.cs", 753, 90).WithMessage("Argument 2: cannot convert from 'Microsoft.ML.Runtime.IHostEnvironment' to 'Microsoft.ML.Runtime.IExceptionContext'"),
                     },
                 },
             };

--- a/test/Microsoft.ML.CodeGenerator.Tests/ApprovalTests/ConsoleCodeGeneratorTests.cs
+++ b/test/Microsoft.ML.CodeGenerator.Tests/ApprovalTests/ConsoleCodeGeneratorTests.cs
@@ -834,7 +834,7 @@ namespace mlnet.Tests
             if (_mockedOvaPipeline == null)
             {
                 MLContext context = new MLContext();
-                // same learners with different hyperparams
+                // same learners with different hyperparameters
                 var hyperparams1 = new Microsoft.ML.AutoML.ParameterSet(new List<Microsoft.ML.AutoML.IParameterValue>() { new LongParameterValue("NumLeaves", 2) });
                 var trainer1 = new SuggestedTrainer(context, new FastForestOvaExtension(), new ColumnInformation(), hyperparams1);
                 var transforms1 = new List<SuggestedTransform>() { ColumnConcatenatingExtension.CreateSuggestedTransform(context, new[] { "In" }, "Out") };

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestHosts.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestHosts.cs
@@ -100,7 +100,7 @@ namespace Microsoft.ML.RunTests
 
             ((MLContext)env).CancelExecution();
 
-            //Ensure all created hosts are cancelled.
+            //Ensure all created hosts are canceled.
             //5 parent and one child for each.
             Assert.Equal(10, hosts.Count);
 

--- a/test/Microsoft.ML.Functional.Tests/Common.cs
+++ b/test/Microsoft.ML.Functional.Tests/Common.cs
@@ -64,7 +64,7 @@ namespace Microsoft.ML.Functional.Tests
         /// <param name="data2">A <see cref="IDataView"/> of <see cref="TypeTestData"/></param>
         public static void AssertTestTypeDatasetsAreEqual(MLContext mlContext, IDataView data1, IDataView data2)
         {
-            // Confirm that they are both of the propery row type.
+            // Confirm that they are both of the property row type.
             AssertTypeTestDataset(data1);
             AssertTypeTestDataset(data2);
 

--- a/test/Microsoft.ML.TestFramework/Attributes/NotCentOS7FactAttribute.cs
+++ b/test/Microsoft.ML.TestFramework/Attributes/NotCentOS7FactAttribute.cs
@@ -14,7 +14,7 @@ namespace Microsoft.ML.TestFramework.Attributes
     /// </summary>
     public sealed class NotCentOS7FactAttribute : EnvironmentSpecificFactAttribute
     {
-        public NotCentOS7FactAttribute() : base("These tests are not CentOS7 complient.")
+        public NotCentOS7FactAttribute() : base("These tests are not CentOS7 complaint.")
         {
         }
         protected override bool IsEnvironmentSupported()

--- a/test/Microsoft.ML.TestFramework/Attributes/NotCentOS7FactAttribute.cs
+++ b/test/Microsoft.ML.TestFramework/Attributes/NotCentOS7FactAttribute.cs
@@ -14,7 +14,7 @@ namespace Microsoft.ML.TestFramework.Attributes
     /// </summary>
     public sealed class NotCentOS7FactAttribute : EnvironmentSpecificFactAttribute
     {
-        public NotCentOS7FactAttribute() : base("These tests are not CentOS7 complaint.")
+        public NotCentOS7FactAttribute() : base("These tests are not CentOS7 compliant.")
         {
         }
         protected override bool IsEnvironmentSupported()

--- a/test/Microsoft.ML.Tests/AnomalyDetectionTests.cs
+++ b/test/Microsoft.ML.Tests/AnomalyDetectionTests.cs
@@ -147,7 +147,7 @@ namespace Microsoft.ML.Tests
                 new DataPoint(){ Features = new float[3] {1, 0, 0} }
             };
 
-            // Convert the List<DataPoint> to IDataView, a consumble format to ML.NET functions.
+            // Convert the List<DataPoint> to IDataView, a consumable format to ML.NET functions.
             var data = mlContext.Data.LoadFromEnumerable(samples);
 
             // Train the anomaly detector.

--- a/test/Microsoft.ML.Tests/FeatureContributionTests.cs
+++ b/test/Microsoft.ML.Tests/FeatureContributionTests.cs
@@ -243,7 +243,7 @@ namespace Microsoft.ML.Tests
         }
 
         /// <summary>
-        /// Features: x1, x2vBuff(sparce vector), x3. 
+        /// Features: x1, x2vBuff(sparse vector), x3. 
         /// y = 10x1 + 10x2vBuff + 30x3 + e.
         /// Within xBuff feature  2nd slot will be sparse most of the time.
         /// 2nd slot of xBuff has the least importance: Evaluation metrics do not change a lot when this slot is permuted.

--- a/tools-local/Microsoft.ML.InternalCodeAnalyzer/ContractsCheckAnalyzer.cs
+++ b/tools-local/Microsoft.ML.InternalCodeAnalyzer/ContractsCheckAnalyzer.cs
@@ -191,7 +191,7 @@ namespace Microsoft.ML.InternalCodeAnalyzer
             if ((!(isCheck = name.StartsWith("Check")) && !(isExcept = name.StartsWith("Except"))) || !_targetSet.Contains(name))
                 return;
             // Now that we've verified we're approximately in the right neighborhood, do a more
-            // in depth semantic analysis to verify we're targetting the right sort of object.
+            // in depth semantic analysis to verify we're targeting the right sort of object.
             var symbolInfo = context.SemanticModel.GetSymbolInfo(invocation);
             if (!(symbolInfo.Symbol is IMethodSymbol methodSymbol))
                 return;

--- a/tools-local/Microsoft.ML.InternalCodeAnalyzer/Utils.cs
+++ b/tools-local/Microsoft.ML.InternalCodeAnalyzer/Utils.cs
@@ -19,7 +19,7 @@ namespace Microsoft.ML.InternalCodeAnalyzer
             // C# naming guidelines say, any initialism greater than two characters should not
             // be all upper cased. So: _readIOStream is good, and _readHttpStream is good. You
             // could imagine having two two-letter initialisms, like: _readIOUI, where you use
-            // two two character initialism, but I'm going to suppose that never happens since
+            // two character initialism, but I'm going to suppose that never happens since
             // if someone is doing that, that's pretty odd. The upshot is: 
             const int maxConsecutive = 3;
             // Force the first after the _ to be lower case.

--- a/tools-local/Microsoft.ML.InternalCodeAnalyzer/Utils.cs
+++ b/tools-local/Microsoft.ML.InternalCodeAnalyzer/Utils.cs
@@ -19,7 +19,7 @@ namespace Microsoft.ML.InternalCodeAnalyzer
             // C# naming guidelines say, any initialism greater than two characters should not
             // be all upper cased. So: _readIOStream is good, and _readHttpStream is good. You
             // could imagine having two two-letter initialisms, like: _readIOUI, where you use
-            // two character initialism, but I'm going to suppose that never happens since
+            // two two character initialism, but I'm going to suppose that never happens since
             // if someone is doing that, that's pretty odd. The upshot is: 
             const int maxConsecutive = 3;
             // Force the first after the _ to be lower case.


### PR DESCRIPTION
More typo corrections in this repository.
The typo corrects are almost all in comments, except for one variable which was misspelled.
We should really pay more attention to avoid misspellings, and perhaps do a periodical check to make sure no new mistakes are made.