### PR TITLE
Improve error message when defining custom type for variables

### DIFF
--- a/src/Microsoft.ML.Data/Data/SchemaDefinition.cs
+++ b/src/Microsoft.ML.Data/Data/SchemaDefinition.cs
@@ -331,9 +331,17 @@ namespace Microsoft.ML.Data
         /// </summary>
         /// <param name="userType">The type to base the schema on.</param>
         /// <param name="direction">Accept fields and properties based on their direction.</param>
+        /// <returns>The generated schema definition.</returns>
+        public static SchemaDefinition Create(Type userType, Direction direction = Direction.Both) => Create(userType, direction, null);
+
+        /// <summary>
+        /// Create a schema definition by enumerating all public fields of the given type.
+        /// </summary>
+        /// <param name="userType">The type to base the schema on.</param>
+        /// <param name="direction">Accept fields and properties based on their direction.</param>
         /// <param name="data">onnx data information</param>
         /// <returns>The generated schema definition.</returns>
-        public static SchemaDefinition Create(Type userType, Direction direction = Direction.Both, IDataView data = null)
+        public static SchemaDefinition Create(Type userType, Direction direction, IDataView data)
         {
             // REVIEW: This will have to be updated whenever we start
             // supporting properties and not just fields.

--- a/src/Microsoft.ML.Data/Data/SchemaDefinition.cs
+++ b/src/Microsoft.ML.Data/Data/SchemaDefinition.cs
@@ -339,7 +339,7 @@ namespace Microsoft.ML.Data
         /// </summary>
         /// <param name="userType">The type to base the schema on.</param>
         /// <param name="direction">Accept fields and properties based on their direction.</param>
-        /// <param name="data">onnx data information</param>
+        /// <param name="data">DataView that contains the expected type of input and output of transformers</param>
         /// <returns>The generated schema definition.</returns>
         public static SchemaDefinition Create(Type userType, Direction direction, IDataView data)
         {

--- a/src/Microsoft.ML.Data/Data/SchemaDefinition.cs
+++ b/src/Microsoft.ML.Data/Data/SchemaDefinition.cs
@@ -343,7 +343,7 @@ namespace Microsoft.ML.Data
             return (fieldInfos as IEnumerable<MemberInfo>).Concat(propertyInfos).ToArray();
         }
 
-        public static bool MemberInfoAssertion(MemberInfo memberInfo, Type userType, out string name, HashSet<string> colNames, out IEnumerable<Attribute> customAttributes)
+        public static bool MemberInfoAssertion(MemberInfo memberInfo, Type userType, HashSet<string> colNames, out string name, out IEnumerable<Attribute> customAttributes)
         {
             // Clause to handle the field that may be used to expose the cursor channel.
             // This field does not need a column.
@@ -415,7 +415,7 @@ namespace Microsoft.ML.Data
 
             foreach (var memberInfo in memberInfos)
             {
-                if (MemberInfoAssertion(memberInfo, userType, out string name, colNames, out IEnumerable<Attribute> customAttributes))
+                if (MemberInfoAssertion(memberInfo, userType, colNames, out string name, out IEnumerable<Attribute> customAttributes))
                 {
                     InternalSchemaDefinition.GetVectorAndItemType(memberInfo, out bool isVector, out Type dataType);
 

--- a/src/Microsoft.ML.Data/Data/SchemaDefinition.cs
+++ b/src/Microsoft.ML.Data/Data/SchemaDefinition.cs
@@ -343,16 +343,8 @@ namespace Microsoft.ML.Data
             return (fieldInfos as IEnumerable<MemberInfo>).Concat(propertyInfos).ToArray();
         }
 
-        public static bool ValidateMemberInfo(MemberInfo memberInfo, Type userType, HashSet<string> colNames, out string name, out IEnumerable<Attribute> customAttributes)
+        public static bool CheckMemberInfo(MemberInfo memberInfo)
         {
-            // Clause to handle the field that may be used to expose the cursor channel.
-            // This field does not need a column.
-            // REVIEW: maybe validate the channel attribute now, instead
-            // of later at cursor creation.
-
-            name = null;
-            customAttributes = null;
-
             switch (memberInfo)
             {
                 case FieldInfo fieldInfo:
@@ -376,6 +368,22 @@ namespace Microsoft.ML.Data
             }
 
             if (memberInfo.GetCustomAttribute<NoColumnAttribute>() != null)
+                return false;
+
+            return true;
+        }
+
+        public static bool ValidateMemberInfo(MemberInfo memberInfo, Type userType, HashSet<string> colNames, out string name, out IEnumerable<Attribute> customAttributes)
+        {
+            // Clause to handle the field that may be used to expose the cursor channel.
+            // This field does not need a column.
+            // REVIEW: maybe validate the channel attribute now, instead
+            // of later at cursor creation.
+
+            name = null;
+            customAttributes = null;
+
+            if (!CheckMemberInfo(memberInfo))
                 return false;
 
             customAttributes = memberInfo.GetCustomAttributes();

--- a/src/Microsoft.ML.Data/Data/SchemaDefinition.cs
+++ b/src/Microsoft.ML.Data/Data/SchemaDefinition.cs
@@ -331,8 +331,9 @@ namespace Microsoft.ML.Data
         /// </summary>
         /// <param name="userType">The type to base the schema on.</param>
         /// <param name="direction">Accept fields and properties based on their direction.</param>
+        /// <param name="data">onnx data information</param>
         /// <returns>The generated schema definition.</returns>
-        public static SchemaDefinition Create(Type userType, Direction direction = Direction.Both)
+        public static SchemaDefinition Create(Type userType, Direction direction = Direction.Both, IDataView data = null)
         {
             // REVIEW: This will have to be updated whenever we start
             // supporting properties and not just fields.
@@ -401,7 +402,7 @@ namespace Microsoft.ML.Data
                 if (!colNames.Add(name))
                     throw Contracts.ExceptParam(nameof(userType), "Duplicate column name '{0}' detected, this is disallowed", name);
 
-                InternalSchemaDefinition.GetVectorAndItemType(memberInfo, out bool isVector, out Type dataType);
+                InternalSchemaDefinition.GetVectorAndItemType(memberInfo, out bool isVector, out Type dataType, data, name);
 
                 // Get the column type.
                 DataViewType columnType;

--- a/src/Microsoft.ML.Data/Data/SchemaDefinition.cs
+++ b/src/Microsoft.ML.Data/Data/SchemaDefinition.cs
@@ -343,7 +343,7 @@ namespace Microsoft.ML.Data
             return (fieldInfos as IEnumerable<MemberInfo>).Concat(propertyInfos).ToArray();
         }
 
-        public static bool NeedToCheckMemberInfo(MemberInfo memberInfo)
+        internal static bool NeedToCheckMemberInfo(MemberInfo memberInfo)
         {
             switch (memberInfo)
             {
@@ -377,7 +377,7 @@ namespace Microsoft.ML.Data
             return true;
         }
 
-        public static bool GetNameAndCustomAttributes(MemberInfo memberInfo, Type userType, HashSet<string> colNames, out string name, out IEnumerable<Attribute> customAttributes)
+        internal static bool GetNameAndCustomAttributes(MemberInfo memberInfo, Type userType, HashSet<string> colNames, out string name, out IEnumerable<Attribute> customAttributes)
         {
             name = null;
             customAttributes = null;

--- a/src/Microsoft.ML.Data/Data/SchemaDefinition.cs
+++ b/src/Microsoft.ML.Data/Data/SchemaDefinition.cs
@@ -343,12 +343,14 @@ namespace Microsoft.ML.Data
             return (fieldInfos as IEnumerable<MemberInfo>).Concat(propertyInfos).ToArray();
         }
 
-        public static bool MemberInfoAssertion(MemberInfo memberInfo, Type userType, string name = null, HashSet<string> colNames = null, IEnumerable<Attribute> customAttributes = null)
+        public static bool MemberInfoAssertion(MemberInfo memberInfo, Type userType, out string name, HashSet<string> colNames, IEnumerable<Attribute> customAttributes = null)
         {
             // Clause to handle the field that may be used to expose the cursor channel.
             // This field does not need a column.
             // REVIEW: maybe validate the channel attribute now, instead
             // of later at cursor creation.
+            name = null;
+
             switch (memberInfo)
             {
                 case FieldInfo fieldInfo:
@@ -411,6 +413,103 @@ namespace Microsoft.ML.Data
 
             foreach (var memberInfo in memberInfos)
             {
+                // Clause to handle the field that may be used to expose the cursor channel.
+                // This field does not need a column.
+                // REVIEW: maybe validate the channel attribute now, instead
+                // of later at cursor creation.
+                switch (memberInfo)
+                {
+                    case FieldInfo fieldInfo:
+                        if (fieldInfo.FieldType == typeof(IChannel))
+                            continue;
+
+                        // Const fields do not need to be mapped.
+                        if (fieldInfo.IsLiteral)
+                            continue;
+
+                        break;
+
+                    case PropertyInfo propertyInfo:
+                        if (propertyInfo.PropertyType == typeof(IChannel))
+                            continue;
+                        break;
+
+                    default:
+                        Contracts.Assert(false);
+                        throw Contracts.ExceptNotSupp("Expected a FieldInfo or a PropertyInfo");
+                }
+
+                if (memberInfo.GetCustomAttribute<NoColumnAttribute>() != null)
+                    continue;
+
+                var customAttributes = memberInfo.GetCustomAttributes();
+                var customTypeAttributes = customAttributes.Where(x => x is DataViewTypeAttribute);
+                if (customTypeAttributes.Count() > 1)
+                    throw Contracts.ExceptParam(nameof(userType), "Member {0} cannot be marked with multiple attributes, {1}, derived from {2}.",
+                        memberInfo.Name, customTypeAttributes, typeof(DataViewTypeAttribute));
+                else if (customTypeAttributes.Count() == 1)
+                {
+                    var customTypeAttribute = (DataViewTypeAttribute)customTypeAttributes.First();
+                    customTypeAttribute.Register();
+                }
+
+                var mappingNameAttr = memberInfo.GetCustomAttribute<ColumnNameAttribute>();
+                string name = mappingNameAttr?.Name ?? memberInfo.Name;
+                // Disallow duplicate names, because the field enumeration order is not actually
+                // well defined, so we are not guaranteed to have consistent "hiding" from run to
+                // run, across different .NET versions.
+                if (!colNames.Add(name))
+                    throw Contracts.ExceptParam(nameof(userType), "Duplicate column name '{0}' detected, this is disallowed", name);
+
+                InternalSchemaDefinition.GetVectorAndItemType(memberInfo, out bool isVector, out Type dataType);
+
+                // Get the column type.
+                DataViewType columnType;
+                if (!DataViewTypeManager.Knows(dataType, customAttributes))
+                {
+                    PrimitiveDataViewType itemType;
+                    var keyAttr = memberInfo.GetCustomAttribute<KeyTypeAttribute>();
+                    if (keyAttr != null)
+                    {
+                        if (!KeyDataViewType.IsValidDataType(dataType))
+                            throw Contracts.ExceptParam(nameof(userType), "Member {0} marked with KeyType attribute, but does not appear to be a valid kind of data for a key type", memberInfo.Name);
+                        if (keyAttr.KeyCount == null)
+                            itemType = new KeyDataViewType(dataType, dataType.ToMaxInt());
+                        else
+                            itemType = new KeyDataViewType(dataType, keyAttr.KeyCount.Count.GetValueOrDefault());
+                    }
+                    else
+                        itemType = ColumnTypeExtensions.PrimitiveTypeFromType(dataType);
+
+                    var vectorAttr = memberInfo.GetCustomAttribute<VectorTypeAttribute>();
+                    if (vectorAttr != null && !isVector)
+                        throw Contracts.ExceptParam(nameof(userType), $"Member {memberInfo.Name} marked with {nameof(VectorTypeAttribute)}, but does not appear to be a vector type", memberInfo.Name);
+                    if (isVector)
+                    {
+                        int[] dims = vectorAttr?.Dims;
+                        if (dims != null && dims.Any(d => d < 0))
+                            throw Contracts.ExceptParam(nameof(userType), "Some of member {0}'s dimension lengths are negative");
+                        if (Utils.Size(dims) == 0)
+                            columnType = new VectorDataViewType(itemType, 0);
+                        else
+                            columnType = new VectorDataViewType(itemType, dims);
+                    }
+                    else
+                        columnType = itemType;
+                }
+                else
+                    columnType = DataViewTypeManager.GetDataViewType(dataType, customAttributes);
+
+                cols.Add(new Column(memberInfo.Name, columnType, name));
+            }
+            return cols;
+            /*var memberInfos = GetMemberInfos(userType, direction);
+
+            SchemaDefinition cols = new SchemaDefinition();
+            HashSet<string> colNames = new HashSet<string>();
+
+            foreach (var memberInfo in memberInfos)
+            {
                 IEnumerable<Attribute> customAttributes = null;
                 string name = null;
 
@@ -458,7 +557,7 @@ namespace Microsoft.ML.Data
                     cols.Add(new Column(memberInfo.Name, columnType, name));
                 }
             }
-            return cols;
+            return cols;*/
         }
     }
 }

--- a/src/Microsoft.ML.Data/Data/SchemaDefinition.cs
+++ b/src/Microsoft.ML.Data/Data/SchemaDefinition.cs
@@ -343,7 +343,7 @@ namespace Microsoft.ML.Data
             return (fieldInfos as IEnumerable<MemberInfo>).Concat(propertyInfos).ToArray();
         }
 
-        public static bool MemberInfoAssertion(MemberInfo memberInfo, Type userType, HashSet<string> colNames, out string name, out IEnumerable<Attribute> customAttributes)
+        public static bool ValidateMemberInfo(MemberInfo memberInfo, Type userType, HashSet<string> colNames, out string name, out IEnumerable<Attribute> customAttributes)
         {
             // Clause to handle the field that may be used to expose the cursor channel.
             // This field does not need a column.
@@ -415,7 +415,7 @@ namespace Microsoft.ML.Data
 
             foreach (var memberInfo in memberInfos)
             {
-                if (MemberInfoAssertion(memberInfo, userType, colNames, out string name, out IEnumerable<Attribute> customAttributes))
+                if (ValidateMemberInfo(memberInfo, userType, colNames, out string name, out IEnumerable<Attribute> customAttributes))
                 {
                     InternalSchemaDefinition.GetVectorAndItemType(memberInfo, out bool isVector, out Type dataType);
 

--- a/src/Microsoft.ML.Data/Data/SchemaDefinition.cs
+++ b/src/Microsoft.ML.Data/Data/SchemaDefinition.cs
@@ -343,13 +343,15 @@ namespace Microsoft.ML.Data
             return (fieldInfos as IEnumerable<MemberInfo>).Concat(propertyInfos).ToArray();
         }
 
-        public static bool MemberInfoAssertion(MemberInfo memberInfo, Type userType, out string name, HashSet<string> colNames, IEnumerable<Attribute> customAttributes = null)
+        public static bool MemberInfoAssertion(MemberInfo memberInfo, Type userType, out string name, HashSet<string> colNames, out IEnumerable<Attribute> customAttributes)
         {
             // Clause to handle the field that may be used to expose the cursor channel.
             // This field does not need a column.
             // REVIEW: maybe validate the channel attribute now, instead
             // of later at cursor creation.
+
             name = null;
+            customAttributes = null;
 
             switch (memberInfo)
             {
@@ -413,107 +415,7 @@ namespace Microsoft.ML.Data
 
             foreach (var memberInfo in memberInfos)
             {
-                // Clause to handle the field that may be used to expose the cursor channel.
-                // This field does not need a column.
-                // REVIEW: maybe validate the channel attribute now, instead
-                // of later at cursor creation.
-                switch (memberInfo)
-                {
-                    case FieldInfo fieldInfo:
-                        if (fieldInfo.FieldType == typeof(IChannel))
-                            continue;
-
-                        // Const fields do not need to be mapped.
-                        if (fieldInfo.IsLiteral)
-                            continue;
-
-                        break;
-
-                    case PropertyInfo propertyInfo:
-                        if (propertyInfo.PropertyType == typeof(IChannel))
-                            continue;
-                        break;
-
-                    default:
-                        Contracts.Assert(false);
-                        throw Contracts.ExceptNotSupp("Expected a FieldInfo or a PropertyInfo");
-                }
-
-                if (memberInfo.GetCustomAttribute<NoColumnAttribute>() != null)
-                    continue;
-
-                var customAttributes = memberInfo.GetCustomAttributes();
-                var customTypeAttributes = customAttributes.Where(x => x is DataViewTypeAttribute);
-                if (customTypeAttributes.Count() > 1)
-                    throw Contracts.ExceptParam(nameof(userType), "Member {0} cannot be marked with multiple attributes, {1}, derived from {2}.",
-                        memberInfo.Name, customTypeAttributes, typeof(DataViewTypeAttribute));
-                else if (customTypeAttributes.Count() == 1)
-                {
-                    var customTypeAttribute = (DataViewTypeAttribute)customTypeAttributes.First();
-                    customTypeAttribute.Register();
-                }
-
-                var mappingNameAttr = memberInfo.GetCustomAttribute<ColumnNameAttribute>();
-                string name = mappingNameAttr?.Name ?? memberInfo.Name;
-                // Disallow duplicate names, because the field enumeration order is not actually
-                // well defined, so we are not guaranteed to have consistent "hiding" from run to
-                // run, across different .NET versions.
-                if (!colNames.Add(name))
-                    throw Contracts.ExceptParam(nameof(userType), "Duplicate column name '{0}' detected, this is disallowed", name);
-
-                InternalSchemaDefinition.GetVectorAndItemType(memberInfo, out bool isVector, out Type dataType);
-
-                // Get the column type.
-                DataViewType columnType;
-                if (!DataViewTypeManager.Knows(dataType, customAttributes))
-                {
-                    PrimitiveDataViewType itemType;
-                    var keyAttr = memberInfo.GetCustomAttribute<KeyTypeAttribute>();
-                    if (keyAttr != null)
-                    {
-                        if (!KeyDataViewType.IsValidDataType(dataType))
-                            throw Contracts.ExceptParam(nameof(userType), "Member {0} marked with KeyType attribute, but does not appear to be a valid kind of data for a key type", memberInfo.Name);
-                        if (keyAttr.KeyCount == null)
-                            itemType = new KeyDataViewType(dataType, dataType.ToMaxInt());
-                        else
-                            itemType = new KeyDataViewType(dataType, keyAttr.KeyCount.Count.GetValueOrDefault());
-                    }
-                    else
-                        itemType = ColumnTypeExtensions.PrimitiveTypeFromType(dataType);
-
-                    var vectorAttr = memberInfo.GetCustomAttribute<VectorTypeAttribute>();
-                    if (vectorAttr != null && !isVector)
-                        throw Contracts.ExceptParam(nameof(userType), $"Member {memberInfo.Name} marked with {nameof(VectorTypeAttribute)}, but does not appear to be a vector type", memberInfo.Name);
-                    if (isVector)
-                    {
-                        int[] dims = vectorAttr?.Dims;
-                        if (dims != null && dims.Any(d => d < 0))
-                            throw Contracts.ExceptParam(nameof(userType), "Some of member {0}'s dimension lengths are negative");
-                        if (Utils.Size(dims) == 0)
-                            columnType = new VectorDataViewType(itemType, 0);
-                        else
-                            columnType = new VectorDataViewType(itemType, dims);
-                    }
-                    else
-                        columnType = itemType;
-                }
-                else
-                    columnType = DataViewTypeManager.GetDataViewType(dataType, customAttributes);
-
-                cols.Add(new Column(memberInfo.Name, columnType, name));
-            }
-            return cols;
-            /*var memberInfos = GetMemberInfos(userType, direction);
-
-            SchemaDefinition cols = new SchemaDefinition();
-            HashSet<string> colNames = new HashSet<string>();
-
-            foreach (var memberInfo in memberInfos)
-            {
-                IEnumerable<Attribute> customAttributes = null;
-                string name = null;
-
-                if(MemberInfoAssertion(memberInfo, userType, name, colNames, customAttributes))
+                if (MemberInfoAssertion(memberInfo, userType, out string name, colNames, out IEnumerable<Attribute> customAttributes))
                 {
                     InternalSchemaDefinition.GetVectorAndItemType(memberInfo, out bool isVector, out Type dataType);
 
@@ -557,7 +459,7 @@ namespace Microsoft.ML.Data
                     cols.Add(new Column(memberInfo.Name, columnType, name));
                 }
             }
-            return cols;*/
+            return cols;
         }
     }
 }

--- a/src/Microsoft.ML.Data/Data/SchemaDefinition.cs
+++ b/src/Microsoft.ML.Data/Data/SchemaDefinition.cs
@@ -332,16 +332,7 @@ namespace Microsoft.ML.Data
         /// <param name="userType">The type to base the schema on.</param>
         /// <param name="direction">Accept fields and properties based on their direction.</param>
         /// <returns>The generated schema definition.</returns>
-        public static SchemaDefinition Create(Type userType, Direction direction = Direction.Both) => Create(userType, direction, null);
-
-        /// <summary>
-        /// Create a schema definition by enumerating all public fields of the given type.
-        /// </summary>
-        /// <param name="userType">The type to base the schema on.</param>
-        /// <param name="direction">Accept fields and properties based on their direction.</param>
-        /// <param name="data">DataView that contains the expected type of input and output of transformers</param>
-        /// <returns>The generated schema definition.</returns>
-        public static SchemaDefinition Create(Type userType, Direction direction, IDataView data)
+        public static SchemaDefinition Create(Type userType, Direction direction = Direction.Both)
         {
             // REVIEW: This will have to be updated whenever we start
             // supporting properties and not just fields.
@@ -410,7 +401,7 @@ namespace Microsoft.ML.Data
                 if (!colNames.Add(name))
                     throw Contracts.ExceptParam(nameof(userType), "Duplicate column name '{0}' detected, this is disallowed", name);
 
-                InternalSchemaDefinition.GetVectorAndItemType(memberInfo, out bool isVector, out Type dataType, data, name);
+                InternalSchemaDefinition.GetVectorAndItemType(memberInfo, out bool isVector, out Type dataType);
 
                 // Get the column type.
                 DataViewType columnType;

--- a/src/Microsoft.ML.Data/DataView/InternalSchemaDefinition.cs
+++ b/src/Microsoft.ML.Data/DataView/InternalSchemaDefinition.cs
@@ -141,8 +141,8 @@ namespace Microsoft.ML.Data
         /// <param name="itemType">
         /// The corresponding <see cref="PrimitiveDataViewType"/> RawType of the type, or items of this type if vector.
         /// </param>
-        /// <param name="data">onnx data information</param>
-        /// <param name="singleName">Column name used to find the corresponding data type in onnx</param>
+        /// <param name="data">DataView that contains the expected type of input and output of transformers</param>
+        /// <param name="singleName">Column name used to find the corresponding expected data type</param>
         public static void GetVectorAndItemType(MemberInfo memberInfo, out bool isVector, out Type itemType, IDataView data = null, string singleName = null)
         {
             Contracts.AssertValue(memberInfo);
@@ -174,8 +174,8 @@ namespace Microsoft.ML.Data
         /// <param name="itemType">
         /// The corresponding <see cref="PrimitiveDataViewType"/> RawType of the type, or items of this type if vector.
         /// </param>
-        /// <param name="data">onnx data information</param>
-        /// <param name="singleName">Column name used to find the corresponding data type in onnx</param>
+        /// <param name="data">DataView that contains the expected type of input and output of transformers</param>
+        /// <param name="singleName">Column name used to find the corresponding expected data type</param>
         public static void GetVectorAndItemType(string name, Type rawType, IEnumerable<Attribute> attributes, out bool isVector, out Type itemType, IDataView data = null, string singleName = null)
         {
             // Determine whether this is a vector, and also determine the raw item type.
@@ -199,13 +199,13 @@ namespace Microsoft.ML.Data
             {
                 int colIndex;
                 data.Schema.TryGetColumnIndex(singleName, out colIndex);
-                var onnxType = data.Schema[colIndex].Type;
+                var expectedType = data.Schema[colIndex].Type;
                 //This is a big hack. it uses DataViewTypeManager to check if there's "make-up" types in it
                 //e.g. customer define the type "float", and this will check if "IEnumerable<float>" in the DateTypeManager
                 //It gives helpful information when customer accidently define OnnxSequenceType the same as member type
                 Type containerType = typeof(IEnumerable<>).MakeGenericType(itemType);
                 if (DataViewTypeManager.Knows(containerType, attributes))
-                    throw Contracts.ExceptParam(nameof(rawType), $"The expected type '{onnxType.RawType}' does not match the type of the {name} property: '{itemType.Name}'. Please change the {name} property to '{onnxType.RawType}'", name);
+                    throw Contracts.ExceptParam(nameof(rawType), $"The expected type '{expectedType.RawType}' does not match the type of the {name} property: '{itemType.Name}'. Please change the {name} property to '{expectedType.RawType}'", name);
                 throw Contracts.ExceptParam(nameof(rawType), "Could not determine an IDataView type and registered custom types for member {0}", name);
             }
         }

--- a/src/Microsoft.ML.Data/DataView/InternalSchemaDefinition.cs
+++ b/src/Microsoft.ML.Data/DataView/InternalSchemaDefinition.cs
@@ -194,8 +194,9 @@ namespace Microsoft.ML.Data
             else if (!itemType.TryGetDataKind(out _) && !DataViewTypeManager.Knows(itemType, attributes))
             {
                 //This is a big hack. it uses DataViewTypeManager to check if there's "make-up" types in it
-                //(e.g. customer define the type "float", and this will check if "iEnumerable" in the DateTypeManager)
+                //e.g. customer define the type "float", and this will check if "IEnumerable<float>" in the DateTypeManager
                 //It gives helpful information when customer accidently define OnnxSequenceType the same as member type
+                //The suggestion type here is not always correct, but will at least guide customer to next-step checks which will give more informational messages
                 Type containerType = typeof(IEnumerable<>).MakeGenericType(itemType);
                 if (DataViewTypeManager.Knows(containerType, attributes))
                     throw Contracts.ExceptParam(nameof(rawType), $"The possible expected type '{containerType.Name}' does not match the type of the property: '{itemType.Name}'. Change the {0} property to '{containerType.Name}' may solve the issue", name);

--- a/src/Microsoft.ML.Data/DataView/InternalSchemaDefinition.cs
+++ b/src/Microsoft.ML.Data/DataView/InternalSchemaDefinition.cs
@@ -160,19 +160,7 @@ namespace Microsoft.ML.Data
             }
         }
 
-        /// <summary>
-        /// Given a type and name for a variable, returns whether this appears to be a vector type,
-        /// and also the associated data type for this type. If a valid data type could not
-        /// be determined, this will throw.
-        /// </summary>
-        /// <param name="name">The name of the variable to inspect.</param>
-        /// <param name="rawType">The type of the variable to inspect.</param>
-        /// <param name="attributes">Attribute of <paramref name="rawType"/>. It can be <see langword="null"/> if attributes don't exist.</param>
-        /// <param name="isVector">Whether this appears to be a vector type.</param>
-        /// <param name="itemType">
-        /// The corresponding <see cref="PrimitiveDataViewType"/> RawType of the type, or items of this type if vector.
-        /// </param>
-        public static void GetVectorAndItemType(string name, Type rawType, IEnumerable<Attribute> attributes, out bool isVector, out Type itemType)
+        public static void GetMappedType(Type rawType, out Type itemType, out bool isVector)
         {
             // Determine whether this is a vector, and also determine the raw item type.
             isVector = true;
@@ -189,9 +177,26 @@ namespace Microsoft.ML.Data
             // The internal type of string is ReadOnlyMemory<char>. That is, string will be stored as ReadOnlyMemory<char> in IDataView.
             if (itemType == typeof(string))
                 itemType = typeof(ReadOnlyMemory<char>);
+        }
+
+        /// <summary>
+        /// Given a type and name for a variable, returns whether this appears to be a vector type,
+        /// and also the associated data type for this type. If a valid data type could not
+        /// be determined, this will throw.
+        /// </summary>
+        /// <param name="name">The name of the variable to inspect.</param>
+        /// <param name="rawType">The type of the variable to inspect.</param>
+        /// <param name="attributes">Attribute of <paramref name="rawType"/>. It can be <see langword="null"/> if attributes don't exist.</param>
+        /// <param name="isVector">Whether this appears to be a vector type.</param>
+        /// <param name="itemType">
+        /// The corresponding <see cref="PrimitiveDataViewType"/> RawType of the type, or items of this type if vector.
+        /// </param>
+        public static void GetVectorAndItemType(string name, Type rawType, IEnumerable<Attribute> attributes, out bool isVector, out Type itemType)
+        {
+            GetMappedType(rawType, out itemType, out isVector);
             // Check if the itemType extracted from rawType is supported by ML.NET's type system.
             // It must be one of either ML.NET's pre-defined types or custom types registered by the user.
-            else if (!itemType.TryGetDataKind(out _) && !DataViewTypeManager.Knows(itemType, attributes))
+            if (!itemType.TryGetDataKind(out _) && !DataViewTypeManager.Knows(itemType, attributes))
             {
                 throw Contracts.ExceptParam(nameof(rawType), "Could not determine an IDataView type and registered custom types for member {0}", name);
             }

--- a/src/Microsoft.ML.Data/DataView/InternalSchemaDefinition.cs
+++ b/src/Microsoft.ML.Data/DataView/InternalSchemaDefinition.cs
@@ -210,17 +210,13 @@ namespace Microsoft.ML.Data
             }
         }
 
-        public static InternalSchemaDefinition Create(Type userType, SchemaDefinition.Direction direction) => Create(userType, direction, null);
-
-        public static InternalSchemaDefinition Create(Type userType, SchemaDefinition.Direction direction, IDataView data)
+        public static InternalSchemaDefinition Create(Type userType, SchemaDefinition.Direction direction)
         {
-            var userSchemaDefinition = SchemaDefinition.Create(userType, direction, data);
-            return Create(userType, userSchemaDefinition, data);
+            var userSchemaDefinition = SchemaDefinition.Create(userType, direction);
+            return Create(userType, userSchemaDefinition);
         }
 
-        public static InternalSchemaDefinition Create(Type userType, SchemaDefinition userSchemaDefinition) => Create(userType, userSchemaDefinition, null);
-
-        public static InternalSchemaDefinition Create(Type userType, SchemaDefinition userSchemaDefinition, IDataView data)
+        public static InternalSchemaDefinition Create(Type userType, SchemaDefinition userSchemaDefinition)
         {
             Contracts.AssertValue(userType);
             Contracts.AssertValueOrNull(userSchemaDefinition);

--- a/src/Microsoft.ML.Data/DataView/InternalSchemaDefinition.cs
+++ b/src/Microsoft.ML.Data/DataView/InternalSchemaDefinition.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using Microsoft.ML.Runtime;

--- a/src/Microsoft.ML.Data/DataView/InternalSchemaDefinition.cs
+++ b/src/Microsoft.ML.Data/DataView/InternalSchemaDefinition.cs
@@ -210,13 +210,17 @@ namespace Microsoft.ML.Data
             }
         }
 
-        public static InternalSchemaDefinition Create(Type userType, SchemaDefinition.Direction direction, IDataView data = null)
+        public static InternalSchemaDefinition Create(Type userType, SchemaDefinition.Direction direction) => Create(userType, direction, null);
+
+        public static InternalSchemaDefinition Create(Type userType, SchemaDefinition.Direction direction, IDataView data)
         {
             var userSchemaDefinition = SchemaDefinition.Create(userType, direction, data);
             return Create(userType, userSchemaDefinition, data);
         }
 
-        public static InternalSchemaDefinition Create(Type userType, SchemaDefinition userSchemaDefinition, IDataView data = null)
+        public static InternalSchemaDefinition Create(Type userType, SchemaDefinition userSchemaDefinition) => Create(userType, userSchemaDefinition, null);
+
+        public static InternalSchemaDefinition Create(Type userType, SchemaDefinition userSchemaDefinition, IDataView data)
         {
             Contracts.AssertValue(userType);
             Contracts.AssertValueOrNull(userSchemaDefinition);

--- a/src/Microsoft.ML.Data/DataView/InternalSchemaDefinition.cs
+++ b/src/Microsoft.ML.Data/DataView/InternalSchemaDefinition.cs
@@ -178,13 +178,7 @@ namespace Microsoft.ML.Data
             // Determine whether this is a vector, and also determine the raw item type.
             isVector = true;
             if (rawType.IsArray)
-            {
                 itemType = rawType.GetElementType();
-                // Sometimes when user define the type in a wrong way. e.g [OnnxSequenceType(typeof(IEnumerable<float>))]\n public IEnumerable<float> loss;
-                //
-                //if (itemType.IsArray)
-                //    itemType = itemType.GetElementType();
-            }
             else if (rawType.IsGenericType && rawType.GetGenericTypeDefinition() == typeof(VBuffer<>))
                 itemType = rawType.GetGenericArguments()[0];
             else

--- a/src/Microsoft.ML.Data/DataView/InternalSchemaDefinition.cs
+++ b/src/Microsoft.ML.Data/DataView/InternalSchemaDefinition.cs
@@ -193,7 +193,9 @@ namespace Microsoft.ML.Data
             // It must be one of either ML.NET's pre-defined types or custom types registered by the user.
             else if (!itemType.TryGetDataKind(out _) && !DataViewTypeManager.Knows(itemType, attributes))
             {
-                //This is a big hack. It gives helpful information when customer accidently define OnnxSequenceType the same as member type
+                //This is a big hack. it uses DataViewTypeManager to check if there's "make-up" types in it
+                //(e.g. customer define the type "float", and this will check if "iEnumerable" in the DateTypeManager)
+                //It gives helpful information when customer accidently define OnnxSequenceType the same as member type
                 Type containerType = typeof(IEnumerable<>).MakeGenericType(itemType);
                 if (DataViewTypeManager.Knows(containerType, attributes))
                     throw Contracts.ExceptParam(nameof(rawType), $"The possible expected type '{containerType.Name}' does not match the type of the property: '{itemType.Name}'. Change the {0} property to '{containerType.Name}' may solve the issue", name);

--- a/src/Microsoft.ML.Data/DataView/InternalSchemaDefinition.cs
+++ b/src/Microsoft.ML.Data/DataView/InternalSchemaDefinition.cs
@@ -194,8 +194,9 @@ namespace Microsoft.ML.Data
             else if (!itemType.TryGetDataKind(out _) && !DataViewTypeManager.Knows(itemType, attributes))
             {
                 //This is a big hack. It gives helpful information when customer accidently define OnnxSequenceType the same as member type
-                if (DataViewTypeManager.Knows(typeof(IEnumerable<>).MakeGenericType(itemType), attributes))
-                    throw Contracts.ExceptParam(nameof(rawType), "Defined uncessary container type of member {0}", name);
+                Type containerType = typeof(IEnumerable<>).MakeGenericType(itemType);
+                if (DataViewTypeManager.Knows(containerType, attributes))
+                    throw Contracts.ExceptParam(nameof(rawType), $"The possible expected type '{containerType.Name}' does not match the type of the property: '{itemType.Name}'. Change the {0} property to '{containerType.Name}' may solve the issue", name);
                 throw Contracts.ExceptParam(nameof(rawType), "Could not determine an IDataView type and registered custom types for member {0}", name);
             }
         }

--- a/src/Microsoft.ML.Data/DataView/TypedCursor.cs
+++ b/src/Microsoft.ML.Data/DataView/TypedCursor.cs
@@ -255,7 +255,7 @@ namespace Microsoft.ML.Data
             }
         }
 
-        public static void ValidateUserType(SchemaDefinition schemaDefinition, Type userType, IDataView data)
+        private static void ValidateUserType(SchemaDefinition schemaDefinition, Type userType, IDataView data)
         {
             //Get memberInfos
             MemberInfo[] memberInfos = null;

--- a/src/Microsoft.ML.Data/DataView/TypedCursor.cs
+++ b/src/Microsoft.ML.Data/DataView/TypedCursor.cs
@@ -221,16 +221,11 @@ namespace Microsoft.ML.Data
         {
             var memberInfos = SchemaDefinition.GetMemberInfos(userType, SchemaDefinition.Direction.Write);
 
+            HashSet<string> colNames = new HashSet<string>();
             foreach (var memberInfo in memberInfos)
             {
-                string name = null;
-                if (SchemaDefinition.MemberInfoAssertion(memberInfo, userType, name))
-                {
-                    int colIndex;
-                    data.Schema.TryGetColumnIndex(name, out colIndex);
-                    var expectedType = data.Schema[colIndex].Type;
-                }
-                InternalSchemaDefinition.GetVectorAndItemType(memberInfo, out bool isVector, out Type dataType, data, name);
+                if (SchemaDefinition.MemberInfoAssertion(memberInfo, userType, out string name, colNames))
+                    InternalSchemaDefinition.GetVectorAndItemType(memberInfo, out bool isVector, out Type dataType, data, name);
             }
         }
 

--- a/src/Microsoft.ML.Data/DataView/TypedCursor.cs
+++ b/src/Microsoft.ML.Data/DataView/TypedCursor.cs
@@ -224,7 +224,7 @@ namespace Microsoft.ML.Data
             HashSet<string> colNames = new HashSet<string>();
             foreach (var memberInfo in memberInfos)
             {
-                if (SchemaDefinition.MemberInfoAssertion(memberInfo, userType, out string name, colNames))
+                if (SchemaDefinition.MemberInfoAssertion(memberInfo, userType, out string name, colNames, out IEnumerable<Attribute> customAttributes))
                     InternalSchemaDefinition.GetVectorAndItemType(memberInfo, out bool isVector, out Type dataType, data, name);
             }
         }

--- a/src/Microsoft.ML.Data/DataView/TypedCursor.cs
+++ b/src/Microsoft.ML.Data/DataView/TypedCursor.cs
@@ -224,7 +224,7 @@ namespace Microsoft.ML.Data
             HashSet<string> colNames = new HashSet<string>();
             foreach (var memberInfo in memberInfos)
             {
-                if (SchemaDefinition.MemberInfoAssertion(memberInfo, userType, out string name, colNames, out IEnumerable<Attribute> customAttributes))
+                if (SchemaDefinition.MemberInfoAssertion(memberInfo, userType, colNames, out string name, out IEnumerable<Attribute> customAttributes))
                     InternalSchemaDefinition.GetVectorAndItemType(memberInfo, out bool isVector, out Type dataType, data, name);
             }
         }

--- a/src/Microsoft.ML.Data/DataView/TypedCursor.cs
+++ b/src/Microsoft.ML.Data/DataView/TypedCursor.cs
@@ -301,23 +301,7 @@ namespace Microsoft.ML.Data
                 data.Schema.TryGetColumnIndex(name, out colIndex);
                 var expectedType = data.Schema[colIndex].Type;
 
-                Contracts.AssertValue(memberInfo);
-                switch (memberInfo)
-                {
-                    case FieldInfo fieldInfo:
-                        if (!fieldInfo.FieldType.Equals(expectedType))
-                            throw Contracts.ExceptParam(nameof(fieldInfo.FieldType), $"The expected type '{expectedType.RawType}' does not match the type of the {name} property: '{fieldInfo.FieldType.Name}'. Please change the {name} property to '{expectedType.RawType}'", name);
-                        break;
-
-                    case PropertyInfo propertyInfo:
-                        if (!propertyInfo.PropertyType.Equals(expectedType))
-                            throw Contracts.ExceptParam(nameof(propertyInfo.PropertyType), $"The expected type '{expectedType.RawType}' does not match the type of the {name} property: '{propertyInfo.PropertyType.Name}'. Please change the {name} property to '{expectedType.RawType}'", name);
-                        break;
-
-                    default:
-                        Contracts.Assert(false);
-                        throw Contracts.ExceptNotSupp("Expected a FieldInfo or a PropertyInfo");
-                }
+                InternalSchemaDefinition.GetVectorAndItemType(memberInfo, out bool isVector, out Type dataType, data, name);
             }
             //--------------------------------------------------------------------------------------------------------------
 

