### PR TITLE
Remove WeakReference list in PredictionEnginePoolPolicy.

### DIFF
--- a/src/Microsoft.Extensions.ML/PredictionEnginePoolPolicy.cs
+++ b/src/Microsoft.Extensions.ML/PredictionEnginePoolPolicy.cs
@@ -2,26 +2,22 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using Microsoft.Extensions.ObjectPool;
 using Microsoft.ML;
 
 namespace Microsoft.Extensions.ML
 {
     /// <summary>
-    /// <see cref="IPooledObjectPolicy{T}"/> for <see cref="PredictionEngine{TData, TPrediction}"/>
+    /// <see cref="PooledObjectPolicy{T}"/> for <see cref="PredictionEngine{TData, TPrediction}"/>
     /// which is responsible for creating pooled objects, and when to return objects to the pool.
     /// </summary>
     internal class PredictionEnginePoolPolicy<TData, TPrediction>
-        : IPooledObjectPolicy<PredictionEngine<TData, TPrediction>>
+        : PooledObjectPolicy<PredictionEngine<TData, TPrediction>>
         where TData : class
         where TPrediction : class, new()
     {
         private readonly MLContext _mlContext;
         private readonly ITransformer _model;
-        private readonly List<WeakReference> _references;
 
         /// <summary>
         /// Initializes a new instance of <see cref="PredictionEnginePoolPolicy{TData, TPrediction}"/>.
@@ -34,21 +30,13 @@ namespace Microsoft.Extensions.ML
         {
             _mlContext = mlContext;
             _model = model;
-            _references = new List<WeakReference>();
         }
 
         /// <inheritdoc />
-        public PredictionEngine<TData, TPrediction> Create()
-        {
-            var engine = _mlContext.Model.CreatePredictionEngine<TData, TPrediction>(_model);
-            _references.Add(new WeakReference(engine));
-            return engine;
-        }
+        public override PredictionEngine<TData, TPrediction> Create() =>
+            _mlContext.Model.CreatePredictionEngine<TData, TPrediction>(_model);
 
         /// <inheritdoc />
-        public bool Return(PredictionEngine<TData, TPrediction> obj)
-        {
-            return _references.Any(x => x.Target == obj);
-        }
+        public override bool Return(PredictionEngine<TData, TPrediction> obj) => true;
     }
 }


### PR DESCRIPTION
Accesses to this list are not thread-safe because we can be enumerating it on one thread (in Return) while another thread adds to it (in Create).

The list is unnecessary because the PredictionEngine will always be "rooted". Either it was being held in memory by someone who got the PredictionEngine from the pool, or it is being held by the ObjectPool itself. So it won't ever be GC'd, and the WeakReference is not doing anything.

Also, inherit from PooledObjectPolicy instead of IPooledObjectPolicy, so it can take the "fastPolicy" path in DefaultObjectPool. (See https://github.com/dotnet/extensions/pull/318).

Fix #4981