### PR TITLE
Let ImageLoadingTransformer dispose the last image it loads

### DIFF
--- a/src/Microsoft.ML.ImageAnalytics/ImageLoader.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ImageLoader.cs
@@ -217,7 +217,17 @@ namespace Microsoft.ML.Data
             {
                 Contracts.AssertValue(input);
                 Contracts.Assert(0 <= iinfo && iinfo < _parent.ColumnPairs.Length);
-                disposer = null;
+                var lastImage = default(Bitmap);
+
+                disposer = () =>
+                {
+                    if (lastImage != null)
+                    {
+                        lastImage.Dispose();
+                        lastImage = null;
+                    }
+                };
+
                 var getSrc = input.GetGetter<ReadOnlyMemory<char>>(input.Schema[ColMapNewToOld[iinfo]]);
                 ReadOnlyMemory<char> src = default;
                 ValueGetter<Bitmap> del =
@@ -247,6 +257,8 @@ namespace Microsoft.ML.Data
                             if (dst.PixelFormat == System.Drawing.Imaging.PixelFormat.DontCare)
                                 throw Host.Except($"Failed to load image {src.ToString()}.");
                         }
+
+                        lastImage = dst;
                     };
 
                 return del;

--- a/src/Microsoft.ML.ImageAnalytics/ImageResizer.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ImageResizer.cs
@@ -285,7 +285,6 @@ namespace Microsoft.ML.Transforms.Image
                     {
                         if (src != null)
                         {
-                            src.Dispose();
                             src = null;
                         }
                     };

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -19,6 +19,7 @@ using Microsoft.ML.TestFrameworkCommon;
 using Microsoft.ML.Transforms;
 using Microsoft.ML.Transforms.Image;
 using Microsoft.ML.TensorFlow;
+using InMemoryImage = Microsoft.ML.Tests.ImageTests.InMemoryImage;
 using Xunit;
 using Xunit.Abstractions;
 using static Microsoft.ML.DataOperationsCatalog;
@@ -1124,52 +1125,6 @@ namespace Microsoft.ML.Scenarios
                     numRows += 1;
                 }
                 Assert.Equal(4, numRows);
-            }
-        }
-
-        public class InMemoryImage
-        {
-            [ImageType(229,299)]
-            public Bitmap LoadedImage;
-            public string Label;
-
-            public static List<InMemoryImage> LoadFromTsv(MLContext mlContext, string tsvPath, string imageFolder)
-            {
-                var inMemoryImages = new List<InMemoryImage>();
-                var tsvFile = mlContext.Data.LoadFromTextFile(tsvPath, columns: new[]
-                    {
-                            new TextLoader.Column("ImagePath", DataKind.String, 0),
-                            new TextLoader.Column("Label", DataKind.String, 1),
-                    }
-                );
-
-                using (var cursor = tsvFile.GetRowCursorForAllColumns())
-                {
-                    var pathBuffer = default(ReadOnlyMemory<char>);
-                    var labelBuffer = default(ReadOnlyMemory<char>);
-                    var pathGetter = cursor.GetGetter<ReadOnlyMemory<char>>(tsvFile.Schema["ImagePath"]);
-                    var labelGetter = cursor.GetGetter<ReadOnlyMemory<char>>(tsvFile.Schema["Label"]);
-                    while (cursor.MoveNext())
-                    {
-                        pathGetter(ref pathBuffer);
-                        labelGetter(ref labelBuffer);
-
-                        var label = labelBuffer.ToString();
-                        var fileName = pathBuffer.ToString();
-                        var imagePath = Path.Combine(imageFolder, fileName);
-
-                        inMemoryImages.Add(
-                                new InMemoryImage()
-                                {
-                                    Label = label,
-                                    LoadedImage = (Bitmap)Image.FromFile(imagePath)
-                                }
-                            );
-                    }
-                }
-
-                return inMemoryImages;
-
             }
         }
 


### PR DESCRIPTION
Fixes #4126.

By investigating issue #4126 I found out that `ImageResizingTransformer `disposed the last input Bitmap object it resized (i.e. _only_ the last image object in the input dataset). When working with in-memory images (i.e. NOT loaded with `ImageLoaderTransformer`) this is inadequate, since the `ImageResizingTransformer `will dispose the last image in the dataset, and the user won't be able to use that image again. Particullarly, issue #4126 happened when running Cross Validation with a pipeline that included applying `ImageResizingTransformer `to in memory images: when scoring the first model during cross validation, the last image of the input dataset got disposed, and when trying to score the second model, the image wasn't there, and a exception was thrown.

The only reason I found as to why `ImageResizingTransformer` had this behavior, is because `ImageLoadingTransformer` actually disposes all the images it loads except for the last one ([link](https://github.com/dotnet/machinelearning/blob/919bc8b886a6bc20c5022e8dad00f84bc1248236/src/Microsoft.ML.ImageAnalytics/ImageLoader.cs#L226-L230)). So assuming this is the only reason for `ImageResizingTransformer's `disposer, I simply moved the disposal mechanism of the last image to `ImageLoadingTransformer`.

I added two tests that used to throw exceptions without the changes on this PR. And I also manually tested with the debugger's profiler that the last image got correctly disposed when using `ImageLoadingTransformer`.