### PR TITLE
Calculate ReduceSum row by row in ONNX model from OneVsAllTrainer

### DIFF
--- a/src/Microsoft.ML.StandardTrainers/Standard/MulticlassClassification/OneVersusAllTrainer.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/MulticlassClassification/OneVersusAllTrainer.cs
@@ -928,6 +928,8 @@ namespace Microsoft.ML.Trainers
                 var sumOutput = ctx.AddIntermediateVariable(NumberDataViewType.Single, "SumOutput");
                 var sumNode = ctx.CreateNode(opType, expOutput, sumOutput, ctx.GetNodeName(opType), "");
                 sumNode.AddAttribute("keepdims", 1);
+                long[] list = { 1 };
+                sumNode.AddAttribute("axes", list);
 
                 opType = "Div";
                 var divOutput = ctx.AddIntermediateVariable(type, "DivOutput");


### PR DESCRIPTION
There's a bug with the ONNX models exported from `OneVsAllTrainers` that have `OutputFormula = OutputFormula.Softmax`. (Notice that to the best of my knowledge, only a LightGBM multiclass trainer that had `useSoftmax = true` would have such an `OutputFormula`).

Problem was that the SoftMax (particularly the `ReduceSum` part of it) would be applied by summing the whole input batch, instead of doing separate sums for each row. This PR fixes that.

Notice that this error wasn't presented in our tests, since the `OnnxTransformer` which applies the ONNX model, actually process one row at a time, so the batch would always consist of one row. When trying to use this model directly with OnnxRuntime API (without the `OnnxTransformer`), then this problem appeared.