### PR TITLE
Added SciSharp.TensorFlow as a dependency to Microsoft.ML.TensorFlow

### DIFF
--- a/src/Microsoft.ML.TensorFlow/Microsoft.ML.TensorFlow.csproj
+++ b/src/Microsoft.ML.TensorFlow/Microsoft.ML.TensorFlow.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="SciSharp.TensorFlow.Redist" Version="$(TensorFlowVersion)" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="$(SystemIOFileSystemAccessControl)" />
     <PackageReference Include="System.Security.Principal.Windows" Version="$(SystemSecurityPrincipalWindows)" />
     <PackageReference Include="TensorFlow.NET" Version="$(TensorflowDotNETVersion)" />

--- a/test/Microsoft.ML.Tests/Microsoft.ML.Tests.csproj
+++ b/test/Microsoft.ML.Tests/Microsoft.ML.Tests.csproj
@@ -47,7 +47,6 @@
     <PackageReference Include="Microsoft.ML.Onnx.TestModels" Version="$(MicrosoftMLOnnxTestModelsVersion)" />
     <PackageReference Include="Microsoft.ML.TestDatabases" Version="$(MicrosoftMLTestDatabasesPackageVersion)" />
     <PackageReference Include="Microsoft.ML.TestModels" Version="$(MicrosoftMLTestModelsPackageVersion)" />
-    <PackageReference Include="SciSharp.TensorFlow.Redist" Version="$(TensorFlowVersion)" />
     <PackageReference Include="System.Data.SqlClient" Version="$(SystemDataSqlClientVersion)" />
     <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="$(MicrosoftMLOnnxRuntimePackageVersion)" />
   </ItemGroup>


### PR DESCRIPTION
Fix #4065. Added package reference to `SciSharp.TensorFlow.Redist` in `Microsoft.ML.TensorFlow`, and removed this package reference from `Microsoft.ML.Tests`, as `Microsoft.ML.Tests` already has a reference to `Microsoft.ML.TensorFlow.`

`Microsoft.ML.Tensorflow.csproj` did not include a package reference to `SciSharp.TensorFlow.Redist`, which resulted in users needing to manually install this NuGet package, as demonstrated in issue #4065. I confirmed that this fix works [here](https://github.com/dotnet/machinelearning/issues/4065#issuecomment-623009939).