### PR TITLE
Add allowBinary Flag to internal columnInference 

### DIFF
--- a/src/Microsoft.ML.AutoML/ColumnInference/ColumnInferenceApi.cs
+++ b/src/Microsoft.ML.AutoML/ColumnInference/ColumnInferenceApi.cs
@@ -36,11 +36,11 @@ namespace Microsoft.ML.AutoML
         }
 
         public static ColumnInferenceResults InferColumns(MLContext context, string path, ColumnInformation columnInfo,
-            char? separatorChar, bool? allowQuotedStrings, bool? supportSparse, bool trimWhitespace, bool groupColumns, bool hasHeader = true)
+            char? separatorChar, bool? allowQuotedStrings, bool? supportSparse, bool trimWhitespace, bool groupColumns, bool hasHeader = true, bool allowBinary = true)
         {
             var sample = TextFileSample.CreateFromFullFile(path);
             var splitInference = InferSplit(context, sample, separatorChar, allowQuotedStrings, supportSparse);
-            var typeInference = InferColumnTypes(context, sample, splitInference, hasHeader, null, columnInfo.LabelColumnName);
+            var typeInference = InferColumnTypes(context, sample, splitInference, hasHeader, null, columnInfo.LabelColumnName, allowBinary);
             return InferColumns(context, path, columnInfo, hasHeader, splitInference, typeInference, trimWhitespace, groupColumns);
         }
 
@@ -126,7 +126,7 @@ namespace Microsoft.ML.AutoML
         }
 
         private static ColumnTypeInference.InferenceResult InferColumnTypes(MLContext context, TextFileSample sample,
-            TextFileContents.ColumnSplitResult splitInference, bool hasHeader, uint? labelColumnIndex, string label)
+            TextFileContents.ColumnSplitResult splitInference, bool hasHeader, uint? labelColumnIndex, string label, bool allowBinary = true)
         {
             // infer column types
             var typeInferenceResult = ColumnTypeInference.InferTextFileColumnTypes(context, sample,
@@ -139,7 +139,7 @@ namespace Microsoft.ML.AutoML
                     HasHeader = hasHeader,
                     LabelColumnIndex = labelColumnIndex,
                     Label = label
-                });
+                }, allowBinary);
 
             if (!typeInferenceResult.IsSuccess)
             {

--- a/test/Microsoft.ML.AutoML.Tests/ColumnInferenceTests.cs
+++ b/test/Microsoft.ML.AutoML.Tests/ColumnInferenceTests.cs
@@ -78,18 +78,63 @@ namespace Microsoft.ML.AutoML.Test
         public void DatasetWithBoolColumn()
         {
             var result = new MLContext(1).Auto().InferColumns(Path.Combine("TestData", "BinaryDatasetWithBoolColumn.txt"), DefaultColumnNames.Label);
-            Assert.Equal(2, result.TextLoaderOptions.Columns.Count());
+            Assert.Equal(3, result.TextLoaderOptions.Columns.Count());
 
             var boolColumn = result.TextLoaderOptions.Columns.First(c => c.Name == "Bool");
+            var boolFeaturesColumn = result.TextLoaderOptions.Columns.First(c => c.Name == "BooleanFeatures");
             var labelColumn = result.TextLoaderOptions.Columns.First(c => c.Name == DefaultColumnNames.Label);
+
             // ensure non-label Boolean column is detected as R4
             Assert.Equal(DataKind.Single, boolColumn.DataKind);
+            Assert.Equal(DataKind.Boolean, boolFeaturesColumn.DataKind);
+
             Assert.Equal(DataKind.Boolean, labelColumn.DataKind);
 
             // ensure non-label Boolean column is detected as R4
-            Assert.Single(result.ColumnInformation.NumericColumnNames);
+            Assert.Equal(2, result.ColumnInformation.NumericColumnNames.Count);
             Assert.Equal("Bool", result.ColumnInformation.NumericColumnNames.First());
             Assert.Equal(DefaultColumnNames.Label, result.ColumnInformation.LabelColumnName);
+        }
+
+        [Fact]
+        public void Should_parse_as_numeric_if_allowBinary_is_false()
+        {
+            var context = new MLContext(1);
+            var filePath = Path.Combine("TestData", "BinaryDatasetWithBoolColumn.txt");
+            var columnInfo = new ColumnInformation()
+            {
+                LabelColumnName = "Label",
+            };
+            var result = ColumnInferenceApi.InferColumns(context, filePath, columnInfo, ',', null, null, false, false, true, false);
+            Assert.Equal(4, result.TextLoaderOptions.Columns.Count());
+
+            var boolColumn = result.TextLoaderOptions.Columns.First(c => c.Name == "Bool");
+            var bool1Column = result.TextLoaderOptions.Columns.First(c => c.Name == "Bool1");
+            var bool2Column = result.TextLoaderOptions.Columns.First(c => c.Name == "Bool2");
+
+            var labelColumn = result.TextLoaderOptions.Columns.First(c => c.Name == "Label");
+
+            Assert.Equal(DataKind.Single, labelColumn.DataKind);
+            Assert.Equal(DataKind.Boolean, bool1Column.DataKind);
+            Assert.Equal(DataKind.Boolean, bool2Column.DataKind);
+            Assert.Equal(DataKind.Single, boolColumn.DataKind);
+        }
+
+        [Fact]
+        public void Should_parse_as_text_if_allowBinary_is_false()
+        {
+            var context = new MLContext(1);
+            var filePath = Path.Combine("TestData", "BinaryDatasetWithBoolColumn.txt");
+            var columnInfo = new ColumnInformation()
+            {
+                LabelColumnName = "Bool1",
+            };
+            var result = ColumnInferenceApi.InferColumns(context, filePath, columnInfo, ',', null, null, false, false, true, false);
+            Assert.Equal(4, result.TextLoaderOptions.Columns.Count());
+
+            var labelColumn = result.TextLoaderOptions.Columns.First(c => c.Name == "Bool1");
+
+            Assert.Equal(DataKind.String, labelColumn.DataKind);
         }
 
         [Fact]

--- a/test/Microsoft.ML.AutoML.Tests/TestData/BinaryDatasetWithBoolColumn.txt
+++ b/test/Microsoft.ML.AutoML.Tests/TestData/BinaryDatasetWithBoolColumn.txt
@@ -1,5 +1,5 @@
-﻿Label,Bool
-0,1
-0,0
-1,1
-1,0
+﻿Label,Bool, Bool1, Bool2
+0,1,T,true
+0,0,F,false
+1,1,T,true
+1,0,F,false


### PR DESCRIPTION
Add allowBinary flag to internal columnInference API. to stop parsing label as `Boolean` type when it's not binary experiment.