--- a/src/Microsoft.ML.Data/DataView/TypedCursor.cs
+++ b/src/Microsoft.ML.Data/DataView/TypedCursor.cs
@@ -231,6 +231,96 @@ namespace Microsoft.ML.Data
             env.AssertValue(data);
             env.AssertValueOrNull(schemaDefinition);
 
+            //------------------------------------------------------------------------------------------------
+            //this is new
+            Type userType = typeof(TRow);
+            var direction = SchemaDefinition.Direction.Write;
+            // REVIEW: This will have to be updated whenever we start
+            // supporting properties and not just fields.
+            Contracts.CheckValue(userType, nameof(userType));
+
+            //SchemaDefinition cols = new SchemaDefinition();
+            HashSet<string> colNames = new HashSet<string>();
+
+            var fieldInfos = userType.GetFields(BindingFlags.Public | BindingFlags.Instance);
+            var propertyInfos =
+                userType
+                .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Where(x => (((direction & SchemaDefinition.Direction.Read) == SchemaDefinition.Direction.Read && (x.CanRead && x.GetGetMethod() != null)) ||
+                ((direction & SchemaDefinition.Direction.Write) == SchemaDefinition.Direction.Write && (x.CanWrite && x.GetSetMethod() != null))) &&
+                x.GetIndexParameters().Length == 0);
+
+            var memberInfos = (fieldInfos as IEnumerable<MemberInfo>).Concat(propertyInfos).ToArray();
+
+            foreach (var memberInfo in memberInfos)
+            {
+                // Clause to handle the field that may be used to expose the cursor channel.
+                // This field does not need a column.
+                // REVIEW: maybe validate the channel attribute now, instead
+                // of later at cursor creation.
+                switch (memberInfo)
+                {
+                    case FieldInfo fieldInfo:
+                        if (fieldInfo.FieldType == typeof(IChannel))
+                            continue;
+
+                        // Const fields do not need to be mapped.
+                        if (fieldInfo.IsLiteral)
+                            continue;
+
+                        break;
+
+                    case PropertyInfo propertyInfo:
+                        if (propertyInfo.PropertyType == typeof(IChannel))
+                            continue;
+                        break;
+
+                    default:
+                        Contracts.Assert(false);
+                        throw Contracts.ExceptNotSupp("Expected a FieldInfo or a PropertyInfo");
+                }
+
+                if (memberInfo.GetCustomAttribute<NoColumnAttribute>() != null)
+                    continue;
+
+                var customAttributes = memberInfo.GetCustomAttributes();
+                var customTypeAttributes = customAttributes.Where(x => x is DataViewTypeAttribute);
+                if (customTypeAttributes.Count() > 1)
+                    throw Contracts.ExceptParam(nameof(userType), "Member {0} cannot be marked with multiple attributes, {1}, derived from {2}.",
+                        memberInfo.Name, customTypeAttributes, typeof(DataViewTypeAttribute));
+                else if (customTypeAttributes.Count() == 1)
+                {
+                    var customTypeAttribute = (DataViewTypeAttribute)customTypeAttributes.First();
+                    customTypeAttribute.Register();
+                }
+
+                var mappingNameAttr = memberInfo.GetCustomAttribute<ColumnNameAttribute>();
+                string name = mappingNameAttr?.Name ?? memberInfo.Name;
+
+                int colIndex;
+                data.Schema.TryGetColumnIndex(name, out colIndex);
+                var expectedType = data.Schema[colIndex].Type;
+
+                Contracts.AssertValue(memberInfo);
+                switch (memberInfo)
+                {
+                    case FieldInfo fieldInfo:
+                        if (!fieldInfo.FieldType.Equals(expectedType))
+                            throw Contracts.ExceptParam(nameof(fieldInfo.FieldType), $"The expected type '{expectedType.RawType}' does not match the type of the {name} property: '{fieldInfo.FieldType.Name}'. Please change the {name} property to '{expectedType.RawType}'", name);
+                        break;
+
+                    case PropertyInfo propertyInfo:
+                        if (!propertyInfo.PropertyType.Equals(expectedType))
+                            throw Contracts.ExceptParam(nameof(propertyInfo.PropertyType), $"The expected type '{expectedType.RawType}' does not match the type of the {name} property: '{propertyInfo.PropertyType.Name}'. Please change the {name} property to '{expectedType.RawType}'", name);
+                        break;
+
+                    default:
+                        Contracts.Assert(false);
+                        throw Contracts.ExceptNotSupp("Expected a FieldInfo or a PropertyInfo");
+                }
+            }
+            //--------------------------------------------------------------------------------------------------------------
+
             var outSchema = schemaDefinition == null
                 ? InternalSchemaDefinition.Create(typeof(TRow), SchemaDefinition.Direction.Write, data)
                 : InternalSchemaDefinition.Create(typeof(TRow), schemaDefinition, data);

