### PR TITLE
clean nuget package to save disk space

### DIFF
--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -57,6 +57,24 @@ jobs:
         displayName: Set LD_LIBRARY_PATH for Ubuntu and CentOS to locate Native shared library in current running path
     - script: ${{ parameters.buildScript }} -$(_configuration) -buildArch=${{ parameters.architecture }}
       displayName: Build
+    - ${{ if eq(parameters.pool.name, 'Hosted macOS') }}:
+      - task: Bash@3
+        inputs:
+          targetType: inline
+          script: cd packages;find . -type d -path "*/runtimes/linux-*"  -exec rm -rv {} +;find . -type d -path "*/runtimes/win-*"  -exec rm -rv {} +;cd ..
+        displayName: Clean up non-MacOS runtime folders of NuGet Packages to save disk space
+    - ${{ if eq(parameters.pool.name, 'Hosted Ubuntu 1604') }}:
+      - task: Bash@3
+        inputs:
+          targetType: inline
+          script: cd packages;find . -type d -path "*/runtimes/osx-*"  -exec rm -rv {} +;find . -type d -path "*/runtimes/win-*"  -exec rm -rv {} +;cd ..
+        displayName: Clean up non-Linux runtime folders of NuGet Packages to save disk space
+    - ${{ if eq(parameters.buildScript, 'build.cmd') }}:
+      - task: PowerShell@2
+        inputs:
+          targetType: inline
+          script: Get-ChildItem -Path  '.\packages\*\runtimes\*' -Recurse | Select -ExpandProperty FullName | Where {$_ -notlike '*\win-*'} | sort length -Descending | Remove-Item -Recurse -Confirm:$false -Force
+        displayName: Clean up non-Windows runtime folders of NuGet Packages to save disk space
     - ${{ if eq(parameters.nightlyBuild, 'true') }}:
       - script: $(dotnetPath) restore $(nightlyBuildProjPath)
         displayName: Restore nightly build project


### PR DESCRIPTION
run out of disk space on CI, so clean up nuget packages to save disk space:
1. delete windows and mac os packages for linux
2. delete windows and linux packages for mac os
3.delete linux and mac os packages for windows

