### PR TITLE
pipeline configuration change

### DIFF
--- a/build/.night-build.yml
+++ b/build/.night-build.yml
@@ -92,7 +92,8 @@ jobs:
     buildScript: build.cmd
     nightlyBuild: true
     pool:
-      name: Hosted VS2017
+      name:  NetCorePublic-Pool
+      queue: buildpool.server.amd64.vs2017.open
 
 - template: /build/ci/job-template.yml
   parameters:
@@ -109,7 +110,8 @@ jobs:
         _includeBenchmarkData: false
     nightlyBuild: true
     pool:
-      name: Hosted VS2017
+      name:  NetCorePublic-Pool
+      queue: buildpool.server.amd64.vs2017.open
 
 - template: /build/ci/job-template.yml
   parameters:
@@ -118,4 +120,5 @@ jobs:
     buildScript: build.cmd
     nightlyBuild: true
     pool:
-      name: Hosted VS2017
+      name:  NetCorePublic-Pool
+      queue: buildpool.server.amd64.vs2017.open

--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -18,7 +18,7 @@ jobs:
     ${{ if and(eq(parameters.nightlyBuild, 'false'), eq(parameters.codeCoverage, 'false')) }}:
       timeoutInMinutes: 75
     ${{ if eq(parameters.codeCoverage, 'true') }}:
-      timeoutInMinutes: 75
+      timeoutInMinutes: 100
     cancelTimeoutInMinutes: 10
     variables:
       dotnetPath: $(Build.SourcesDirectory)/Tools/dotnetcli/dotnet


### PR DESCRIPTION
1. make code coverage timeout to 90 minutes due to frequent timeout at code coverage pipeline
2. move nightly build pipeline to netcore app agent pool as we see disk out of space error



