### PR TITLE
Fixing build in UNIX systems that don't have en-US as default culture

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -7,6 +7,9 @@ export DOTNET_CLI_TELEMETRY_OPTOUT=1
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 export DOTNET_MULTILEVEL_LOOKUP=0
 
+# Set the terminal language to en-US in order to avoid problems with MSBuild compareversion command
+export LANG=en_US.UTF-8
+
 # Source the init-tools.sh script rather than execute in order to preserve ulimit values in child-processes. https://github.com/dotnet/corefx/issues/19152
 . "$__scriptpath/init-tools.sh"
 


### PR DESCRIPTION
This Pull Request fixes #5016 as is set the language to en-US for the shell session, fixing the build problem existing in the cultures that uses comma as decimal separator.

