### PR TITLE
Handle NaN optimization metric in AutoML

### DIFF
--- a/src/Microsoft.ML.AutoML/Experiment/Runners/CrossValRunner.cs
+++ b/src/Microsoft.ML.AutoML/Experiment/Runners/CrossValRunner.cs
@@ -66,11 +66,11 @@ namespace Microsoft.ML.AutoML
 
         private static double CalcAverageScore(IEnumerable<double> scores)
         {
-            if (scores.Any(s => double.IsNaN(s)))
-            {
+            var newScores = scores.Where(r => !double.IsNaN(r));
+            // Return NaN iff all scores are NaN
+            if (newScores.Count() == 0)
                 return double.NaN;
-            }
-            return scores.Average();
+            return newScores.Average();
         }
     }
 }

--- a/src/Microsoft.ML.AutoML/Experiment/Runners/CrossValSummaryRunner.cs
+++ b/src/Microsoft.ML.AutoML/Experiment/Runners/CrossValSummaryRunner.cs
@@ -6,7 +6,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Microsoft.ML.Data;
 using Microsoft.ML.Runtime;
+using Microsoft.ML.Trainers.FastTree;
 
 namespace Microsoft.ML.AutoML
 {
@@ -90,7 +92,7 @@ namespace Microsoft.ML.AutoML
         {
             var newResults = results.Where(r => !double.IsNaN(r.score));
             // Return NaN iff all scores are NaN
-            if (newResults.Count() ==0)
+            if (newResults.Count() == 0)
                 return double.NaN;
             // Return average of non-NaN scores otherwise
             return newResults.Average(r => r.score);

--- a/src/Microsoft.ML.AutoML/Experiment/Runners/CrossValSummaryRunner.cs
+++ b/src/Microsoft.ML.AutoML/Experiment/Runners/CrossValSummaryRunner.cs
@@ -6,9 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Microsoft.ML.Data;
 using Microsoft.ML.Runtime;
-using Microsoft.ML.Trainers.FastTree;
 
 namespace Microsoft.ML.AutoML
 {

--- a/src/Microsoft.ML.AutoML/Experiment/Runners/CrossValSummaryRunner.cs
+++ b/src/Microsoft.ML.AutoML/Experiment/Runners/CrossValSummaryRunner.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Google.Protobuf.WellKnownTypes;
 using Microsoft.ML.Runtime;
 
 namespace Microsoft.ML.AutoML

--- a/src/Microsoft.ML.AutoML/Experiment/Runners/CrossValSummaryRunner.cs
+++ b/src/Microsoft.ML.AutoML/Experiment/Runners/CrossValSummaryRunner.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Microsoft.ML.Data;
 using Microsoft.ML.Runtime;
 
 namespace Microsoft.ML.AutoML
@@ -70,6 +71,9 @@ namespace Microsoft.ML.AutoML
 
             // Get the model from the best fold
             var bestFoldIndex = BestResultUtil.GetIndexOfBestScore(trainResults.Select(r => r.score), _optimizingMetricInfo.IsMaximizing);
+            // bestFoldIndex will be -1 if the optimization metric for all folds is NaN.
+            // In this case, return model from the first fold.
+            bestFoldIndex = bestFoldIndex != -1 ? bestFoldIndex : 0;
             var bestModel = trainResults.ElementAt(bestFoldIndex).model;
 
             // Get the metrics from the fold whose score is closest to avg of all fold scores

--- a/src/Microsoft.ML.AutoML/Experiment/Runners/CrossValSummaryRunner.cs
+++ b/src/Microsoft.ML.AutoML/Experiment/Runners/CrossValSummaryRunner.cs
@@ -141,7 +141,7 @@ namespace Microsoft.ML.AutoML
                 return result as TMetrics;
             }
 
-            return null;
+            throw new NotImplementedException($"Metric {typeof(TMetrics)} not implemented");
         }
 
         private static double GetAverageOfNonNaNScores(IEnumerable<double> results)

--- a/src/Microsoft.ML.AutoML/Utils/BestResultUtil.cs
+++ b/src/Microsoft.ML.AutoML/Utils/BestResultUtil.cs
@@ -4,9 +4,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using Microsoft.ML.Data;
-using Microsoft.ML.Internal.CpuMath.Core;
 
 namespace Microsoft.ML.AutoML
 {

--- a/src/Microsoft.ML.AutoML/Utils/BestResultUtil.cs
+++ b/src/Microsoft.ML.AutoML/Utils/BestResultUtil.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Microsoft.ML.Data;
 using Microsoft.ML.Internal.CpuMath.Core;
 
@@ -42,8 +43,9 @@ namespace Microsoft.ML.AutoML
             if (!results.Any()) { return null; }
             var scores = results.Select(r => metricsAgent.GetScore(r.ValidationMetrics));
             var indexOfBestScore = GetIndexOfBestScore(scores, isMetricMaximizing);
-            Contracts.Check(indexOfBestScore != -1,
-                "The optimization metric in all runs was undefined. A best run could not be found.");
+            // indexOfBestScore will be -1 if the optimization metric for all models is NaN.
+            // In this case, return the first model.
+            indexOfBestScore = indexOfBestScore != -1 ? indexOfBestScore : 0;
             return results.ElementAt(indexOfBestScore);
         }
 
@@ -54,8 +56,9 @@ namespace Microsoft.ML.AutoML
             if (!results.Any()) { return null; }
             var scores = results.Select(r => r.Results.Average(x => metricsAgent.GetScore(x.ValidationMetrics)));
             var indexOfBestScore = GetIndexOfBestScore(scores, isMetricMaximizing);
-            Contracts.Check(indexOfBestScore != -1,
-                "The average optimization metric in all runs was undefined. A best run could not be found.");
+            // indexOfBestScore will be -1 if the optimization metric for all models is NaN.
+            // In this case, return the first model.
+            indexOfBestScore = indexOfBestScore != -1 ? indexOfBestScore : 0;
             return results.ElementAt(indexOfBestScore);
         }
 

