### PR TITLE
Fixed path to Procdump files

### DIFF
--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -27,7 +27,7 @@ jobs:
       nightlyBuildRunPath: $(Build.SourcesDirectory)/bin/AnyCPU.$(_configuration)/Microsoft.ML.NightlyBuild.Tests/$(_targetFramework)
       packageUpdaterProjPath: $(Build.SourcesDirectory)/test/Microsoft.ML.NugetPackageVersionUpdater/Microsoft.ML.NugetPackageVersionUpdater.csproj
       versionFilePath: $(Build.SourcesDirectory)/test/Microsoft.ML.NugetPackageVersionUpdater/latest_versions.txt
-      PROCDUMP_PATH: '$(Build.SourcesDirectory)/Procdump_Files/'
+      PROCDUMP_PATH: '$(Build.SourcesDirectory)/Tools/Procdump_Files/'
     strategy:
       matrix:
         ${{ if eq(parameters.customMatrixes, '') }}:

--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -27,7 +27,7 @@ jobs:
       nightlyBuildRunPath: $(Build.SourcesDirectory)/bin/AnyCPU.$(_configuration)/Microsoft.ML.NightlyBuild.Tests/$(_targetFramework)
       packageUpdaterProjPath: $(Build.SourcesDirectory)/test/Microsoft.ML.NugetPackageVersionUpdater/Microsoft.ML.NugetPackageVersionUpdater.csproj
       versionFilePath: $(Build.SourcesDirectory)/test/Microsoft.ML.NugetPackageVersionUpdater/latest_versions.txt
-      PROCDUMP_PATH: '$(Build.SourcesDirectory)/Tools/Procdump_Files/'
+      PROCDUMP_PATH: '$(Build.SourcesDirectory)/Tools/ProcDump/'
     strategy:
       matrix:
         ${{ if eq(parameters.customMatrixes, '') }}:

--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -27,7 +27,7 @@ jobs:
       nightlyBuildRunPath: $(Build.SourcesDirectory)/bin/AnyCPU.$(_configuration)/Microsoft.ML.NightlyBuild.Tests/$(_targetFramework)
       packageUpdaterProjPath: $(Build.SourcesDirectory)/test/Microsoft.ML.NugetPackageVersionUpdater/Microsoft.ML.NugetPackageVersionUpdater.csproj
       versionFilePath: $(Build.SourcesDirectory)/test/Microsoft.ML.NugetPackageVersionUpdater/latest_versions.txt
-      PROCDUMP_PATH: '$(Build.SourcesDirectory)/Tools/procdump/'
+      PROCDUMP_PATH: '$(Build.SourcesDirectory)/Procdump_Files/'
     strategy:
       matrix:
         ${{ if eq(parameters.customMatrixes, '') }}:

--- a/init-tools.cmd
+++ b/init-tools.cmd
@@ -70,7 +70,7 @@ if NOT [%AGENT_ID%] == [] (
 :: install procdump.exe to take process dump when test crashes, hangs or fails
 echo Installing procdump.exe
 powershell -Command "Invoke-WebRequest https://download.sysinternals.com/files/Procdump.zip -UseBasicParsing -outfile procdump.zip | Out-Null"
-powershell -Command "Expand-Archive -Force procdump.zip Tools\Procdump_Files"
+powershell -Command "Expand-Archive -Force procdump.zip Tools\ProcDump"
 del /f procdump.zip
 echo Finish install procdump.exe
 

--- a/init-tools.cmd
+++ b/init-tools.cmd
@@ -70,7 +70,7 @@ if NOT [%AGENT_ID%] == [] (
 :: install procdump.exe to take process dump when test crashes, hangs or fails
 echo Installing procdump.exe
 powershell -Command "Invoke-WebRequest https://download.sysinternals.com/files/Procdump.zip -UseBasicParsing -outfile procdump.zip | Out-Null"
-powershell -Command "Expand-Archive -Force procdump.zip Procdump_Files"
+powershell -Command "Expand-Archive -Force procdump.zip Tools\Procdump_Files"
 del /f procdump.zip
 echo Finish install procdump.exe
 

--- a/init-tools.cmd
+++ b/init-tools.cmd
@@ -70,7 +70,7 @@ if NOT [%AGENT_ID%] == [] (
 :: install procdump.exe to take process dump when test crashes, hangs or fails
 echo Installing procdump.exe
 powershell -Command "Invoke-WebRequest https://download.sysinternals.com/files/Procdump.zip -UseBasicParsing -outfile procdump.zip | Out-Null"
-powershell -Command "Expand-Archive -Force procdump.zip Tools"
+powershell -Command "Expand-Archive -Force procdump.zip Procdump_Files"
 del /f procdump.zip
 echo Finish install procdump.exe
 


### PR DESCRIPTION
Small bug fix in PowerShell command on the exact location where Procdump files are downloaded. The unzipping of a .zip file with `Expand-Archive` does not make a new folder specifically for the .zip file.