### PR TITLE
Disabled AutoFitImageClassificationTrainTest for test stability

### DIFF
--- a/test/Microsoft.ML.AutoML.Tests/AutoFitTests.cs
+++ b/test/Microsoft.ML.AutoML.Tests/AutoFitTests.cs
@@ -54,6 +54,8 @@ namespace Microsoft.ML.AutoML.Test
         }
 
         [TensorFlowFact]
+        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
+        [Trait("Category", "SkipInCI")]
         public void AutoFitImageClassificationTrainTest()
         {
             var context = new MLContext(seed: 1);


### PR DESCRIPTION
Disabled `AutoFitImageClassificationTrainTest `from runs on CI, as it continues to hang on builds.