--- a/src/Microsoft.ML.Data/DataView/TypedCursor.cs
+++ b/src/Microsoft.ML.Data/DataView/TypedCursor.cs
@@ -232,8 +232,8 @@ namespace Microsoft.ML.Data
             env.AssertValueOrNull(schemaDefinition);
 
             var outSchema = schemaDefinition == null
-                ? InternalSchemaDefinition.Create(typeof(TRow), SchemaDefinition.Direction.Write)
-                : InternalSchemaDefinition.Create(typeof(TRow), schemaDefinition);
+                ? InternalSchemaDefinition.Create(typeof(TRow), SchemaDefinition.Direction.Write, data)
+                : InternalSchemaDefinition.Create(typeof(TRow), schemaDefinition, data);
 
             return new TypedCursorable<TRow>(env, data, ignoreMissingColumns, outSchema);
         }

--- a/src/Microsoft.ML.Data/DataView/TypedCursor.cs
+++ b/src/Microsoft.ML.Data/DataView/TypedCursor.cs
@@ -217,71 +217,13 @@ namespace Microsoft.ML.Data
                  .ToArray();
         }
 
-        public static void GetVectorAndItemType(string name, Type rawType, IEnumerable<Attribute> attributes, out bool isVector, out Type itemType, IDataView data, string singleName)
-        {
-            // Determine whether this is a vector, and also determine the raw item type.
-            isVector = true;
-            if (rawType.IsArray)
-                itemType = rawType.GetElementType();
-            else if (rawType.IsGenericType && rawType.GetGenericTypeDefinition() == typeof(VBuffer<>))
-                itemType = rawType.GetGenericArguments()[0];
-            else
-            {
-                itemType = rawType;
-                isVector = false;
-            }
-
-            // The internal type of string is ReadOnlyMemory<char>. That is, string will be stored as ReadOnlyMemory<char> in IDataView.
-            if (itemType == typeof(string))
-                itemType = typeof(ReadOnlyMemory<char>);
-            // Check if the itemType extracted from rawType is supported by ML.NET's type system.
-            // It must be one of either ML.NET's pre-defined types or custom types registered by the user.
-            else if (!itemType.TryGetDataKind(out _) && !DataViewTypeManager.Knows(itemType, attributes))
-            {
-                int colIndex;
-                data.Schema.TryGetColumnIndex(singleName, out colIndex);
-                var expectedType = data.Schema[colIndex].Type;
-                //This is a big hack. it uses DataViewTypeManager to check if there's "make-up" types in it
-                //e.g. customer define the type "float", and this will check if "IEnumerable<float>" in the DateTypeManager
-                //It gives helpful information when customer accidently define OnnxSequenceType the same as member type
-                Type containerType = typeof(IEnumerable<>).MakeGenericType(itemType);
-                if (DataViewTypeManager.Knows(containerType, attributes))
-                    throw Contracts.ExceptParam(nameof(rawType), $"The expected type '{expectedType.RawType}' does not match the type of the {name} property: '{itemType.Name}'. Please change the {name} property to '{expectedType.RawType}'", name);
-                throw Contracts.ExceptParam(nameof(rawType), "Could not determine an IDataView type and registered custom types for member {0}", name);
-            }
-        }
-
-        public static void GetVectorAndItemType(MemberInfo memberInfo, out bool isVector, out Type itemType, IDataView data, string singleName)
-        {
-            Contracts.AssertValue(memberInfo);
-            switch (memberInfo)
-            {
-                case FieldInfo fieldInfo:
-                    GetVectorAndItemType(fieldInfo.Name, fieldInfo.FieldType, fieldInfo.GetCustomAttributes(), out isVector, out itemType, data, singleName);
-                    break;
-
-                case PropertyInfo propertyInfo:
-                    GetVectorAndItemType(propertyInfo.Name, propertyInfo.PropertyType, propertyInfo.GetCustomAttributes(), out isVector, out itemType, data, singleName);
-                    break;
-
-                default:
-                    Contracts.Assert(false);
-                    throw Contracts.ExceptNotSupp("Expected a FieldInfo or a PropertyInfo");
-            }
-        }
-
         public static void ValidateUserType(SchemaDefinition schemaDefinition, Type userType, IDataView data)
         {
+            //Get memberInfos
+            MemberInfo[] memberInfos = null;
             if (schemaDefinition == null)
             {
-                var memberInfos = SchemaDefinition.GetMemberInfos(userType, SchemaDefinition.Direction.Write);
-
-                HashSet<string> colNames = new HashSet<string>();
-                foreach (var memberInfo in memberInfos)
-                {
-                    if (SchemaDefinition.ValidateMemberInfo(memberInfo, userType, colNames, out string name, out IEnumerable<Attribute> customAttributes))
-                        GetVectorAndItemType(memberInfo, out bool isVector, out Type dataType, data, name);
-                }
+                memberInfos = SchemaDefinition.GetMemberInfos(userType, SchemaDefinition.Direction.Write);
             }
             else
             {
@@ -291,10 +233,7 @@ namespace Microsoft.ML.Data
                     if (col.MemberName == null)
                         throw Contracts.ExceptParam(nameof(schemaDefinition), "Null field name detected in schema definition");
 
-                    bool isVector;
-                    Type dataItemType;
                     MemberInfo memberInfo = null;
-
                     // Infer the column name.
                     var colName = string.IsNullOrEmpty(col.ColumnName) ? col.MemberName : col.ColumnName;
 
@@ -304,28 +243,44 @@ namespace Microsoft.ML.Data
 
                         if (memberInfo == null)
                             memberInfo = userType.GetProperty(col.MemberName);
-
-                        if (memberInfo == null)
-                            throw Contracts.ExceptParam(nameof(schemaDefinition), "No field or property with name '{0}' found in type '{1}'",
-                                col.MemberName,
-                                userType.FullName);
-
-                        //Clause to handle the field that may be used to expose the cursor channel.
-                        //This field does not need a column.
-                        if ((memberInfo is FieldInfo && (memberInfo as FieldInfo).FieldType == typeof(IChannel)) ||
-                            (memberInfo is PropertyInfo && (memberInfo as PropertyInfo).PropertyType == typeof(IChannel)))
-                            continue;
-
-                        GetVectorAndItemType(memberInfo, out isVector, out dataItemType, data, colName);
                     }
                     else
                     {
-                        var parameterType = col.ReturnType;
-                        if (parameterType == null)
-                            throw Contracts.ExceptParam(nameof(schemaDefinition), "No return parameter found in computed column.");
-                        GetVectorAndItemType("returnType", parameterType, null, out isVector, out dataItemType, data, colName);
+                        memberInfo = col.ReturnType;
                     }
+                    memberInfos.AppendElement(memberInfo);
                 }
