### PR TITLE
upgrade hosted mac agent pool to use new version of mac os

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -46,7 +46,7 @@ jobs:
     buildScript: ./build.sh
     innerLoop: true
     pool:
-      name: Hosted macOS High Sierra
+      name: Hosted macOS
 
 - template: /build/ci/job-template.yml
   parameters:

--- a/build/.night-build.yml
+++ b/build/.night-build.yml
@@ -62,7 +62,7 @@ jobs:
     buildScript: ./build.sh
     nightlyBuild: true
     pool:
-      name: Hosted macOS High Sierra
+      name: Hosted macOS
 
 - template: /build/ci/job-template.yml
   parameters:

--- a/build/.outer-loop-build.yml
+++ b/build/.outer-loop-build.yml
@@ -60,7 +60,7 @@ jobs:
     name: MacOS_x64_NetCoreApp21
     buildScript: ./build.sh
     pool:
-      name: Hosted macOS High Sierra
+      name: Hosted macOS
 
 - template: /build/ci/job-template.yml
   parameters:

--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -47,7 +47,7 @@ jobs:
       container: ${{ parameters.container }}
 
     steps:
-    - ${{ if eq(parameters.pool.name, 'Hosted macOS High Sierra') }}:
+    - ${{ if eq(parameters.pool.name, 'Hosted macOS') }}:
       - script: brew update && brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/f5b1ac99a7fba27c19cee0bc4f036775c889b359/Formula/libomp.rb && brew unlink python@2 && brew install mono-libgdiplus gettext && brew link gettext --force && brew link libomp --force
         displayName: Install build dependencies
     - ${{ if and( eq(parameters.nightlyBuild, 'true'), eq(parameters.pool.name, 'Hosted Ubuntu 1604')) }}:

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -44,7 +44,7 @@ phases:
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
     DOTNET_MULTILEVEL_LOOKUP: 0
   queue:
-    name: Hosted macOS High Sierra
+    name: Hosted macOS
   steps:
   - script: brew update && brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/f5b1ac99a7fba27c19cee0bc4f036775c889b359/Formula/libomp.rb && brew link libomp --force
     displayName: Install build dependencies


### PR DESCRIPTION
current version of mac os will be out of support at March 23, 2020, move to new version:

https://devblogs.microsoft.com/devops/removing-older-images-in-azure-pipelines-hosted-pools/