### PR TITLE
move ubuntu and centos to agent pool with larger disk space

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -29,7 +29,8 @@ jobs:
         _targetFramework: netcoreapp3.1
     innerLoop: true
     pool:
-      name: Hosted Ubuntu 1604
+      name:  NetCorePublic-Pool
+      queue: BuildPool.Ubuntu.1604.Amd64.Open
 
 - template: /build/ci/job-template.yml
   parameters:
@@ -38,7 +39,8 @@ jobs:
     container: UbuntuContainer
     innerLoop: true
     pool:
-      name: Hosted Ubuntu 1604
+      name:  NetCorePublic-Pool
+      queue: BuildPool.Ubuntu.1604.Amd64.Open
 
 - template: /build/ci/job-template.yml
   parameters:

--- a/build/.night-build.yml
+++ b/build/.night-build.yml
@@ -47,7 +47,8 @@ jobs:
         _includeBenchmarkData: true
     nightlyBuild: true
     pool:
-      name: Hosted Ubuntu 1604
+      name:  NetCorePublic-Pool
+      queue: BuildPool.Ubuntu.1604.Amd64.Open
 
 - template: /build/ci/job-template.yml
   parameters:
@@ -56,7 +57,8 @@ jobs:
     container: UbuntuContainer
     nightlyBuild: true
     pool:
-      name: Hosted Ubuntu 1604
+      name:  NetCorePublic-Pool
+      queue: BuildPool.Ubuntu.1604.Amd64.Open
 
 - template: /build/ci/job-template.yml
   parameters:

--- a/build/.outer-loop-build.yml
+++ b/build/.outer-loop-build.yml
@@ -45,7 +45,8 @@ jobs:
         _config_short: RI
         _includeBenchmarkData: true
     pool:
-      name: Hosted Ubuntu 1604
+      name:  NetCorePublic-Pool
+      queue: BuildPool.Ubuntu.1604.Amd64.Open
 
 - template: /build/ci/job-template.yml
   parameters:
@@ -53,7 +54,8 @@ jobs:
     buildScript: ./build.sh
     container: UbuntuContainer
     pool:
-      name: Hosted Ubuntu 1604
+      name:  NetCorePublic-Pool
+      queue: BuildPool.Ubuntu.1604.Amd64.Open
 
 - template: /build/ci/job-template.yml
   parameters:

--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -52,7 +52,7 @@ jobs:
     - ${{ if eq(parameters.pool.name, 'Hosted macOS') }}:
       - script: brew update && brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/f5b1ac99a7fba27c19cee0bc4f036775c889b359/Formula/libomp.rb && brew unlink python@2 && brew install mono-libgdiplus gettext && brew link gettext --force && brew link libomp --force
         displayName: Install build dependencies
-    - ${{ if and( eq(parameters.nightlyBuild, 'true'), eq(parameters.pool.name, 'Hosted Ubuntu 1604')) }}:
+    - ${{ if and( eq(parameters.nightlyBuild, 'true'), eq(parameters.pool.queue, 'BuildPool.Ubuntu.1604.Amd64.Open')) }}:
       - bash: echo "##vso[task.setvariable variable=LD_LIBRARY_PATH]$(nightlyBuildRunPath):$LD_LIBRARY_PATH"
         displayName: Set LD_LIBRARY_PATH for Ubuntu and CentOS to locate Native shared library in current running path
     - script: ${{ parameters.buildScript }} -$(_configuration) -buildArch=${{ parameters.architecture }}


### PR DESCRIPTION
Ubuntu and CentOS is facing disk space issue, move to agent pool with larger disk space, this pool has 120 machines so should be good for use:

https://helix.dot.net/api/2019-06-17/info/queues

"Purpose": "Build",
    "Architecture": "AMD64",
    "IsAvailable": true,
    "IsInternalOnly": true,
    "IsOnPremises": false,
    "OperatingSystemGroup": "linux",
    "PreInstalledImage": null,
    "PreparedImage": null,
    "QueueId": "BuildPool.Ubuntu.1604.Amd64.Open",
    "QueueDepth": 0,
    "ScaleMin": 0,
    **"ScaleMax": 120,**
    "UserList": "helix-buildagent-bot",
    "WorkspacePath": "/datadisks/disk1/workspace"