+            }
+
+            foreach (var memberInfo in memberInfos)
+            {
+                if (memberInfo == null)
+                    continue;
+                var mappingNameAttr = memberInfo.GetCustomAttribute<ColumnNameAttribute>();
+                var singleName = mappingNameAttr?.Name ?? memberInfo.Name;
+
+                int colIndex;
+                data.Schema.TryGetColumnIndex(singleName, out colIndex);
+                DataViewType expectedType = data.Schema[colIndex].Type;
+
+                Type actualType = null;
+                switch (memberInfo)
+                {
+                    case FieldInfo fieldInfo:
+                        actualType = fieldInfo.FieldType;
+                        break;
+
+                    case PropertyInfo propertyInfo:
+                        actualType = propertyInfo.PropertyType;
+                        break;
+
+                    default:
+                        Contracts.Assert(false);
+                        throw Contracts.ExceptNotSupp("Expected a FieldInfo or a PropertyInfo");
+                    }
+
+                if (!actualType.Equals(expectedType.RawType))
+                    throw Contracts.ExceptParam(nameof(actualType), $"The expected type '{expectedType.RawType}' does not match the type of the '{singleName}' property: '{actualType.Name}'. Please change the {singleName} property to '{expectedType.RawType}'");
             }
         }
 

--- a/src/Microsoft.ML.Data/DataView/TypedCursor.cs
+++ b/src/Microsoft.ML.Data/DataView/TypedCursor.cs
@@ -306,8 +306,8 @@ namespace Microsoft.ML.Data
             //--------------------------------------------------------------------------------------------------------------
 
             var outSchema = schemaDefinition == null
