### PR TITLE
disable test that are hanging and failing

### DIFF
--- a/test/Microsoft.Extensions.ML.Tests/UriLoaderTests.cs
+++ b/test/Microsoft.Extensions.ML.Tests/UriLoaderTests.cs
@@ -24,6 +24,8 @@ namespace Microsoft.Extensions.ML
         }
 
         [Fact]
+        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
+        [Trait("Category", "SkipInCI")]
         public void throw_until_started()
         {
             var services = new ServiceCollection()

--- a/test/Microsoft.ML.AutoML.Tests/MetricsAgentsTests.cs
+++ b/test/Microsoft.ML.AutoML.Tests/MetricsAgentsTests.cs
@@ -102,6 +102,8 @@ namespace Microsoft.ML.AutoML.Test
         }
 
         [Fact]
+        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
+        [Trait("Category", "SkipInCI")]
         public void RegressionMetricsNonPerfectTest()
         {
             var metrics = MetricsUtil.CreateRegressionMetrics(0.2, 0.3, 0.4, 0.5, 0.6);

--- a/test/Microsoft.ML.AutoML.Tests/TextFileSampleTests.cs
+++ b/test/Microsoft.ML.AutoML.Tests/TextFileSampleTests.cs
@@ -18,6 +18,8 @@ namespace Microsoft.ML.AutoML.Test
         }
 
         [Fact]
+        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
+        [Trait("Category", "SkipInCI")]
         public void CanParseLargeRandomStream()
         {
             using (var stream = new MemoryStream())

--- a/test/Microsoft.ML.AutoML.Tests/TrainerExtensionsTests.cs
+++ b/test/Microsoft.ML.AutoML.Tests/TrainerExtensionsTests.cs
@@ -231,6 +231,8 @@ namespace Microsoft.ML.AutoML.Test
         }
 
         [Fact]
+        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
+        [Trait("Category", "SkipInCI")]
         public void BuildDefaultAveragedPerceptronPipelineNode()
         {
             var pipelineNode = new AveragedPerceptronBinaryExtension().CreatePipelineNode(null, new ColumnInformation() { LabelColumnName = "L" });

--- a/test/Microsoft.ML.AutoML.Tests/TransformPostTrainerInferenceTests.cs
+++ b/test/Microsoft.ML.AutoML.Tests/TransformPostTrainerInferenceTests.cs
@@ -19,6 +19,8 @@ namespace Microsoft.ML.AutoML.Test
         }
 
         [Fact]
