### PR TITLE
Use KeyTypeAttribute from Schema in CreateTextLoader

### DIFF
--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
@@ -1489,6 +1489,13 @@ namespace Microsoft.ML.Data
                 var column = new Column();
                 column.Name = mappingAttrName?.Name ?? memberInfo.Name;
                 column.Source = mappingAttr.Sources.ToArray();
+
+                var keyTypeAttr = memberInfo.GetCustomAttribute<KeyTypeAttribute>();
+                if (keyTypeAttr != null)
+                {
+                    column.KeyCount = keyTypeAttr.KeyCount;
+                }
+
                 InternalDataKind dk;
                 switch (memberInfo)
                 {

--- a/test/Microsoft.ML.Tests/TextLoaderTests.cs
+++ b/test/Microsoft.ML.Tests/TextLoaderTests.cs
@@ -877,5 +877,45 @@ namespace Microsoft.ML.EntryPoints.Tests
                 Assert.StartsWith("Should define at least one public, readable field or property in TInput.", ex.Message);
             }
         }
+
+        public class BreastCancerInputModelWithKeyType
+        {
+            [LoadColumn(0)]
+            public bool IsMalignant { get; set; }
+
+            [LoadColumn(1), KeyType(10)]
+            public uint Thickness { get; set; }
+        }
+
+        public class BreastCancerInputModelWithoutKeyType
+        {
+            [LoadColumn(0)]
+            public bool IsMalignant { get; set; }
+
+            [LoadColumn(1)]
+            public uint Thickness { get; set; }
+        }
+
+        [Fact]
+        public void TestLoadTextWithKeyTypeAttribute()
+        {
+            var mlContext = new MLContext(seed: 1);
+            string breastCancerPath = GetDataPath(TestDatasets.breastCancer.trainFilename);
+
+            var data = mlContext.Data.CreateTextLoader<BreastCancerInputModelWithKeyType>(separatorChar: ',').Load(breastCancerPath);
+
+            Assert.True(data.Schema[1].Type.GetKeyCount() == 10);
+        }
+
+        [Fact]
+        public void TestLoadTextWithoutKeyTypeAttribute()
+        {
+            var mlContext = new MLContext(seed: 1);
+            string breastCancerPath = GetDataPath(TestDatasets.breastCancer.trainFilename);
+
+            var data = mlContext.Data.CreateTextLoader<BreastCancerInputModelWithoutKeyType>(separatorChar: ',').Load(breastCancerPath);
+
+            Assert.True(data.Schema[1].Type.GetKeyCount() == 0);
+        }
     }
 }

--- a/test/Microsoft.ML.Tests/TextLoaderTests.cs
+++ b/test/Microsoft.ML.Tests/TextLoaderTests.cs
@@ -899,23 +899,26 @@ namespace Microsoft.ML.EntryPoints.Tests
         [Fact]
         public void TestLoadTextWithKeyTypeAttribute()
         {
+            ulong expectedCount = 10;
+
             var mlContext = new MLContext(seed: 1);
             string breastCancerPath = GetDataPath(TestDatasets.breastCancer.trainFilename);
 
             var data = mlContext.Data.CreateTextLoader<BreastCancerInputModelWithKeyType>(separatorChar: ',').Load(breastCancerPath);
 
-            Assert.True(data.Schema[1].Type.GetKeyCount() == 10);
+            Assert.Equal(expectedCount, data.Schema[1].Type.GetKeyCount());
         }
 
         [Fact]
         public void TestLoadTextWithoutKeyTypeAttribute()
         {
+            ulong expectedCount = 0;
             var mlContext = new MLContext(seed: 1);
             string breastCancerPath = GetDataPath(TestDatasets.breastCancer.trainFilename);
 
             var data = mlContext.Data.CreateTextLoader<BreastCancerInputModelWithoutKeyType>(separatorChar: ',').Load(breastCancerPath);
 
-            Assert.True(data.Schema[1].Type.GetKeyCount() == 0);
+            Assert.Equal(expectedCount, data.Schema[1].Type.GetKeyCount());
         }
     }
 }


### PR DESCRIPTION
Fixes #2642 

This PR reads the KeyTypeAttribute from the schema of the incoming type and sets that on the corresponding column when loading a text file using the CreateTextLoader.