-                ? InternalSchemaDefinition.Create(typeof(TRow), SchemaDefinition.Direction.Write, data)
-                : InternalSchemaDefinition.Create(typeof(TRow), schemaDefinition, data);
+                ? InternalSchemaDefinition.Create(typeof(TRow), SchemaDefinition.Direction.Write)
+                : InternalSchemaDefinition.Create(typeof(TRow), schemaDefinition);
 
             return new TypedCursorable<TRow>(env, data, ignoreMissingColumns, outSchema);
         }

--- a/src/Microsoft.ML.Data/DataView/TypedCursor.cs
+++ b/src/Microsoft.ML.Data/DataView/TypedCursor.cs
@@ -217,10 +217,10 @@ namespace Microsoft.ML.Data
                  .ToArray();
         }
 
-        public static bool ValidateMemberInfo(MemberInfo memberInfo, IDataView data)
+        public static void ValidateMemberInfo(MemberInfo memberInfo, IDataView data)
         {
             if (!SchemaDefinition.CheckMemberInfo(memberInfo))
-                return false;
+                return;
 
             var mappingNameAttr = memberInfo.GetCustomAttribute<ColumnNameAttribute>();
             var singleName = mappingNameAttr?.Name ?? memberInfo.Name;
@@ -253,8 +253,6 @@ namespace Microsoft.ML.Data
                 if (!actualType.Equals(expectedType.RawType))
                     throw Contracts.ExceptParam(nameof(actualType), $"The expected type '{expectedType.RawType}' does not match the type of the '{singleName}' property: '{actualType.Name}'. Please change the {singleName} property to '{expectedType.RawType}'");
             }