+        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
+        [Trait("Category", "SkipInCI")]
         public void TransformPostTrainerMulticlassNonKeyLabel()
         {
             TransformPostTrainerInferenceTestCore(TaskKind.MulticlassClassification,

--- a/test/Microsoft.ML.Functional.Tests/Debugging.cs
+++ b/test/Microsoft.ML.Functional.Tests/Debugging.cs
@@ -158,6 +158,8 @@ namespace Microsoft.ML.Functional.Tests
         /// Debugging: The progress of training can be accessed.
         /// </summary>
         [Fact]
+        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
+        [Trait("Category", "SkipInCI")]
         public void ViewTrainingOutput()
         {
             var mlContext = new MLContext(seed: 1);

--- a/test/Microsoft.ML.Functional.Tests/Debugging.cs
+++ b/test/Microsoft.ML.Functional.Tests/Debugging.cs
@@ -158,8 +158,6 @@ namespace Microsoft.ML.Functional.Tests
         /// Debugging: The progress of training can be accessed.
         /// </summary>
         [Fact]
-        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
-        [Trait("Category", "SkipInCI")]
         public void ViewTrainingOutput()
         {
             var mlContext = new MLContext(seed: 1);

--- a/test/Microsoft.ML.Predictor.Tests/CmdLine/CmdLineReverseTest.cs
+++ b/test/Microsoft.ML.Predictor.Tests/CmdLine/CmdLineReverseTest.cs
@@ -78,6 +78,8 @@ namespace Microsoft.ML.RunTests
         }
 
         [Fact]
+        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
+        [Trait("Category", "SkipInCI")]
         [TestCategory("Cmd Parsing")]
         public void NewTest()
         {

--- a/test/Microsoft.ML.Predictor.Tests/TestGamPublicInterfaces.cs
+++ b/test/Microsoft.ML.Predictor.Tests/TestGamPublicInterfaces.cs
@@ -18,6 +18,8 @@ namespace Microsoft.ML.RunTests
         }
 
         [Fact]
+        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
+        [Trait("Category", "SkipInCI")]
         [TestCategory("FastTree")]
         public void TestGamDirectInstatiation()
         {

--- a/test/Microsoft.ML.Predictor.Tests/TestIniModels.cs
+++ b/test/Microsoft.ML.Predictor.Tests/TestIniModels.cs
@@ -512,6 +512,8 @@ namespace Microsoft.ML.RunTests
         }
 
         [Fact]
+        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
+        [Trait("Category", "SkipInCI")]
         public void TestGamRegressionIni()
         {
             var mlContext = new MLContext(seed: 0);

--- a/test/Microsoft.ML.Predictor.Tests/TestPredictors.cs
+++ b/test/Microsoft.ML.Predictor.Tests/TestPredictors.cs
@@ -2154,6 +2154,8 @@ output Out [3] from H all;
         ///A test for binary classifiers
         ///</summary>
         [Fact]
+        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
+        [Trait("Category", "SkipInCI")]
         [TestCategory("Binary")]
         [TestCategory("LDSVM")]
         public void BinaryClassifierLDSvmNoBiasTest()

--- a/test/Microsoft.ML.Predictor.Tests/TestTransposer.cs
+++ b/test/Microsoft.ML.Predictor.Tests/TestTransposer.cs
@@ -148,6 +148,8 @@ namespace Microsoft.ML.RunTests
         }
 
         [Fact]
+        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
+        [Trait("Category", "SkipInCI")]
         [TestCategory("Transposer")]
         public void TransposerTest()
         {

--- a/test/Microsoft.ML.TestFramework/DataPipe/Parquet.cs
+++ b/test/Microsoft.ML.TestFramework/DataPipe/Parquet.cs
@@ -25,6 +25,8 @@ namespace Microsoft.ML.RunTests
         }
 
         [Fact]
+        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
+        [Trait("Category", "SkipInCI")]
         public void TestParquetNull()
         {
             string pathData = GetDataPath(@"Parquet", "test-null.parquet");

--- a/test/Microsoft.ML.TestFramework/DataPipe/Parquet.cs
+++ b/test/Microsoft.ML.TestFramework/DataPipe/Parquet.cs
@@ -17,6 +17,8 @@ namespace Microsoft.ML.RunTests
         }
 
         [Fact]
+        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
+        [Trait("Category", "SkipInCI")]
         public void TestParquetPrimitiveDataTypes()
         {
             string pathData = GetDataPath(@"Parquet", "alltypes.parquet");

--- a/test/Microsoft.ML.TestFramework/DataPipe/PartitionedFileLoaderTests.cs
+++ b/test/Microsoft.ML.TestFramework/DataPipe/PartitionedFileLoaderTests.cs
@@ -24,6 +24,8 @@ namespace Microsoft.ML.RunTests
         }
 
         [Fact]
+        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
+        [Trait("Category", "SkipInCI")]
         public void PartitionedNamedDirectories()
         {
             string basePath = GetDataPath("Partitioned", "Named");

--- a/test/Microsoft.ML.TestFramework/DataPipe/PartitionedFileLoaderTests.cs
+++ b/test/Microsoft.ML.TestFramework/DataPipe/PartitionedFileLoaderTests.cs
@@ -38,6 +38,8 @@ namespace Microsoft.ML.RunTests
         }
 
         [Fact]
+        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
+        [Trait("Category", "SkipInCI")]
         public void PartitionedUnnamedDirectories()
         {
             string basePath = GetDataPath("Partitioned", "Unnamed"); ;

--- a/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipe.cs
+++ b/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipe.cs
@@ -710,6 +710,8 @@ namespace Microsoft.ML.RunTests
         }
 
         [Fact]
+        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
+        [Trait("Category", "SkipInCI")]
         public void SavePipeWordBag()
         {
             string pathData = GetDataPath(@"lm.sample.txt");
@@ -1428,6 +1430,8 @@ namespace Microsoft.ML.RunTests
     public sealed partial class TestDataPipeNoBaseline : TestDataViewBase
     {
         [Fact]
+        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
+        [Trait("Category", "SkipInCI")]
         public void TestLDATransform()
         {
             var builder = new ArrayDataViewBuilder(Env);

--- a/test/Microsoft.ML.TestFramework/TestCommandBase.cs
+++ b/test/Microsoft.ML.TestFramework/TestCommandBase.cs
@@ -1985,6 +1985,8 @@ namespace Microsoft.ML.RunTests
 
         [TestCategory(Cat), TestCategory("FieldAwareFactorizationMachine"), TestCategory("Continued Training")]
         [Fact]
+        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
+        [Trait("Category", "SkipInCI")]
         public void CommandTrainingBinaryFieldAwareFactorizationMachineWithInitialization()
         {
             const string loaderArgs = "loader=text{col=Label:0 col=FieldA:1-2 col=FieldB:3-4 col=FieldC:5-6 col=FieldD:7-9}";

--- a/test/Microsoft.ML.TestFramework/TestCommandBase.cs
+++ b/test/Microsoft.ML.TestFramework/TestCommandBase.cs
@@ -1849,6 +1849,8 @@ namespace Microsoft.ML.RunTests
 
         [TestCategory(Cat), TestCategory("Ranking"), TestCategory("FastTree")]
         [Fact]
+        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
+        [Trait("Category", "SkipInCI")]
         public void CommandTrainRanking()
         {
             // First run a training.

--- a/test/Microsoft.ML.TestFramework/TestSparseDataView.cs
+++ b/test/Microsoft.ML.TestFramework/TestSparseDataView.cs
@@ -70,6 +70,8 @@ namespace Microsoft.ML.RunTests
         }
 
         [Fact]
+        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
+        [Trait("Category", "SkipInCI")]
         [TestCategory(Cat)]
         public void DenseDataView()
         {

--- a/test/Microsoft.ML.TestFramework/TestSparseDataView.cs
+++ b/test/Microsoft.ML.TestFramework/TestSparseDataView.cs
@@ -31,6 +31,8 @@ namespace Microsoft.ML.RunTests
 
         [Fact]
         [TestCategory(Cat)]
+        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
+        [Trait("Category", "SkipInCI")]
         public void SparseDataView()
         {
             GenericSparseDataView(new[] { 1f, 2f, 3f }, new[] { 1f, 10f, 100f });

--- a/test/Microsoft.ML.Tests/Transformers/LineParserTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/LineParserTests.cs
@@ -49,6 +49,8 @@ namespace Microsoft.ML.Tests.Transformers
         }
 
         [Fact]
+        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
+        [Trait("Category", "SkipInCI")]
         public void LineParserAndCulture()
         {
             var currentCulture = Thread.CurrentThread.CurrentCulture;

--- a/test/Microsoft.ML.Tests/Transformers/WordTokenizeTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/WordTokenizeTests.cs
@@ -48,7 +48,8 @@ namespace Microsoft.ML.Tests.Transformers
             public float[] B;
         }
         [Fact]
-
+        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
+        [Trait("Category", "SkipInCI")]
         public void WordTokenizeWorkout()
         {
             var data = new[] { new TestClass() { A = "This is a good sentence.", B = new string[2] { "Much words", "Wow So Cool" } } };

--- a/test/Microsoft.ML.TimeSeries.Tests/TimeSeries.cs
+++ b/test/Microsoft.ML.TimeSeries.Tests/TimeSeries.cs
@@ -140,6 +140,8 @@ namespace Microsoft.ML.RunTests
 
 
         [Fact]
+        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
+        [Trait("Category", "SkipInCI")]
         public void SavePipePValue()
         {
             TestCore(null, true,

--- a/test/Microsoft.ML.TimeSeries.Tests/TimeSeriesDirectApi.cs
+++ b/test/Microsoft.ML.TimeSeries.Tests/TimeSeriesDirectApi.cs
@@ -511,6 +511,8 @@ namespace Microsoft.ML.Tests
         }
 
         [Theory]
+        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
+        [Trait("Category", "SkipInCI")]
         [InlineData(true)]
         [InlineData(false)]
         public void AnomalyDetectionWithSrCnn(bool loadDataFromFile)

--- a/test/Microsoft.ML.TimeSeries.Tests/TimeSeriesEstimatorTests.cs
+++ b/test/Microsoft.ML.TimeSeries.Tests/TimeSeriesEstimatorTests.cs
@@ -172,6 +172,8 @@ namespace Microsoft.ML.Tests
         }
 
         [Fact]
+        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
+        [Trait("Category", "SkipInCI")]
         public void TestIidSpikeEstimator()
         {
             int confidence = 95;

--- a/test/Microsoft.ML.TimeSeries.Tests/TimeSeriesSimpleApiTests.cs
+++ b/test/Microsoft.ML.TimeSeries.Tests/TimeSeriesSimpleApiTests.cs
@@ -167,6 +167,8 @@ namespace Microsoft.ML.Tests
         }
 
         [Fact]
+        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
+        [Trait("Category", "SkipInCI")]
         public void SsaSpikeDetection()
         {
             var env = new MLContext(1);


### PR DESCRIPTION
Due to some recent CI failing, disable some test to unblock:

Hanging: 
https://dev.azure.com/dnceng/public/_build/results?buildId=632387&view=logs&j=fbb2cc91-8ee3-5485-dfe8-a5681da76491&t=12433ff8-7284-5589-30ac-02bd5974b6ad

https://dev.azure.com/dnceng/public/_build/results?buildId=631965&view=logs&j=32952595-30e7-56fa-9b86-c4579b87f5d1&t=4390109a-3c77-5b7c-bf35-d176b654cd3c

https://dev.azure.com/dnceng/public/_build/results?buildId=631033&view=logs&j=d1af5113-e574-5a31-f7f3-02fc40ea7b26&t=167d9e7d-b609-5b0a-7efa-d26b0dafb88f

https://dev.azure.com/dnceng/public/_build/results?buildId=630228&view=logs&j=32952595-30e7-56fa-9b86-c4579b87f5d1&s=b15d9194-8f26-5328-b47f-5968c76b37e7

https://dev.azure.com/dnceng/public/_build/results?buildId=628376&view=logs&j=9dffbc46-9322-5a58-fb37-6d66c044e90d&t=11098bf6-eb78-583b-8eab-f14f48444a6b

https://dev.azure.com/dnceng/public/_build/results?buildId=628134&view=logs&j=41509eb4-74ce-5e57-61b4-bdf74b39e7c1&t=dbdc2969-5b98-5c39-1328-31d4a2fdc45e

https://dev.azure.com/dnceng/public/_build/results?buildId=626424&view=logs&j=d1af5113-e574-5a31-f7f3-02fc40ea7b26&t=167d9e7d-b609-5b0a-7efa-d26b0dafb88f

https://dev.azure.com/dnceng/public/_build/results?buildId=620750&view=logs&j=32952595-30e7-56fa-9b86-c4579b87f5d1&s=d654deb9-056d-50a2-1717-90c08683d50a

Fail:

https://dev.azure.com/dnceng/public/_build/results?buildId=614989&view=logs&j=4b233af4-7b14-5f68-27c6-9c4d7ac87519&t=6e2e87e8-8c33-50e6-544b-c271638494a5