### PR TITLE
Nightlybuild fix

### DIFF
--- a/build/.night-build.yml
+++ b/build/.night-build.yml
@@ -38,10 +38,12 @@ jobs:
       Debug_Build:
         _configuration: Debug-netcoreapp3_0
         _config_short: DI
+        _targetFramework: netcoreapp3.0
         _includeBenchmarkData: false
       Release_Build:
         _configuration: Release-netcoreapp3_0
         _config_short: RI
+        _targetFramework: netcoreapp3.0
         _includeBenchmarkData: true
     nightlyBuild: true
     pool:

--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -53,8 +53,6 @@ jobs:
     - ${{ if and( eq(parameters.nightlyBuild, 'true'), eq(parameters.pool.name, 'Hosted Ubuntu 1604')) }}:
       - bash: echo "##vso[task.setvariable variable=LD_LIBRARY_PATH]$(nightlyBuildRunPath):$LD_LIBRARY_PATH"
         displayName: Set LD_LIBRARY_PATH for Ubuntu and CentOS to locate Native shared library in current running path
-      - bash: echo $LD_LIBRARY_PATH
-        displayName: output LD_LIBRARY_PATH
     - script: ${{ parameters.buildScript }} -$(_configuration) -buildArch=${{ parameters.architecture }}
       displayName: Build
     - ${{ if eq(parameters.nightlyBuild, 'true') }}:

--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -53,6 +53,8 @@ jobs:
     - ${{ if and( eq(parameters.nightlyBuild, 'true'), eq(parameters.pool.name, 'Hosted Ubuntu 1604')) }}:
       - bash: echo "##vso[task.setvariable variable=LD_LIBRARY_PATH]$(nightlyBuildRunPath):$LD_LIBRARY_PATH"
         displayName: Set LD_LIBRARY_PATH for Ubuntu and CentOS to locate Native shared library in current running path
+      - bash: echo $LD_LIBRARY_PATH
+        displayName: output LD_LIBRARY_PATH
     - script: ${{ parameters.buildScript }} -$(_configuration) -buildArch=${{ parameters.architecture }}
       displayName: Build
     - ${{ if eq(parameters.nightlyBuild, 'true') }}:

--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -23,7 +23,7 @@ jobs:
       dotnetPath: $(Build.SourcesDirectory)/Tools/dotnetcli/dotnet
       nugetFeed: https://pkgs.dev.azure.com/dnceng/public/_packaging/MachineLearning/nuget/v3/index.json
       nightlyBuildProjPath: $(Build.SourcesDirectory)/test/Microsoft.ML.NightlyBuild.Tests/Microsoft.ML.NightlyBuild.Tests.csproj
-      nightlyBuildRunPath: (Build.SourcesDirectory)/bin/AnyCPU.(_configuration)/Microsoft.ML.NightlyBuild.Tests/(_targetFramework)
+      nightlyBuildRunPath: $(Build.SourcesDirectory)/bin/AnyCPU.(_configuration)/Microsoft.ML.NightlyBuild.Tests/(_targetFramework)
       packageUpdaterProjPath: $(Build.SourcesDirectory)/test/Microsoft.ML.NugetPackageVersionUpdater/Microsoft.ML.NugetPackageVersionUpdater.csproj
       versionFilePath: $(Build.SourcesDirectory)/test/Microsoft.ML.NugetPackageVersionUpdater/latest_versions.txt
     strategy:
@@ -62,6 +62,14 @@ jobs:
         displayName: List latest package versions
       - script: $(dotnetPath) run --project $(packageUpdaterProjPath)
         displayName: Update package versions for nightly build
+      - powershell: |
+                  Get-ChildItem -Path  '.\bin' -Recurse -exclude |
+                  Select -ExpandProperty FullName |
+                  Where {$_ -notlike '.\bin\*\Microsoft.ML.NightlyBuild.Tests*'} |
+                  sort length -Descending |
+                  Remove-Item -force 
+                  Write-Output "Done cleaning up usless project..."
+        displayName: Clean up usless project
       - script: $(dotnetPath) msbuild -restore $(nightlyBuildProjPath) /p:ReferenceTypeForTestFramework="Nuget" /p:Configuration=$(_configuration) /p:TargetArchitecture=${{ parameters.architecture }}
         displayName: Build Nightly-Build Project with latest package versions
       - script: ${{ parameters.buildScript }} -$(_configuration) -runnightlybuildtests

