### PR TITLE
move tf meta file download to build stage

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -8,6 +8,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.props))\Directory.Build.props" />
 
   <Import Project="build/ExternalBenchmarkDataFiles.props" />
+  <Import Project="build/TensorflowMetaFiles.props" />
   <Import Project="$(ToolsDir)VersionTools.targets" Condition="Exists('$(ToolsDir)VersionTools.targets')" />
   <UsingTask TaskName="DownloadFilesFromUrl" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll"/>
   <PropertyGroup>
@@ -36,6 +37,7 @@
       BuildNative;
       $(TraversalBuildDependsOn);
       DownloadExternalTestFiles;
+      DownloadTensorflowMetaFiles;
     </TraversalBuildDependsOn>
   </PropertyGroup>
 
@@ -90,6 +92,25 @@
     <DownloadFile
             SourceUrl="%(BenchmarkFile.Url)"
             DestinationFolder="$(MSBuildThisFileDirectory)/test/data/external/"
+            Retries="5"
+            SkipUnchangedFiles="true">
+    </DownloadFile>
+  </Target>
+
+  <ItemGroup>
+    <MetaFile Update="@(MetaFile)">
+      <Url>https://aka.ms/mlnet-resources/%(Identity)</Url>
+      <DestinationFile>$([System.IO.Path]::GetTempPath())/MLNET/</DestinationFile>
+    </MetaFile>
+
+    <TensorflowMetaFile Include="@(MetaFile->'$([System.IO.Path]::GetTempPath())/MLNET/%(Identity)')" />
+  </ItemGroup>
+
+  <Target Name="DownloadTensorflowMetaFiles" Inputs="@(TensorflowMetaFile)" Outputs="%(TensorflowMetaFile.DestinationFile)">
+    <Message Importance="High" Text="Downloading tensorflow meta files... %(TensorflowMetaFile.DestinationFile)" />
+    <DownloadFile
+            SourceUrl="%(MetaFile.Url)"
+            DestinationFolder="$([System.IO.Path]::GetTempPath())/MLNET/"
             Retries="5"
             SkipUnchangedFiles="true">
     </DownloadFile>

--- a/build/TensorflowMetaFiles.props
+++ b/build/TensorflowMetaFiles.props
@@ -1,0 +1,8 @@
+<Project>
+  <ItemGroup>
+    <MetaFile Include="inception_v3.meta" />
+    <MetaFile Include="mobilenet_v2.meta" />
+    <MetaFile Include="resnet_v2_50_299.meta" />
+    <MetaFile Include="resnet_v2_101_299.meta" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
recently observe several test fail due to meta file download fail, move download to build stage which has 2 advantage,
1. if download fail, fail fast at build stage
2. we used to download large benchmark data (over 800 MB) and this download is quite stable, try download here

https://dev.azure.com/dnceng/public/_build/results?buildId=637938&view=logs&j=5aa5c7df-492a-5eaf-973a-62b7b0f0ee3b&t=ffdbd604-f3e2-5332-cf61-c8dd00799b47
https://dev.azure.com/dnceng/public/_build/results?buildId=639940&view=logs&j=4e8eb92e-b635-5c96-398c-05943bacd8c5&t=cf6d66af-7fee-5841-f0be-a4bf6642a2ae
https://dev.azure.com/dnceng/public/_build/results?buildId=640227&view=logs&j=c54dae93-d956-5713-8cb2-8e90b1d124e1&t=87b64192-025a-5709-ee76-220b68eba827