### PR TITLE
Converted potentially large variables to type long

### DIFF
--- a/src/Microsoft.ML.StandardTrainers/Standard/MulticlassClassification/MulticlassNaiveBayesTrainer.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/MulticlassClassification/MulticlassNaiveBayesTrainer.cs
@@ -259,12 +259,26 @@ namespace Microsoft.ML.Trainers
         /// <summary>
         /// Get the label histogram.
         /// </summary>
-        public IReadOnlyList<long> GetLabelHistogram() => _labelHistogram;
+        [Obsolete("This API is deprecated, please use GetLabelHistogramLong() which returns _labelHistogram " +
+            "with type IReadOnlyList<long> to avoid overflow errors with large datasets.", true)]
+        public IReadOnlyList<int> GetLabelHistogram() => Array.ConvertAll(_labelHistogram, x => (int)x);
+
+        /// <summary>
+        /// Get the label histogram with generic type long.
+        /// </summary>
+        public IReadOnlyList<long> GetLabelHistogramLong() => _labelHistogram;
 
         /// <summary>
         /// Get the feature histogram.
         /// </summary>
-        public IReadOnlyList<IReadOnlyList<long>> GetFeatureHistogram() => _featureHistogram;
+        [Obsolete("This API is deprecated, please use GetFeatureHistogramLong() which returns _featureHistogram " +
+            "with type IReadOnlyList<long> to avoid overflow errors with large datasets.", true)]
+        public IReadOnlyList<IReadOnlyList<int>> GetFeatureHistogram() => Array.ConvertAll(_featureHistogram, x => Array.ConvertAll(x, y=> (int)y));
+
+        /// <summary>
+        /// Get the feature histogram with generic type long.
+        /// </summary>
+        public IReadOnlyList<IReadOnlyList<long>> GetFeatureHistogramLong() => _featureHistogram;
 
         /// <summary>
         /// Instantiates new model parameters from trained model.

--- a/src/Microsoft.ML.StandardTrainers/Standard/MulticlassClassification/MulticlassNaiveBayesTrainer.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/MulticlassClassification/MulticlassNaiveBayesTrainer.cs
@@ -305,6 +305,11 @@ namespace Microsoft.ML.Trainers
             _outputType = new VectorDataViewType(NumberDataViewType.Single, _labelCount);
         }
 
+        /// <remarks>
+        /// The unit test TestEntryPoints.LoadEntryPointModel() exercises the ReadIntArrary(int size) codepath below
+        /// as its ctx.Header.ModelVerWritten is 0x00010001, and the persistent model that gets loaded and executed
+        /// for this unit test is located at test\data\backcompat\ep_model3.zip/>
+        /// </remarks>
         private NaiveBayesMulticlassModelParameters(IHostEnvironment env, ModelLoadContext ctx)
             : base(env, LoaderSignature, ctx)
         {


### PR DESCRIPTION
Fixes #3228

As explained in Issue #3228, very large datasets more than 2.14 billion rows of data can cause overflow when, say, the sum of these labels are obtained, **and** if these are stored as ints. This PR converts arrays and matrices for storing labels and features in their respective histograms from type `int` to type `long`. In addition, this PR updates the version of NaiveBayesMulticlassTrainer's Loader to preserve backwards compatibility. 