-
-            return true;
         }
 
         public static void ValidateUserType(SchemaDefinition schemaDefinition, Type userType, IDataView data)
@@ -292,9 +290,7 @@ namespace Microsoft.ML.Data
                     {
                         memberInfo = col.ReturnType;
                     }
-
-                    if (!ValidateMemberInfo(memberInfo, data))
-                        continue;
+                    ValidateMemberInfo(memberInfo, data);
                 }
             }
 
@@ -302,10 +298,7 @@ namespace Microsoft.ML.Data
                 return;
 
             foreach (var memberInfo in memberInfos)
-            {
-                if (!ValidateMemberInfo(memberInfo, data))
-                    continue;
-            }
+                ValidateMemberInfo(memberInfo, data);
         }
 
         /// <summary>

--- a/test/Microsoft.ML.Tests/OnnxSequenceTypeWithAttributesTest.cs
+++ b/test/Microsoft.ML.Tests/OnnxSequenceTypeWithAttributesTest.cs
@@ -63,7 +63,45 @@ namespace Microsoft.ML.Tests
             {
                 Assert.Equal(onnxOut[keys[i]], input.Input[i]);
             }
+        }
 
+        public class WrongOutputObj
+        {
+            [ColumnName("output")]
+            [OnnxSequenceType(typeof(IEnumerable<float>))]
+            public IEnumerable<float> Output;
+        }
+
+        public static PredictionEngine<FloatInput, WrongOutputObj> LoadModelWithWrongCustomType(string onnxModelFilePath)
+        {
+            var ctx = new MLContext(1);
+            var dataView = ctx.Data.LoadFromEnumerable(new List<FloatInput>());
+
+            var pipeline = ctx.Transforms.ApplyOnnxModel(
+                                modelFile: onnxModelFilePath,
+                                outputColumnNames: new[] { "output" }, inputColumnNames: new[] { "input" });
+
+            var model = pipeline.Fit(dataView);
+            return ctx.Model.CreatePredictionEngine<FloatInput, WrongOutputObj>(model);
+        }
+
+        [OnnxFact]
+        public void OnnxSequenceTypeWithColumnNameAttributeTestWithWrongCustomType()
+        {
+            var modelFile = Path.Combine(Directory.GetCurrentDirectory(), "zipmap", "TestZipMapString.onnx");
+            //var predictor = LoadModelWithWrongCustomType(modelFile);
+            var expectedExceptionMessage = "The expected type 'System.Collections.Generic.IEnumerable`1[System.Collections.Generic.IDictionary`2[System.String,System.Single]]'" +
+                " does not match the type of the 'output' member: 'System.Collections.Generic.IEnumerable`1[System.Single]'." +
+                " Please change the output member to 'System.Collections.Generic.IEnumerable`1[System.Collections.Generic.IDictionary`2[System.String,System.Single]]'\r\nParameter name: actualType";
+            try
+            {
+                var predictor = LoadModelWithWrongCustomType(modelFile);
+            }
+            catch (System.Exception ex)
+            {
+                Assert.Equal(ex.Message, expectedExceptionMessage);
+                return;
+            }
         }
     }
 }

