### PR TITLE
fix race condition for test MulticlassTreeFeaturizedLRTest

### DIFF
--- a/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
+++ b/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
@@ -742,8 +742,9 @@ namespace Microsoft.ML.Data
                 mapper =
                     (in TInput src, ref Single dst) =>
                     {
-                        // Attention: this method will be used in multipe threading,
-                        // don't put temp variable outside of this method to avoid race condition
+                        //Attention: This method is called from multiple threads.
+                        //Do not move the temp variable outside this method.
+                        //If you do, the variable is shared between the threads and results in a race condition.
                         ulong temp = 0;
                         if (isNa(in src))
                         {
@@ -761,8 +762,9 @@ namespace Microsoft.ML.Data
                 mapper =
                     (in TInput src, ref Single dst) =>
                     {
-                        // Attention: this method will be used in multipe threading,
-                        // don't put temp variable outside of this method to avoid race condition
+                        //Attention: This method is called from multiple threads.
+                        //Do not move the temp variable outside this method.
+                        //If you do, the variable is shared between the threads and results in a race condition.
                         ulong temp = 0;
                         if (isNa(in src))
                         {

--- a/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
+++ b/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
@@ -742,6 +742,8 @@ namespace Microsoft.ML.Data
                 mapper =
                     (in TInput src, ref Single dst) =>
                     {
+                        // Attention: this method will be used in multipe threading,
+                        // don't put temp variable outside of this method to avoid race condition
                         ulong temp = 0;
                         if (isNa(in src))
                         {
@@ -759,6 +761,8 @@ namespace Microsoft.ML.Data
                 mapper =
                     (in TInput src, ref Single dst) =>
                     {
+                        // Attention: this method will be used in multipe threading,
+                        // don't put temp variable outside of this method to avoid race condition
                         ulong temp = 0;
                         if (isNa(in src))
                         {

--- a/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
+++ b/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
@@ -735,7 +735,6 @@ namespace Microsoft.ML.Data
             bool identity;
             var converter = Conversions.Instance.GetStandardConversion<TInput, ulong>(type, dstType, out identity);
             var isNa = Conversions.Instance.GetIsNAPredicate<TInput>(type);
-            ulong temp = 0;
 
             ValueMapper<TInput, Single> mapper;
             if (seed == 0)
@@ -743,6 +742,7 @@ namespace Microsoft.ML.Data
                 mapper =
                     (in TInput src, ref Single dst) =>
                     {
+                        ulong temp = 0;
                         if (isNa(in src))
                         {
                             dst = Single.NaN;
@@ -759,6 +759,7 @@ namespace Microsoft.ML.Data
                 mapper =
                     (in TInput src, ref Single dst) =>
                     {
+                        ulong temp = 0;
                         if (isNa(in src))
                         {
                             dst = Single.NaN;


### PR DESCRIPTION
method in TreeEnsembleFeaturizerTransform will be called from multi-threading, make variable "temp" as local variable to avoid race condition.