### PR TITLE
ColumnSelectingTransformer now infers ONNX shape

### DIFF
--- a/src/Microsoft.ML.Data/Transforms/ColumnSelecting.cs
+++ b/src/Microsoft.ML.Data/Transforms/ColumnSelecting.cs
@@ -741,7 +741,7 @@ namespace Microsoft.ML.Transforms
                         continue;
 
                     var srcVariable = ctx.GetVariableName(srcCol.Name);
-                    var dstVariable = ctx.AddIntermediateVariable(dstCol.Type, dstCol.Name, true);
+                    var dstVariable = ctx.AddIntermediateVariable(dstCol.Type, dstCol.Name);
                     string opType = "Identity";
                     ctx.CreateNode(opType, srcVariable, dstVariable, ctx.GetNodeName(opType), "");
                 }

--- a/test/BaselineOutput/Common/Onnx/Transforms/SelectColumns.txt
+++ b/test/BaselineOutput/Common/Onnx/Transforms/SelectColumns.txt
@@ -370,6 +370,78 @@
         }
       },
       {
+        "name": "Size1",
+        "type": {
+          "tensorType": {
+            "elemType": 1,
+            "shape": {
+              "dim": [
+                {
+                  "dimValue": "-1"
+                },
+                {
+                  "dimValue": "1"
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "name": "Shape0",
+        "type": {
+          "tensorType": {
+            "elemType": 6,
+            "shape": {
+              "dim": [
+                {
+                  "dimValue": "-1"
+                },
+                {
+                  "dimValue": "1"
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "name": "Thickness0",
+        "type": {
+          "tensorType": {
+            "elemType": 11,
+            "shape": {
+              "dim": [
+                {
+                  "dimValue": "-1"
+                },
+                {
+                  "dimValue": "1"
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "name": "Label0",
+        "type": {
+          "tensorType": {
+            "elemType": 9,
+            "shape": {
+              "dim": [
+                {
+                  "dimValue": "-1"
+                },
+                {
+                  "dimValue": "1"
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
         "name": "Size.output",
         "type": {
           "tensorType": {


### PR DESCRIPTION
ColumnSelectingTransformer wasn't inferring the ONNX shape during ONNX export. This was causing issues when the shape needed to be known. This PR adds in the shape inference step by removing the skip flag to skip it.