--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -70,7 +70,7 @@ jobs:
                     sort length -Descending | 
                     Remove-Item -force 
                     Write-Output "Done cleaning up usless project..."
-          displayName: Clean up usless project
+          displayName: Clean up useless project
       - script: $(dotnetPath) msbuild -restore $(nightlyBuildProjPath) /p:ReferenceTypeForTestFramework="Nuget" /p:Configuration=$(_configuration) /p:TargetArchitecture=${{ parameters.architecture }}
         displayName: Build Nightly-Build Project with latest package versions
       - script: ${{ parameters.buildScript }} -$(_configuration) -runnightlybuildtests

--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -13,7 +13,7 @@ parameters:
 jobs:
   - job: ${{ parameters.name }}
     ${{ if eq(parameters.nightlyBuild, 'true') }}:
-      timeoutInMinutes: 20
+      timeoutInMinutes: 30
     ${{ if and(eq(parameters.nightlyBuild, 'false'), eq(parameters.codeCoverage, 'false')) }}:
       timeoutInMinutes: 75
     ${{ if eq(parameters.codeCoverage, 'true') }}:
@@ -50,12 +50,9 @@ jobs:
     - ${{ if eq(parameters.pool.name, 'Hosted macOS') }}:
       - script: brew update && brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/f5b1ac99a7fba27c19cee0bc4f036775c889b359/Formula/libomp.rb && brew unlink python@2 && brew install mono-libgdiplus gettext && brew link gettext --force && brew link libomp --force
         displayName: Install build dependencies
-    - ${{ if and( eq(parameters.nightlyBuild, 'true'), eq(parameters.name, 'Ubuntu_x64_NetCoreApp21')) }}:
+    - ${{ if and( eq(parameters.nightlyBuild, 'true'), eq(parameters.pool.name, 'Hosted Ubuntu 1604')) }}:
       - bash: echo "##vso[task.setvariable variable=LD_LIBRARY_PATH]$(nightlyBuildRunPath):$LD_LIBRARY_PATH"
-        displayName: Set LD_LIBRARY_PATH for Ubuntu to locate Native shared library in current running path
-    - ${{ if and( eq(parameters.nightlyBuild, 'true'), eq(parameters.name, 'Centos_x64_NetCoreApp30')) }}:
-      - bash: echo "##vso[task.setvariable variable=LIBRARY_PATH]$(nightlyBuildRunPath):$LIBRARY_PATH"
-        displayName: Set LIBRARY_PATH for CentOS to locate Native shared library in current running path
+        displayName: Set LD_LIBRARY_PATH for Ubuntu and CentOS to locate Native shared library in current running path
     - script: ${{ parameters.buildScript }} -$(_configuration) -buildArch=${{ parameters.architecture }}
       displayName: Build
     - ${{ if eq(parameters.nightlyBuild, 'true') }}:

--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -23,7 +23,7 @@ jobs:
       dotnetPath: $(Build.SourcesDirectory)/Tools/dotnetcli/dotnet
       nugetFeed: https://pkgs.dev.azure.com/dnceng/public/_packaging/MachineLearning/nuget/v3/index.json
       nightlyBuildProjPath: $(Build.SourcesDirectory)/test/Microsoft.ML.NightlyBuild.Tests/Microsoft.ML.NightlyBuild.Tests.csproj
-      nightlyBuildRunPath: $(Build.SourcesDirectory)/bin/AnyCPU.(_configuration)/Microsoft.ML.NightlyBuild.Tests/(_targetFramework)
+      nightlyBuildRunPath: $(Build.SourcesDirectory)/bin/AnyCPU.$(_configuration)/Microsoft.ML.NightlyBuild.Tests/$(_targetFramework)
       packageUpdaterProjPath: $(Build.SourcesDirectory)/test/Microsoft.ML.NugetPackageVersionUpdater/Microsoft.ML.NugetPackageVersionUpdater.csproj
       versionFilePath: $(Build.SourcesDirectory)/test/Microsoft.ML.NugetPackageVersionUpdater/latest_versions.txt
     strategy:

