### PR TITLE
CountFeatureSelectingEstimator no selection support

### DIFF
--- a/src/Microsoft.ML.Data/Transforms/SlotsDroppingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/SlotsDroppingTransformer.cs
@@ -895,13 +895,15 @@ namespace Microsoft.ML.Transforms
             {
                 string opType;
                 var slots = _slotDropper[iinfo].GetPreservedSlots();
-                if (_srcTypes[iinfo] is VectorDataViewType && slots.Count() > 0)
+                // vector column is not suppressed
+                if (slots.Count() > 0)
                 {
                     opType = "GatherElements";
                     var slotsVar = ctx.AddInitializer(slots, new long[] { 1, slots.Count() }, "PreservedSlots");
                     var node = ctx.CreateNode(opType, new[] { srcVariableName, slotsVar }, new[] { dstVariableName }, ctx.GetNodeName(opType), "");
                     node.AddAttribute("axis", 1);
                 }
+                // When the vector/scalar columnn is suppressed, we simply create an empty output vector
                 else
                 {
                     string constVal;

--- a/src/Microsoft.ML.Transforms/CountFeatureSelection.cs
+++ b/src/Microsoft.ML.Transforms/CountFeatureSelection.cs
@@ -28,7 +28,7 @@ namespace Microsoft.ML.Transforms
     /// |  |  |
     /// | -- | -- |
     /// | Does this estimator need to look at the data to train its parameters? | Yes |
-    /// | Input column data type | Vector or scalar of numeric, [text](xref:Microsoft.ML.Data.TextDataViewType) or [key](xref:Microsoft.ML.Data.KeyDataViewType) data types|
+    /// | Input column data type | Vector or scalar of <xref:System.Single>, <xref:System.Double> or [text](xref:Microsoft.ML.Data.TextDataViewType) data types|
     /// | Output column data type | Same as the input column|
     /// | Exportable to ONNX | Yes |
     ///

--- a/test/BaselineOutput/Common/Onnx/BinaryClassification/BreastCancer/ExcludeVariablesInOnnxConversion.txt
+++ b/test/BaselineOutput/Common/Onnx/BinaryClassification/BreastCancer/ExcludeVariablesInOnnxConversion.txt
@@ -695,6 +695,45 @@
         }
       },
       {
+        "name": "Cast",
+        "type": {
+          "tensorType": {
+            "elemType": 7,
+            "shape": {
+              "dim": [
+                {
+                  "dimValue": "-1"
+                },
+                {
+                  "dimValue": "1"
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "name": "encoded",
+        "type": {
+          "tensorType": {
+            "elemType": 1,
+            "shape": {
+              "dim": [
+                {
+                  "dimValue": "-1"
+                },
+                {
+                  "dimValue": "1"
+                },
+                {
+                  "dimValue": "10"
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
         "name": "F22",
         "type": {
           "tensorType": {

--- a/test/BaselineOutput/Common/Onnx/BinaryClassification/BreastCancer/ExcludeVariablesInOnnxConversion.txt
+++ b/test/BaselineOutput/Common/Onnx/BinaryClassification/BreastCancer/ExcludeVariablesInOnnxConversion.txt
@@ -695,45 +695,6 @@
         }
       },
       {
-        "name": "Cast",
-        "type": {
-          "tensorType": {
-            "elemType": 7,
-            "shape": {
-              "dim": [
-                {
-                  "dimValue": "-1"
-                },
-                {
-                  "dimValue": "1"
-                }
-              ]
-            }
-          }
-        }
-      },
-      {
-        "name": "encoded",
-        "type": {
-          "tensorType": {
-            "elemType": 1,
-            "shape": {
-              "dim": [
-                {
-                  "dimValue": "-1"
-                },
-                {
-                  "dimValue": "1"
-                },
-                {
-                  "dimValue": "10"
-                }
-              ]
-            }
-          }
-        }
-      },
-      {
         "name": "F22",
         "type": {
           "tensorType": {


### PR DESCRIPTION
**Issue**: The GatherElements ONNX operator used by SlotsDroppingTransformer (transformer for CountFeatureSelectingEstimator) has issues when there's nothing selected, so mlnet needs to handle this case separately. 

**This PR**
- Fixes the issue mentioned above
- Modifies the estimator's test to be more robust

**Other issues:**
- There's no support for string initializing in ONNX, which prevents us from handling the case where no string columns get selected.
- The documentation for CountFeatureSelectingEstimator is ambiguous. It states that it supports input as  "vector or scalar of numeric, text or key data types". However, only strings, doubles, and singles are supported. 