--- a/test/Microsoft.ML.Tests/OnnxSequenceTypeWithAttributesTest.cs
+++ b/test/Microsoft.ML.Tests/OnnxSequenceTypeWithAttributesTest.cs
@@ -89,17 +89,18 @@ namespace Microsoft.ML.Tests
         public void OnnxSequenceTypeWithColumnNameAttributeTestWithWrongCustomType()
         {
             var modelFile = Path.Combine(Directory.GetCurrentDirectory(), "zipmap", "TestZipMapString.onnx");
-            //var predictor = LoadModelWithWrongCustomType(modelFile);
             var expectedExceptionMessage = "The expected type 'System.Collections.Generic.IEnumerable`1[System.Collections.Generic.IDictionary`2[System.String,System.Single]]'" +
                 " does not match the type of the 'output' member: 'System.Collections.Generic.IEnumerable`1[System.Single]'." +
-                " Please change the output member to 'System.Collections.Generic.IEnumerable`1[System.Collections.Generic.IDictionary`2[System.String,System.Single]]'\r\nParameter name: actualType";
+                " Please change the output member to 'System.Collections.Generic.IEnumerable`1[System.Collections.Generic.IDictionary`2[System.String,System.Single]]'";
             try
             {
                 var predictor = LoadModelWithWrongCustomType(modelFile);
+                Assert.True(false);
             }
             catch (System.Exception ex)
             {
-                Assert.Equal(ex.Message, expectedExceptionMessage);
+                //truncate the string to only necessary information as Linux and Windows have different way of encoding the string
+                Assert.Equal(expectedExceptionMessage, ex.Message.Substring(0, 387));
                 return;
             }
         }


### PR DESCRIPTION
resolve https://github.com/dotnet/machinelearning/issues/4122

The unhelpful message stuff is a bit different from the above link's description. ML.NET throws unhelpful message not because the customer uses the wrong type(different from the type defined in onnx), but defining the variable using the same type as OnnxSequenceType. However, the correct type should be IEnumerable<OnnxSequenceType>.

This change adds more information to existing exception message and adds a special error message for errors like this when customer carelessly defines a container variable without using container type


