### PR TITLE
LoadColumnName support in TextLoader and auto map class members 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -330,3 +330,6 @@ ASALocalRun/
 *.binlog
 # Ignore external test datasets.
 /test/data/external/
+
+# Ignore Mac DS_Store files
+.DS_Store

--- a/Microsoft.ML.sln
+++ b/Microsoft.ML.sln
@@ -94,7 +94,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.ML.CpuMath.Perfor
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.ML.CpuMath.UnitTests", "test\Microsoft.ML.CpuMath.UnitTests\Microsoft.ML.CpuMath.UnitTests.csproj", "{E97D8B5A-3035-4D41-9B0D-77FF8FB8D132}"
 EndProject
-Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Microsoft.ML.FSharp.Tests", "test\Microsoft.ML.FSharp.Tests\Microsoft.ML.FSharp.Tests.fsproj", "{802233D6-8CC0-46AD-9F23-FEE1E9AED9B3}"
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Microsoft.ML.FSharp.Tests", "test\Microsoft.ML.FSharp.Tests\Microsoft.ML.FSharp.Tests.fsproj", "{802233D6-8CC0-46AD-9F23-FEE1E9AED9B3}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.ML.ImageAnalytics", "src\Microsoft.ML.ImageAnalytics\Microsoft.ML.ImageAnalytics.csproj", "{00E38F77-1E61-4CDF-8F97-1417D4E85053}"
 EndProject

--- a/src/Microsoft.ML.Data/DataLoadSave/Database/LoadColumnNameAttribute.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Database/LoadColumnNameAttribute.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 namespace Microsoft.ML.Data
 {
     /// <summary>
-    /// Allow member to specify mapping to field(s) in database.
+    /// Allow member to specify mapping to field(s) in database or text file.
     /// To override name of <see cref="IDataView"/> column use <see cref="ColumnNameAttribute"/>.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false, Inherited = true)]

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/LoadColumnIgnoreAttribute.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/LoadColumnIgnoreAttribute.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.ML.Data
+{
+    /// <summary>
+    /// Allow member to be ignored in mapping to text file.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
+    public sealed class LoadColumnIgnoreAttribute : Attribute
+    {
+        /// <summary>
+        /// Ignore member
+        /// </summary>
+        /// <param name="ignore">If the member should be ignored</param>
+        public LoadColumnIgnoreAttribute(bool ignore = true)
+        {
+            Ignore = ignore;
+        }
+
+        internal bool Ignore;
+    }
+}

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
@@ -1513,6 +1513,16 @@ namespace Microsoft.ML.Data
         /// </example>
         public IDataView Load(IMultiStreamSource source) => new BoundLoader(this, source);
 
+        // 1.4.0 BACKCOMPAT OVERLOAD -- DO NOT TOUCH
+        internal static TextLoader CreateTextLoader<TInput>(IHostEnvironment host,
+           bool hasHeader,
+           char separator,
+           bool allowQuoting,
+           bool supportSparse,
+           bool trimWhitespace,
+           IMultiStreamSource dataSample = null)
+           => CreateTextLoader<TInput>(host, hasHeader, separator, allowQuoting, supportSparse, trimWhitespace, Defaults.AutoMapLoadColumns, dataSample);
+
         internal static TextLoader CreateTextLoader<TInput>(IHostEnvironment host,
            bool hasHeader = Defaults.HasHeader,
            char separator = Defaults.Separator,

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderParser.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderParser.cs
@@ -575,7 +575,7 @@ namespace Microsoft.ML.Data
             /// This holds a set of raw text fields. This is the input into the parsing
             /// of the individual typed values.
             /// </summary>
-            private sealed class FieldSet
+            internal sealed class FieldSet
             {
                 public int Count;
 
@@ -725,12 +725,9 @@ namespace Microsoft.ML.Data
                 }
             }
 
-            public static void ParseSlotNames(TextLoader parent, ReadOnlyMemory<char> textHeader, ColInfo[] infos, VBuffer<ReadOnlyMemory<char>>[] slotNames)
+            public static FieldSet GetHeaderFields(TextLoader parent, ReadOnlyMemory<char> textHeader)
             {
                 Contracts.Assert(!textHeader.IsEmpty);
-                Contracts.Assert(infos.Length == slotNames.Length);
-
-                var sb = new StringBuilder();
                 var stats = new ParseStats(parent._host, cref: 1, maxShow: 0);
                 var impl = new HelperImpl(stats, parent._flags, parent._separators, parent._inputSize, int.MaxValue);
                 try
@@ -742,7 +739,14 @@ namespace Microsoft.ML.Data
                     stats.Release();
                 }
 
-                var header = impl.Fields;
+                return impl.Fields;
+            }
+
+            public static void ParseSlotNames(TextLoader parent, ReadOnlyMemory<char> textHeader, ColInfo[] infos, VBuffer<ReadOnlyMemory<char>>[] slotNames)
+            {
+                Contracts.Assert(infos.Length == slotNames.Length);
+
+                var header = GetHeaderFields(parent, textHeader);
                 var bldr = BufferBuilder<ReadOnlyMemory<char>>.CreateDefault();
                 for (int iinfo = 0; iinfo < infos.Length; iinfo++)
                 {

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
@@ -85,6 +85,16 @@ namespace Microsoft.ML
             IMultiStreamSource dataSample = null)
             => new TextLoader(CatalogUtils.GetEnvironment(catalog), options, dataSample);
 
+        // 1.4.0 BACKCOMPAT OVERLOAD -- DO NOT TOUCH
+        public static TextLoader CreateTextLoader<TInput>(this DataOperationsCatalog catalog,
+            char separatorChar,
+            bool hasHeader,
+            IMultiStreamSource dataSample,
+            bool allowQuoting,
+            bool trimWhitespace,
+            bool allowSparse)
+            => CreateTextLoader<TInput>(catalog, separatorChar, hasHeader, dataSample, allowQuoting, trimWhitespace, allowSparse, default);
+
         /// <summary>
         /// Create a text loader <see cref="TextLoader"/> by inferencing the dataset schema from a data model type.
         /// </summary>
@@ -174,6 +184,16 @@ namespace Microsoft.ML
             var loader = new TextLoader(CatalogUtils.GetEnvironment(catalog), options: options, dataSample: source);
             return loader.Load(source);
         }