--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -50,9 +50,12 @@ jobs:
     - ${{ if eq(parameters.pool.name, 'Hosted macOS') }}:
       - script: brew update && brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/f5b1ac99a7fba27c19cee0bc4f036775c889b359/Formula/libomp.rb && brew unlink python@2 && brew install mono-libgdiplus gettext && brew link gettext --force && brew link libomp --force
         displayName: Install build dependencies
-    - ${{ if and( eq(parameters.nightlyBuild, 'true'), eq(parameters.pool.name, 'Hosted Ubuntu 1604')) }}:
+    - ${{ if and( eq(parameters.nightlyBuild, 'true'), eq(parameters.name, 'Ubuntu_x64_NetCoreApp21')) }}:
       - bash: echo "##vso[task.setvariable variable=LD_LIBRARY_PATH]$(nightlyBuildRunPath):$LD_LIBRARY_PATH"
         displayName: Set LD_LIBRARY_PATH for Ubuntu to locate Native shared library in current running path
+    - ${{ if and( eq(parameters.nightlyBuild, 'true'), eq(parameters.name, 'Centos_x64_NetCoreApp30')) }}:
+      - bash: echo "##vso[task.setvariable variable=LIBRARY_PATH]$(nightlyBuildRunPath):$LIBRARY_PATH"
+        displayName: Set LIBRARY_PATH for CentOS to locate Native shared library in current running path
     - script: ${{ parameters.buildScript }} -$(_configuration) -buildArch=${{ parameters.architecture }}
       displayName: Build
     - ${{ if eq(parameters.nightlyBuild, 'true') }}:

--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -62,14 +62,15 @@ jobs:
         displayName: List latest package versions
       - script: $(dotnetPath) run --project $(packageUpdaterProjPath)
         displayName: Update package versions for nightly build
-      - powershell: |
-                  Get-ChildItem -Path  '.\bin' -Recurse -exclude |
-                  Select -ExpandProperty FullName |
-                  Where {$_ -notlike '.\bin\*\Microsoft.ML.NightlyBuild.Tests*'} |
-                  sort length -Descending |
-                  Remove-Item -force 
-                  Write-Output "Done cleaning up usless project..."
-        displayName: Clean up usless project
+      - ${{ if eq(parameters.buildScript, 'build.cmd') }}:
+        - powershell: |
+                    Get-ChildItem -Path  '.\bin\AnyCPU.*' -Recurse |
+                    Select -ExpandProperty FullName |
+                    Where {$_ -notlike '*\Microsoft.ML.NightlyBuild.Tests*'} |
+                    sort length -Descending | 
+                    Remove-Item -force 
+                    Write-Output "Done cleaning up usless project..."
+          displayName: Clean up usless project
       - script: $(dotnetPath) msbuild -restore $(nightlyBuildProjPath) /p:ReferenceTypeForTestFramework="Nuget" /p:Configuration=$(_configuration) /p:TargetArchitecture=${{ parameters.architecture }}
         displayName: Build Nightly-Build Project with latest package versions
       - script: ${{ parameters.buildScript }} -$(_configuration) -runnightlybuildtests

--- a/test/Microsoft.ML.NightlyBuild.Tests/Microsoft.ML.NightlyBuild.Tests.csproj
+++ b/test/Microsoft.ML.NightlyBuild.Tests/Microsoft.ML.NightlyBuild.Tests.csproj
@@ -29,4 +29,8 @@
     <ProjectReference Include="..\Microsoft.ML.TestFrameworkCommon\Microsoft.ML.TestFrameworkCommon.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="$(MicrosoftMLOnnxRuntimePackageVersion)" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
several issue here:
1. delete useless folder to avoid no disk space
2. add missing dependency for nightly build
3. fix LD_LIBRARY_PATH for CentOS to set proper native reference path
4. increase build time, seems it takes more time now for net core 3.0 to build