### PR TITLE
Changed Dictionary to ConcurrentDictionary

### DIFF
--- a/test/Microsoft.ML.Functional.Tests/Debugging.cs
+++ b/test/Microsoft.ML.Functional.Tests/Debugging.cs
@@ -186,14 +186,14 @@ namespace Microsoft.ML.Functional.Tests
                 @"[Source=SdcaTrainerBase; Training, Kind=Info] Using best model from iteration 7."};
             foreach (var line in expectedLines)
             {
-                Assert.Contains(line, logWatcher.Lines);
+                Assert.Contains(line, logWatcher.Lines as IReadOnlyDictionary<string, int>);
                 Assert.Equal(1, logWatcher.Lines[line]);
             }
         }
 
         internal class LogWatcher {
 
-            public readonly IDictionary<string, int> Lines;
+            public readonly ConcurrentDictionary<string, int> Lines;
 
             public LogWatcher()
             {
@@ -202,10 +202,7 @@ namespace Microsoft.ML.Functional.Tests
             
             public void ObserveEvent(object sender, LoggingEventArgs e)
             {
-                if (Lines.ContainsKey(e.Message))
-                    Lines[e.Message]++;
-                else
-                    Lines[e.Message] = 1;
+                Lines.AddOrUpdate(e.Message, 1, (key, oldValue) => oldValue + 1);
             }
         }
     }

--- a/test/Microsoft.ML.Functional.Tests/Debugging.cs
+++ b/test/Microsoft.ML.Functional.Tests/Debugging.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using Microsoft.ML.Data;
 using Microsoft.ML.Functional.Tests.Datasets;
@@ -196,7 +197,7 @@ namespace Microsoft.ML.Functional.Tests
 
             public LogWatcher()
             {
-                Lines = new Dictionary<string, int>();
+                Lines = new ConcurrentDictionary<string, int>();
             }
             
             public void ObserveEvent(object sender, LoggingEventArgs e)


### PR DESCRIPTION
We are seeing new test failure sporadically with the following call stack:

```
[xUnit.net 00:00:05.18]     Microsoft.ML.Functional.Tests.Debugging.ViewTrainingOutput [FAIL]

  X Microsoft.ML.Functional.Tests.Debugging.ViewTrainingOutput [16ms]
  Error Message:
   System.InvalidOperationException : Operations that change non-concurrent collections must have exclusive access. A concurrent update was performed on this collection and corrupted its state. The collection's state is no longer correct.
  Stack Trace:
     at System.Collections.Generic.Dictionary`2.FindEntry(TKey key)
   at System.Collections.Generic.Dictionary`2.ContainsKey(TKey key)
   at Microsoft.ML.Functional.Tests.Debugging.LogWatcher.ObserveEvent(Object sender, LoggingEventArgs e) in /Users/runner/runners/2.166.3/work/1/s/test/Microsoft.ML.Functional.Tests/Debugging.cs:line 204
   at Microsoft.ML.MLContext.ProcessMessage(IMessageSource source, ChannelMessage message) in /Users/runner/runners/2.166.3/work/1/s/src/Microsoft.ML.Data/MLContext.cs:line 135
   at Microsoft.ML.Runtime.HostEnvironmentBase`1.Dispatcher`1.DispatchCore(IMessageSource sender, TMessage message) in /Users/runner/runners/2.166.3/work/1/s/src/Microsoft.ML.Core/Environment/HostEnvironmentBase.cs:line 314
```

Since the dictionary is being modified by multiple threads, I am changing this to a ConcurrentDictionary.
