### PR TITLE
Enabling SavePipeExponentialAverage test

### DIFF
--- a/test/Microsoft.ML.TimeSeries.Tests/TimeSeries.cs
+++ b/test/Microsoft.ML.TimeSeries.Tests/TimeSeries.cs
@@ -89,8 +89,6 @@ namespace Microsoft.ML.RunTests
         }
 
         [Fact]
-        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
-        [Trait("Category", "SkipInCI")]
         public void SavePipeExponentialAverage()
         {
             TestCore(null, true,


### PR DESCRIPTION
This PR  re-enables the test `SavePipeExponentialAverage`, as the race condition/WaiterWaiter bug was fixed in PR #4829.