--- a/src/Microsoft.ML.AutoML/Utils/BestResultUtil.cs
+++ b/src/Microsoft.ML.AutoML/Utils/BestResultUtil.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.ML.Data;
+using Microsoft.ML.Internal.CpuMath.Core;
 
 namespace Microsoft.ML.AutoML
 {
@@ -41,6 +42,8 @@ namespace Microsoft.ML.AutoML
             if (!results.Any()) { return null; }
             var scores = results.Select(r => metricsAgent.GetScore(r.ValidationMetrics));
             var indexOfBestScore = GetIndexOfBestScore(scores, isMetricMaximizing);
+            Contracts.Check(indexOfBestScore != -1,
+                "The optimization metric in all runs was undefined. A best run could not be found.");
             return results.ElementAt(indexOfBestScore);
         }
 
@@ -51,6 +54,8 @@ namespace Microsoft.ML.AutoML
             if (!results.Any()) { return null; }
             var scores = results.Select(r => r.Results.Average(x => metricsAgent.GetScore(x.ValidationMetrics)));
             var indexOfBestScore = GetIndexOfBestScore(scores, isMetricMaximizing);
+            Contracts.Check(indexOfBestScore != -1,
+                "The average optimization metric in all runs was undefined. A best run could not be found.");
             return results.ElementAt(indexOfBestScore);
         }
 

--- a/src/Microsoft.ML.Data/Evaluators/Metrics/BinaryClassificationMetrics.cs
+++ b/src/Microsoft.ML.Data/Evaluators/Metrics/BinaryClassificationMetrics.cs
@@ -122,5 +122,12 @@ namespace Microsoft.ML.Data
             F1Score = f1Score;
             AreaUnderPrecisionRecallCurve = auprc;
         }
+
+        internal BinaryClassificationMetrics(double auc, double accuracy, double positivePrecision, double positiveRecall,
+            double negativePrecision, double negativeRecall, double f1Score, double auprc, ConfusionMatrix confusionMatrix)
+            : this(auc, accuracy, positivePrecision, positiveRecall, negativePrecision, negativeRecall, f1Score, auprc)
+        {
+            ConfusionMatrix = confusionMatrix;
+        }
     }
 }

--- a/src/Microsoft.ML.Data/Evaluators/Metrics/MulticlassClassificationMetrics.cs
+++ b/src/Microsoft.ML.Data/Evaluators/Metrics/MulticlassClassificationMetrics.cs
@@ -134,5 +134,12 @@ namespace Microsoft.ML.Data
             TopKAccuracy = topKAccuracy;
             PerClassLogLoss = perClassLogLoss.ToImmutableArray();
         }
+
+        internal MulticlassClassificationMetrics(double accuracyMicro, double accuracyMacro, double logLoss, double logLossReduction,
+            int topKPredictionCount, double topKAccuracy, double[] perClassLogLoss, ConfusionMatrix confusionMatrix)
+            : this(accuracyMicro, accuracyMacro, logLoss, logLossReduction, topKPredictionCount, topKAccuracy, perClassLogLoss)
+        {
+            ConfusionMatrix = confusionMatrix;
+        }
     }
 }


### PR DESCRIPTION
Fixes #4663 
Fixes #5042

In AutoML, `CrossValSummaryRunner` is invoked if the dataset contains less than 15000 rows. It runs 10-fold cross validation on it, and then returns the model from the fold with the best optimization metric. It does this by looking for the index of the model with the best metric in the list of run results, and returning the element at this index.

If the metric in all 10 folds is `NaN`, then this index is `-1`, resulting in an `IndexOutOfRangeException`.