### PR TITLE
Bitmap(file) locks the file.

### DIFF
--- a/src/Microsoft.ML.ImageAnalytics/ImageLoader.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ImageLoader.cs
@@ -238,8 +238,10 @@ namespace Microsoft.ML.Data
                                 path = Path.Combine(_parent.ImageFolder, path);
 
                             // to avoid locking file, use the construct below to load bitmap
-                            using(var bmpTemp = new Bitmap(path))
-                                dst = new Bitmap(bmpTemp) { Tag = path };
+                            var bytes = File.ReadAllBytes(path);
+                            var ms = new MemoryStream(bytes);
+                            dst = (Bitmap)Image.FromStream(ms);
+                            dst.Tag = path;
 
                             // Check for an incorrect pixel format which indicates the loading failed
                             if (dst.PixelFormat == System.Drawing.Imaging.PixelFormat.DontCare)

--- a/src/Microsoft.ML.ImageAnalytics/ImageLoader.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ImageLoader.cs
@@ -237,7 +237,9 @@ namespace Microsoft.ML.Data
                             if (!string.IsNullOrWhiteSpace(_parent.ImageFolder))
                                 path = Path.Combine(_parent.ImageFolder, path);
 
-                            dst = new Bitmap(path) { Tag = path };
+                            // to avoid locking file, use the construct below to load bitmap
+                            using(var bmpTemp = new Bitmap(path))
+                                dst = new Bitmap(bmpTemp) { Tag = path };
 
                             // Check for an incorrect pixel format which indicates the loading failed
                             if (dst.PixelFormat == System.Drawing.Imaging.PixelFormat.DontCare)


### PR DESCRIPTION
Fixes #4585 

Construct "new Bitmap(file)" locks the underlying file for the lifetime of Bitmap. Use workaround suggested https://stackoverflow.com/questions/6576341/open-image-from-file-then-release-lock

