### PR TITLE
Avoid propagating some input columns when applying an Onnx model

### DIFF
--- a/src/Microsoft.ML.Data/Transforms/RowToRowTransformerBase.cs
+++ b/src/Microsoft.ML.Data/Transforms/RowToRowTransformerBase.cs
@@ -28,7 +28,9 @@ namespace Microsoft.ML.Data
 
         bool ITransformer.IsRowToRowMapper => true;
 
-        IRowToRowMapper ITransformer.GetRowToRowMapper(DataViewSchema inputSchema)
+        IRowToRowMapper ITransformer.GetRowToRowMapper(DataViewSchema inputSchema) => GetRowToRowMapperCore(inputSchema);
+
+        protected virtual IRowToRowMapper GetRowToRowMapperCore(DataViewSchema inputSchema)
         {
             Host.CheckValue(inputSchema, nameof(inputSchema));
             return new RowToRowMapperTransform(Host, new EmptyDataView(Host, inputSchema), MakeRowMapper(inputSchema), MakeRowMapper);
@@ -37,16 +39,20 @@ namespace Microsoft.ML.Data
         [BestFriend]
         private protected abstract IRowMapper MakeRowMapper(DataViewSchema schema);
 
-        public DataViewSchema GetOutputSchema(DataViewSchema inputSchema)
+        public DataViewSchema GetOutputSchema(DataViewSchema inputSchema) => GetOutputSchemaCore(inputSchema);
+
+        protected virtual DataViewSchema GetOutputSchemaCore(DataViewSchema inputSchema)
         {
             Host.CheckValue(inputSchema, nameof(inputSchema));
             var mapper = MakeRowMapper(inputSchema);
             return RowToRowMapperTransform.GetOutputSchema(inputSchema, mapper);
         }
 
-        public IDataView Transform(IDataView input) => MakeDataTransform(input);
+        public IDataView Transform(IDataView input) => MakeDataTransformCore(input);
 
-        [BestFriend]
+        private protected virtual IDataView MakeDataTransformCore(IDataView input) => MakeDataTransform(input);
+
+        [BestFriend] // MYTODO: Since this is "BestFriend" here, should I also make the MakeDataTransformCore in OnnxDataTransform a "BestFriend"? What's the purpose?
         private protected RowToRowMapperTransform MakeDataTransform(IDataView input)
         {
             Host.CheckValue(input, nameof(input));

--- a/src/Microsoft.ML.OnnxTransformer/OnnxUtils.cs
+++ b/src/Microsoft.ML.OnnxTransformer/OnnxUtils.cs
@@ -26,7 +26,7 @@ namespace Microsoft.ML.Transforms.Onnx
     {
         /// <summary>
         /// OnnxModelInfo contains the data that we should get from
-        /// OnnxRuntime API once that functionality is added.
+        /// the OnnxRuntime API
         /// </summary>
         public sealed class OnnxModelInfo
         {

--- a/test/Microsoft.ML.OnnxTransformerTest/OnnxTransformTests.cs
+++ b/test/Microsoft.ML.OnnxTransformerTest/OnnxTransformTests.cs
@@ -139,6 +139,19 @@ namespace Microsoft.ML.Tests
             }
             catch (ArgumentOutOfRangeException) { }
             catch (InvalidOperationException) { }
+
+            try
+            {
+                // MYTODO: Is this side effect acceptable? Should I remove this from this test?
+                // OnnxTransformer will drop all the columns in the input that have
+                // a corresponding input in the onnx model.
+                // A side effect of this, is that after applying a pretrained onnx model
+                // like the one in here, we won't be able to use or access the input
+                // columns of the model.
+                var transformedData = pipe.Fit(dataView).Transform(dataView);
+                var col = transformedData.Schema["data_0"];
+            }
+            catch (ArgumentOutOfRangeException) { }
         }
 
         [OnnxTheory]


### PR DESCRIPTION
Fixes #4970 

After discussing this issue with @harishsk we agreed that the way to go is to drop all the input columns that are used as inputs of the onnx model that is applied by an `OnnxTransformer`. I've added the `ColumnSelectingOnnxTestColumnPropagation` where I explain and show more clearly what effects this has on different scenarios.

Since the `OnnxTransformer` is a `RowToRowTransformerBase`, it can't drop columns only add columns. In fact, it seems that there's no transformer that do both dropping and adding columns.

To solve this, changes needed to be made in `RowToRowTransformerBase `to let `OnnxTransformer `override some methods, so that it can have more control on the output schema. This way the `OnnxTransformer `now creates a `OnnxDataTransform `which in turn uses the same `OnnxTransformer.Mapper `that always existed, but now it also uses a `OnnxTransformer.Bindings` that enable dropping columns while also adding the new columns added by the mapper. This is different from the previous behavior, where the `RowToRowTransformerBase `would return a `RowToRowMapperTransform `which used the typical `ColumnBindings `which only add columns to the input but don't drop columns from it.

NOTE: I have left several "//MYTODO" comments with thoughts and questions for myself, which shall be removed before merging this PR. I've also added some comments here on GitHub pointing to the thoughts and questions that I find more important to address first.