+
+        // 1.4.0 BACKCOMPAT OVERLOAD -- DO NOT TOUCH
+        public static IDataView LoadFromTextFile<TInput>(this DataOperationsCatalog catalog,
+            string path,
+            char separatorChar,
+            bool hasHeader,
+            bool allowQuoting,
+            bool trimWhitespace,
+            bool allowSparse)
+            => LoadFromTextFile<TInput>(catalog, path, separatorChar, hasHeader, allowQuoting, trimWhitespace, allowSparse, default);
 
         /// <summary>
         /// Load a <see cref="IDataView"/> from a text file using <see cref="TextLoader"/>.

--- a/test/Microsoft.ML.Tests/TextLoaderTests.cs
+++ b/test/Microsoft.ML.Tests/TextLoaderTests.cs
@@ -740,6 +740,7 @@ namespace Microsoft.ML.EntryPoints.Tests
             [LoadColumnName("native-country")]
             public float NativeCountry { get; set; }
 
+            [LoadColumnName("label(IsOver50K)")]
             public bool IsOver50K { get; set; }
         }
 


### PR DESCRIPTION
This pull request resolves #4480.

These features were add in this pull request:
* Support of `LoadColumnName` attribute in `TextLoader` class (when loaded file has headers).
* Possibility to ignore a member when using `CreateTextLoader` using the `LoadColumnIgnoreAttribute`
* Feature to map the `TInput` properties/fields name to column of TextLoader (when loaded file has headers)
