### PR TITLE
Updated build docs for .NET Core 3.1

### DIFF
--- a/docs/building/netcoreapp3.1-instructions.md
+++ b/docs/building/netcoreapp3.1-instructions.md
@@ -1,4 +1,9 @@
-ML.NET now builds for .NET Core 3.1 by default. However to run tests on .NET Core 3.1, you need to do a few manual steps.
+ML.NET source code files build for .NET Core 3.1 and .NET Core 2.0. However, ML.NET test files only build on one target framework below at a time:
+- .NET Core 2.1
+- .NET Core 3.1
+- .NET Framework 4.6.1
+
+To run tests on .NET Core 3.1, you need to do a few manual steps.
 
 1. Run `.\build.cmd -- /p:Configuration=Release-netcoreapp3_1` or `.\build.cmd -Release-netcoreapp3_1` from the root of the repo.
 2. If you want to build the NuGet packages, `.\build.cmd -buildPackages` after step 1.

--- a/docs/building/netcoreapp3.1-instructions.md
+++ b/docs/building/netcoreapp3.1-instructions.md
@@ -1,4 +1,4 @@
-ML.NET now builds for .NET Core 3.0 by default. However to run tests on .NET Core 3.0, you need to do a few manual steps.
+ML.NET now builds for .NET Core 3.1 by default. However to run tests on .NET Core 3.1, you need to do a few manual steps.
 
 1. Run `.\build.cmd -- /p:Configuration=Release-netcoreapp3_1` or `.\build.cmd -Release-netcoreapp3_1` from the root of the repo.
 2. If you want to build the NuGet packages, `.\build.cmd -buildPackages` after step 1.

--- a/docs/building/netcoreapp3.1-instructions.md
+++ b/docs/building/netcoreapp3.1-instructions.md
@@ -1,4 +1,4 @@
-ML.NET source code files build for .NET Core 3.1 and .NET Core 2.0. However, ML.NET test files only build on one target framework below at a time:
+ML.NET source code files build for .NET Core 3.1 and .NET Standard 2.0. However, ML.NET test files only build on one target framework below at a time:
 - .NET Core 2.1
 - .NET Core 3.1
 - .NET Framework 4.6.1

--- a/docs/building/unix-instructions.md
+++ b/docs/building/unix-instructions.md
@@ -28,7 +28,7 @@ The following components are needed:
 * libunwind8
 * libomp-dev
 * curl
-* All the requirements necessary to run .NET Core 3.0 applications: libssl1.0.0 (1.0.2 for Debian 9) and libicu5x (libicu52 for ubuntu 14.x, libicu55 for ubuntu 16.x, and libicu57 for ubuntu 17.x). For more information on prerequisites in different linux distributions click [here](https://docs.microsoft.com/en-us/dotnet/core/linux-prerequisites?tabs=netcore30).
+* All the requirements necessary to run .NET Core 3.1 applications: libssl1.0.0 (1.0.2 for Debian 9) and libicu5x (libicu55 for ubuntu 16.x, and libicu57 for ubuntu 17.x). For more information on prerequisites in different linux distributions click [here](https://docs.microsoft.com/en-us/dotnet/core/linux-prerequisites?tabs=netcore30).
 
 For example, for Ubuntu 16.x:
 
@@ -41,14 +41,14 @@ sudo apt-get install libomp-dev
 
 ### macOS
 
-macOS 10.13 (High Sierra) or higher is needed to build dotnet/machinelearning. We are using a .NET Core 3.0 SDK to build, which supports 10.13 or higher.
+macOS 10.13 (High Sierra) or higher is needed to build dotnet/machinelearning. We are using a .NET Core 3.1 SDK to build, which supports 10.13 or higher.
 
 On macOS a few components are needed which are not provided by a default developer setup:
 * cmake 3.10.3
 * libomp 7
 * libgdiplus
 * gettext
-* All the requirements necessary to run .NET Core 3.0 applications. To view macOS prerequisites click [here](https://docs.microsoft.com/en-us/dotnet/core/macos-prerequisites?tabs=netcore30).
+* All the requirements necessary to run .NET Core 3.1 applications. To view macOS prerequisites click [here](https://docs.microsoft.com/en-us/dotnet/core/macos-prerequisites?tabs=netcore30).
 
 One way of obtaining CMake and other required libraries is via [Homebrew](https://brew.sh):
 ```sh

--- a/docs/building/windows-instructions.md
+++ b/docs/building/windows-instructions.md
@@ -5,11 +5,11 @@ You can build ML.NET either via the command line or by using Visual Studio.
 
 ## Required Software
 
-1. **[Visual Studio 2019 Version 16.3](https://www.visualstudio.com/downloads/) (Community, Professional, Enterprise)** The Community version is completely free. The below build instructions were verified for VS 16.3.
+1. **[Visual Studio 2019 Version 16.4+](https://www.visualstudio.com/downloads/) (Community, Professional, Enterprise)** The Community version is completely free. The below build instructions were verified for VS 16.4.
 2. **[CMake](https://cmake.org/)** must be installed from [the CMake download page](https://cmake.org/download/#latest) and added to your path.
 
 ### Visual Studio 2019 Installation
-We have successfully verified the below build instructions for Visual Studio version 16.3 and higher. 
+We have successfully verified the below build instructions for Visual Studio version 16.4 and higher. 
 
 #### Visual Studio 2019 - 'Workloads' based install
 
@@ -28,7 +28,7 @@ The following are the minimum requirements:
 
 The following are the minimum requirements:
   * C# and Visual Basic Roslyn Compilers
-  * .NET Core 3.0 SDK
+  * .NET Core 3.1 SDK
   * Static Analysis Tools
   * .NET Portable Library Targeting Pack
   * Visual Studio C++ Core Features


### PR DESCRIPTION
Updated Windows and Unix build docs for .NET Core 3.1.

Some specific things to note:

- In addition to other platforms, .NET Core 3.1 supports Ubuntu **16.04**+ and macOS 10.13 (High Sierra)
- [Visual Studio 2019 Version **16.4 or higher** is needed for .NET Core 3.1.
- /src files always build on both `netstandard2.0 `and `netcoreapp3.1`, and /tests only build on one target framework at a time: `netcoreapp2.1`, `net461 `or `netcoreapp3.1`