### PR TITLE
clarifying parameters on time series

### DIFF
--- a/src/Microsoft.ML.TimeSeries/AdaptiveSingularSpectrumSequenceModeler.cs
+++ b/src/Microsoft.ML.TimeSeries/AdaptiveSingularSpectrumSequenceModeler.cs
@@ -209,9 +209,13 @@ namespace Microsoft.ML.Transforms.TimeSeries
         /// The constructor for Adaptive SSA model.
         /// </summary>
         /// <param name="env">The exception context.</param>
-        /// <param name="trainSize">The length of series from the beginning used for training. (parameter N)</param>
+        /// <param name="trainSize">The length of series from the beginning used for training (parameter N).
+        ///  Must be at least twice the windowSize.!-- </param>
         /// <param name="seriesLength">This parameter must be greater than windowSize</param>
-        /// <param name="windowSize">The length of the window on the series for building the trajectory matrix (parameter L). Should be more than twice the maximum seasonality in the data.</param>
+        /// <param name="windowSize">The length of the window on the series for building the trajectory matrix (parameter L).
+        ///  We recommend you set this to be more than twice the maximum seasonality in the data. For example, 
+        /// if your data can exhibit both monthly and yearly seasonality, and you have data points from each day, 
+        /// set this to be twice the number of days in a year.</param>
         /// <param name="discountFactor">The discount factor in [0,1] used for online updates (default = 1).</param>
         /// <param name="rankSelectionMethod">The rank selection method (default = Exact).</param>
         /// <param name="rank">The desired rank of the subspace used for SSA projection (parameter r). This parameter should be in the range in [1, windowSize].

--- a/src/Microsoft.ML.TimeSeries/AdaptiveSingularSpectrumSequenceModeler.cs
+++ b/src/Microsoft.ML.TimeSeries/AdaptiveSingularSpectrumSequenceModeler.cs
@@ -209,9 +209,9 @@ namespace Microsoft.ML.Transforms.TimeSeries
         /// The constructor for Adaptive SSA model.
         /// </summary>
         /// <param name="env">The exception context.</param>
-        /// <param name="trainSize">The length of series from the beginning used for training.</param>
-        /// <param name="seriesLength">The length of series that is kept in buffer for modeling (parameter N).</param>
-        /// <param name="windowSize">The length of the window on the series for building the trajectory matrix (parameter L).</param>
+        /// <param name="trainSize">The length of series from the beginning used for training. (parameter N)</param>
+        /// <param name="seriesLength">This parameter must be greater than windowSize</param>
+        /// <param name="windowSize">The length of the window on the series for building the trajectory matrix (parameter L). Should be more than twice the maximum seasonality in the data.</param>
         /// <param name="discountFactor">The discount factor in [0,1] used for online updates (default = 1).</param>
         /// <param name="rankSelectionMethod">The rank selection method (default = Exact).</param>
         /// <param name="rank">The desired rank of the subspace used for SSA projection (parameter r). This parameter should be in the range in [1, windowSize].

--- a/src/Microsoft.ML.TimeSeries/AdaptiveSingularSpectrumSequenceModeler.cs
+++ b/src/Microsoft.ML.TimeSeries/AdaptiveSingularSpectrumSequenceModeler.cs
@@ -210,7 +210,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
         /// </summary>
         /// <param name="env">The exception context.</param>
         /// <param name="trainSize">The length of series from the beginning used for training (parameter N).
-        ///  Must be at least twice the windowSize.!-- </param>
+        /// Must be at least twice the windowSize.</param>
         /// <param name="seriesLength">This parameter must be greater than windowSize</param>
         /// <param name="windowSize">The length of the window on the series for building the trajectory matrix (parameter L).
         ///  We recommend you set this to be more than twice the maximum seasonality in the data. For example, 

--- a/src/Microsoft.ML.TimeSeries/AdaptiveSingularSpectrumSequenceModeler.cs
+++ b/src/Microsoft.ML.TimeSeries/AdaptiveSingularSpectrumSequenceModeler.cs
@@ -214,7 +214,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
         /// <param name="seriesLength">This parameter must be greater than windowSize.</param>
         /// <param name="windowSize">The length of the window on the series for building the trajectory matrix (parameter L).
         /// We recommend you set this to be more than twice the maximum seasonality in the data. For example,
-        /// if your data can exhibit both monthly and yearly seasonality, and you have data points from each day, 
+        /// if your data can exhibit both monthly and yearly seasonality, and you have data points from each day,
         /// set this to be twice the number of days in a year.</param>
         /// <param name="discountFactor">The discount factor in [0,1] used for online updates (default = 1).</param>
         /// <param name="rankSelectionMethod">The rank selection method (default = Exact).</param>

--- a/src/Microsoft.ML.TimeSeries/AdaptiveSingularSpectrumSequenceModeler.cs
+++ b/src/Microsoft.ML.TimeSeries/AdaptiveSingularSpectrumSequenceModeler.cs
@@ -213,7 +213,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
         /// Must be at least twice the windowSize.</param>
         /// <param name="seriesLength">This parameter must be greater than windowSize.</param>
         /// <param name="windowSize">The length of the window on the series for building the trajectory matrix (parameter L).
-        ///  We recommend you set this to be more than twice the maximum seasonality in the data. For example, 
+        /// We recommend you set this to be more than twice the maximum seasonality in the data. For example,
         /// if your data can exhibit both monthly and yearly seasonality, and you have data points from each day, 
         /// set this to be twice the number of days in a year.</param>
         /// <param name="discountFactor">The discount factor in [0,1] used for online updates (default = 1).</param>

--- a/src/Microsoft.ML.TimeSeries/AdaptiveSingularSpectrumSequenceModeler.cs
+++ b/src/Microsoft.ML.TimeSeries/AdaptiveSingularSpectrumSequenceModeler.cs
@@ -211,7 +211,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
         /// <param name="env">The exception context.</param>
         /// <param name="trainSize">The length of series from the beginning used for training (parameter N).
         /// Must be at least twice the windowSize.</param>
-        /// <param name="seriesLength">This parameter must be greater than windowSize</param>
+        /// <param name="seriesLength">This parameter must be greater than windowSize.</param>
         /// <param name="windowSize">The length of the window on the series for building the trajectory matrix (parameter L).
         ///  We recommend you set this to be more than twice the maximum seasonality in the data. For example, 
         /// if your data can exhibit both monthly and yearly seasonality, and you have data points from each day, 


### PR DESCRIPTION
We are excited to review your PR.

Some context:

Also note that, here we are talking about three different parameters:
1.	seriesLength is the length of the whole timeseries.
2.	trainSize is the number of points from the beginning of the series that are used for training.
3.	windowSize is the size of rolling window during the training of SSA.

The first parameter is dictated by the series and even though it’s not used in SSA, it’s not meaningful for the user to “set” it arbitrarily. The third parameter is *recommended* to be at least twice as the biggest seasonality in the data that the user care about. The second parameter must be more twice the third parameter. 

So to summarize we should have:
1.	2*Seasonality length < windowSize
2.	2*windowSize < trainSize
3.	trainSize < seriesLength

The first constraint is recommended while the other two are required.

So we can do the best job, please check:

- [x] There's a descriptive title that will make sense to other developers some time from now. 
- [x] There's associated issues. All PR's should have issue(s) associated - unless a trivial self-evident change such as fixing a typo. You can use the format `Fixes #nnnn` in your description to cause GitHub to automatically close the issue(s) when your PR is merged.
- [x] Your change description explains what the change does, why you chose your approach, and anything else that reviewers should know.
- [x] You have included any necessary tests in the same PR.

