### PR TITLE
Removed WeakReference<IHosts> already cleaned up by GC

### DIFF
--- a/src/Microsoft.ML.Core/Environment/HostEnvironmentBase.cs
+++ b/src/Microsoft.ML.Core/Environment/HostEnvironmentBase.cs
@@ -134,11 +134,11 @@ namespace Microsoft.ML.Runtime
             /// </summary>
             public new IHost Register(string name, int? seed = null, bool? verbose = null)
             {
-                _children.RemoveAll(r => r.TryGetTarget(out IHost _) == false);
                 Contracts.CheckNonEmpty(name, nameof(name));
                 IHost host;
                 lock (_cancelLock)
                 {
+                    _children.RemoveAll(r => r.TryGetTarget(out IHost _) == false);
                     Random rand = (seed.HasValue) ? RandomUtils.Create(seed.Value) : RandomUtils.Create(_rand);
                     host = RegisterCore(this, name, Master?.FullName, rand, verbose ?? Verbose);
                     if (!IsCanceled)
@@ -391,12 +391,18 @@ namespace Microsoft.ML.Runtime
             _children = new List<WeakReference<IHost>>();
         }
 
+        /// <summary>
+        /// This method registers and returns the host for the calling component. The generated host is also
+        /// added to <see cref="_children"/> and encapsulated by <see cref="WeakReference"/>. It becomes
+        /// necessary to remove these hosts when they are reclaimed by the Garbage Collector.
+        /// </summary>
         public IHost Register(string name, int? seed = null, bool? verbose = null)
         {
             Contracts.CheckNonEmpty(name, nameof(name));
             IHost host;
             lock (_cancelLock)
             {
+                _children.RemoveAll(r => r.TryGetTarget(out IHost _) == false);
                 Random rand = (seed.HasValue) ? RandomUtils.Create(seed.Value) : RandomUtils.Create(_rand);
                 host = RegisterCore(this, name, Master?.FullName, rand, verbose ?? Verbose);
                 _children.Add(new WeakReference<IHost>(host));

--- a/src/Microsoft.ML.Core/Environment/HostEnvironmentBase.cs
+++ b/src/Microsoft.ML.Core/Environment/HostEnvironmentBase.cs
@@ -127,8 +127,14 @@ namespace Microsoft.ML.Runtime
                 Depth = source.Depth + 1;
             }
 
+            /// <summary>
+            /// This method registers and returns the host for the calling component. The generated host is also
+            /// added to <see cref="_children"/> and encapsulated by <see cref="WeakReference"/>. It becomes
+            /// necessary to remove these hosts when they are reclaimed by the Garbage Collector.
+            /// </summary>
             public new IHost Register(string name, int? seed = null, bool? verbose = null)
             {
+                _children.RemoveAll(r => r.TryGetTarget(out IHost _) == false);
                 Contracts.CheckNonEmpty(name, nameof(name));
                 IHost host;
                 lock (_cancelLock)


### PR DESCRIPTION
Fixes #4914 

WeakReference<IHost> objects are stored in `_children`. Occasionally Garbage Collector cleans up these WeakReference<IHost>s and change their `target` value to null, but their `WeakReference`s in the `List _children` are never removed. This PR explicity removed those `WeakReference` objects that have null targets.

`List.RemoveAll()` has a time-complexity of O(n) where n is the number of objects in `List`.