### PR TITLE
Added logging for when specific configuration baseline is used

### DIFF
--- a/test/Microsoft.ML.TestFramework/BaseTestBaseline.cs
+++ b/test/Microsoft.ML.TestFramework/BaseTestBaseline.cs
@@ -97,6 +97,7 @@ namespace Microsoft.ML.RunTests
             _baselineCommonDir = Path.Combine(baselineRootDir, "Common");
             _baselineBuildStringDir = Path.Combine(baselineRootDir, BuildString);
             _baselineConfigDirs = GetConfigurationDirs();
+            _usedSpecificBaselineConfigs = new HashSet<string>();
 
             string logDir = Path.Combine(OutDir, _logRootRelPath);
             Directory.CreateDirectory(logDir);

--- a/test/Microsoft.ML.TestFramework/BaseTestBaseline.cs
+++ b/test/Microsoft.ML.TestFramework/BaseTestBaseline.cs
@@ -75,7 +75,7 @@ namespace Microsoft.ML.RunTests
         private string _baselineCommonDir;
         private string _baselineBuildStringDir;
         private IEnumerable<string> _baselineConfigDirs;
-        private HashSet<string> _usedSpecificBaselineConfigs;
+        private string _usedSpecificBaselineConfig;
 
         // The writer to write to test log files.
         protected TestLogger TestLogger;
@@ -97,7 +97,6 @@ namespace Microsoft.ML.RunTests
             _baselineCommonDir = Path.Combine(baselineRootDir, "Common");
             _baselineBuildStringDir = Path.Combine(baselineRootDir, BuildString);
             _baselineConfigDirs = GetConfigurationDirs();
-            _usedSpecificBaselineConfigs = new HashSet<string>();
 
             string logDir = Path.Combine(OutDir, _logRootRelPath);
             Directory.CreateDirectory(logDir);
@@ -170,12 +169,11 @@ namespace Microsoft.ML.RunTests
                 _normal ? "completed normally" : "aborted",
                 IsPassing ? "passed" : "failed");
 
-            if (_usedSpecificBaselineConfigs.Count > 0)
+            if (_usedSpecificBaselineConfig != null)
             {
-                Log(String.Format("Test {0} is using {1} configuration specific baselines.", TestName,
-                    String.Join(",", _usedSpecificBaselineConfigs)));
+                Log(String.Format("Test {0} is using {1} configuration specific baselines.",
+                    TestName, _usedSpecificBaselineConfig));
             }
-            _usedSpecificBaselineConfigs.Clear();
 
             if (!_normal)
                 Assert.Equal(0, _failures);
@@ -269,7 +267,7 @@ namespace Microsoft.ML.RunTests
                 baselinePath = Path.GetFullPath(Path.Combine(_baselineCommonDir, subDir, baselineConfigDir, name));
                 if (File.Exists(baselinePath))
                 {
-                    _usedSpecificBaselineConfigs.Add(baselinePath);
+                    _usedSpecificBaselineConfig = baselineConfigDir;
                     return baselinePath;
                 }
             }
@@ -285,7 +283,7 @@ namespace Microsoft.ML.RunTests
                 baselinePath = Path.GetFullPath(Path.Combine(_baselineBuildStringDir, subDir, baselineConfigDir, name));
                 if (File.Exists(baselinePath))
                 {
-                    _usedSpecificBaselineConfigs.Add(baselinePath);
+                    _usedSpecificBaselineConfig = baselineConfigDir;
                     return baselinePath;
                 }
             }

--- a/test/Microsoft.ML.TestFramework/BaseTestBaseline.cs
+++ b/test/Microsoft.ML.TestFramework/BaseTestBaseline.cs
@@ -75,6 +75,7 @@ namespace Microsoft.ML.RunTests
         private string _baselineCommonDir;
         private string _baselineBuildStringDir;
         private IEnumerable<string> _baselineConfigDirs;
+        private HashSet<string> _usedSpecificBaselineConfigs;
 
         // The writer to write to test log files.
         protected TestLogger TestLogger;
@@ -168,6 +169,13 @@ namespace Microsoft.ML.RunTests
                 _normal ? "completed normally" : "aborted",
                 IsPassing ? "passed" : "failed");
 
+            if (_usedSpecificBaselineConfigs.Count > 0)
+            {
+                Log(String.Format("Test {0} is using {1} configuration specific baselines.", TestName,
+                    String.Join(",", _usedSpecificBaselineConfigs)));
+            }
+            _usedSpecificBaselineConfigs.Clear();
+
             if (!_normal)
                 Assert.Equal(0, _failures);
 
@@ -255,11 +263,14 @@ namespace Microsoft.ML.RunTests
             string baselinePath;
 
             // first check if a platform specific baseline exists
-            foreach (var baselineCOnfigDir in _baselineConfigDirs)
+            foreach (var baselineConfigDir in _baselineConfigDirs)
             {
-                baselinePath = Path.GetFullPath(Path.Combine(_baselineCommonDir, subDir, baselineCOnfigDir, name));
+                baselinePath = Path.GetFullPath(Path.Combine(_baselineCommonDir, subDir, baselineConfigDir, name));
                 if (File.Exists(baselinePath))
+                {
+                    _usedSpecificBaselineConfigs.Add(baselinePath);
                     return baselinePath;
+                }
             }
 
             // then check the common folder without a platform dir, and use it if it exists
@@ -268,11 +279,14 @@ namespace Microsoft.ML.RunTests
                 return baselinePath;
 
             // check again for a platform specific dir
-            foreach (var baselineCOnfigDir in _baselineConfigDirs)
+            foreach (var baselineConfigDir in _baselineConfigDirs)
             {
-                baselinePath = Path.GetFullPath(Path.Combine(_baselineBuildStringDir, subDir, baselineCOnfigDir, name));
+                baselinePath = Path.GetFullPath(Path.Combine(_baselineBuildStringDir, subDir, baselineConfigDir, name));
                 if (File.Exists(baselinePath))
+                {
+                    _usedSpecificBaselineConfigs.Add(baselinePath);
                     return baselinePath;
+                }
             }
 
             return Path.GetFullPath(Path.Combine(_baselineBuildStringDir, subDir, name));


### PR DESCRIPTION
Certain unit tests require configuration specific baselines, for when they differ from "normal" baselines. A unit test may also use more than one configuration, such as `linux-x64` and `netcoreapp31`. 

This PR adds logging for each unit test that utilizes a configuration specific baseline. This PR also corrects a small typo.