### PR TITLE
fix SsaForecast test

### DIFF
--- a/test/Microsoft.ML.TimeSeries.Tests/TimeSeriesDirectApi.cs
+++ b/test/Microsoft.ML.TimeSeries.Tests/TimeSeriesDirectApi.cs
@@ -328,8 +328,6 @@ namespace Microsoft.ML.Tests
         }
 
         [LessThanNetCore30OrNotNetCoreFact("netcoreapp3.1 output differs from Baseline")]
-        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
-        [Trait("Category", "SkipInCI")]
         public void SsaForecast()
         {
             var env = new MLContext(1);


### PR DESCRIPTION
PolynomialUtils.FindPolynomialCoefficients is not thread safe. 
PolynomialFactor class contains static fields Destination that be override by other threads during test execution. 
Lock method call to FindPolynomialCoefficients to make it thread safe.

