### PR TITLE
disable test parallelization for ML.Test assembly to avoid crash

### DIFF
--- a/test/Microsoft.ML.Tests/DatabaseLoaderTests.cs
+++ b/test/Microsoft.ML.Tests/DatabaseLoaderTests.cs
@@ -170,8 +170,6 @@ namespace Microsoft.ML.Tests
         }
 
         [LightGBMFact]
-        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
-        [Trait("Category", "SkipInCI")]
         public void IrisVectorLightGbmWithLoadColumnName()
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/test/Microsoft.ML.Tests/FeatureContributionTests.cs
+++ b/test/Microsoft.ML.Tests/FeatureContributionTests.cs
@@ -91,8 +91,6 @@ namespace Microsoft.ML.Tests
         }
 
         [Fact]
-        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
-        [Trait("Category", "SkipInCI")]
         public void TestGAMRegression()
         {
             TestFeatureContribution(ML.Regression.Trainers.Gam(), GetSparseDataset(numberOfInstances: 100), "GAMRegression");

--- a/test/Microsoft.ML.Tests/OnnxConversionTest.cs
+++ b/test/Microsoft.ML.Tests/OnnxConversionTest.cs
@@ -339,8 +339,6 @@ namespace Microsoft.ML.Tests
         }
 
         [Fact]
-        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
-        [Trait("Category", "SkipInCI")]
         public void PlattCalibratorOnnxConversionTest()
         {
             var mlContext = new MLContext(seed: 1);

--- a/test/Microsoft.ML.Tests/Properties/AssemblyInfo.cs
+++ b/test/Microsoft.ML.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,9 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+// TODO: disable test parallelization for this assembly as running test in parallel sometimes cause test host process to crash
+[assembly: CollectionBehavior(DisableTestParallelization = true)]
+

--- a/test/Microsoft.ML.Tests/Properties/AssemblyInfo.cs
+++ b/test/Microsoft.ML.Tests/Properties/AssemblyInfo.cs
@@ -4,6 +4,6 @@
 
 using Xunit;
 
-// TODO: disable test parallelization for this assembly as running test in parallel sometimes cause test host process to crash
+// TODO: [TEST_STABILITY] disable test parallelization for this assembly as running test in parallel sometimes cause test host process to crash
 [assembly: CollectionBehavior(DisableTestParallelization = true)]
 

--- a/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
@@ -365,8 +365,6 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
         }
 
         [Fact]
-        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
-        [Trait("Category", "SkipInCI")]
         public void GetLinearModelWeights()
         {
             var dataPath = GetDataPath("housing.txt");

--- a/test/Microsoft.ML.Tests/TrainerEstimators/TrainerEstimators.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/TrainerEstimators.cs
@@ -87,8 +87,6 @@ namespace Microsoft.ML.Tests.TrainerEstimators
         /// HogwildSGD TrainerEstimator test (logistic regression).
         /// </summary>
         [Fact]
-        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
-        [Trait("Category", "SkipInCI")]
         public void TestEstimatorHogwildSGD()
         {
             var trainers = new[] { ML.BinaryClassification.Trainers.SgdCalibrated(l2Regularization: 0, numberOfIterations: 80),

--- a/test/Microsoft.ML.Tests/TrainerEstimators/TreeEstimators.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/TreeEstimators.cs
@@ -69,8 +69,6 @@ namespace Microsoft.ML.Tests.TrainerEstimators
         }
 
         [LightGBMFact]
-        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
-        [Trait("Category", "SkipInCI")]
         public void LightGBMBinaryEstimatorUnbalanced()
         {
             var (pipe, dataView) = GetBinaryClassificationPipeline();
@@ -95,8 +93,6 @@ namespace Microsoft.ML.Tests.TrainerEstimators
         /// LightGBMBinaryTrainer CorrectSigmoid test
         /// </summary>
         [LightGBMFact]
-        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
-        [Trait("Category", "SkipInCI")]
         public void LightGBMBinaryEstimatorCorrectSigmoid()
         {
             var (pipe, dataView) = GetBinaryClassificationPipeline();

--- a/test/Microsoft.ML.Tests/Transformers/NormalizerTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/NormalizerTests.cs
@@ -751,8 +751,6 @@ namespace Microsoft.ML.Tests.Transformers
         }
 
         [Fact]
-        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
-        [Trait("Category", "SkipInCI")]
         public void TestGcnNormCommandLine()
         {
             Assert.Equal(Maml.Main(new[] { @"showschema loader=Text{col=A:R4:0-10} xf=GcnTransform{col=B:A} in=f:\2.txt" }), (int)0);


### PR DESCRIPTION
In ML.Tests assembly, when some tests run in parallel, there are chance the host process will crash due to below exception: 
The thread tried to read from or write to a virtual address for which it does not have the appropriate access.
Unhandled exception at 0x00007FFA70E7B049 (ntdll.dll) in dotnet.exe.12884.dmp: 0xC0000374: A heap has been corrupted (parameters: 0x00007FFA70EE27F0).

Looked into this error in detail, they come from LightGBM/OnnxRuntime dll we are referencing, seems like null pointer error during object finalization. 
![image](https://user-images.githubusercontent.com/55860649/75403422-8f548b80-58bc-11ea-8444-eb48027567fa.png)

These crash issue can be mitigated if we disable test parallelization. At the meantime, I'm contacting LightGBM and OnnxRuntime team to take a deeper look, maybe they should do null pointer check at their end.

Below are combination of tests run in parallel likely to cause crash, there maybe more:
LightGBMBinaryEstimatorUnbalanced and BinaryClassificationTrainersOnnxConversionTest
LightGBMRegressorEstimator and BinaryClassificationTrainersOnnxConversionTest
LightGBMBinaryEstimatorUnbalanced and TestSGDBinary
LightGBMBinaryEstimatorUnbalanced and CommandLineOnnxConversionTest
LightGBMBinaryEstimatorCorrectSigmoid and MulticlassConfusionMatrixSlotNames
IrisVectorLightGbmWithLoadColumnName and PlattCalibratorOnnxConversionTest
