### PR TITLE
Updated libmf and corresponding MatrixFactorizationSimpleTrainAndPredict() baselines per build

### DIFF
--- a/test/Microsoft.ML.Tests/TrainerEstimators/MatrixFactorizationTests.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/MatrixFactorizationTests.cs
@@ -54,7 +54,6 @@ namespace Microsoft.ML.Tests.TrainerEstimators
         }
 
         [MatrixFactorizationFact]
-        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
         public void MatrixFactorizationSimpleTrainAndPredict()
         {
             var mlContext = new MLContext(seed: 1);
@@ -96,10 +95,10 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             // MF produce different matrices on different platforms, so check their content on Windows.
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                Assert.Equal(0.290507137775421, leftMatrix[0], 5);
-                Assert.Equal(0.558072924613953, leftMatrix[leftMatrix.Count - 1], 5);
-                Assert.Equal(0.270811557769775, rightMatrix[0], 5);
-                Assert.Equal(0.376706808805466, rightMatrix[rightMatrix.Count - 1], 5);
+                Assert.Equal(0.309137582778931, leftMatrix[0], 5);
+                Assert.Equal(0.468956589698792, leftMatrix[leftMatrix.Count - 1], 5);
+                Assert.Equal(0.303486406803131, rightMatrix[0], 5);
+                Assert.Equal(0.503888845443726, rightMatrix[rightMatrix.Count - 1], 5);
             }
             // Read the test data set as an IDataView
             var testData = reader.Load(new MultiFileSource(GetDataPath(TestDatasets.trivialMatrixFactorization.testFilename)));
@@ -122,28 +121,25 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             // Compute prediction errors
             var metrices = mlContext.Recommendation().Evaluate(prediction, labelColumnName: labelColumnName, scoreColumnName: scoreColumnName);
 
-            // Determine if the selected metric is reasonable for different platforms
-            // Windows tolerance is set at 1e-7, and Linux tolerance is set at 1e-5
-            double windowsTolerance = Math.Pow(10, -7);
-            double linuxTolerance = Math.Pow(10, -5);
+            // Determine if the selected mean-squared error metric is reasonable on different platforms
+            double tolerance = Math.Pow(10, -7);
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 // Linux case
-                var expectedUnixL2Error = 0.610332110253861; // Linux baseline
-                Assert.InRange(metrices.MeanSquaredError, expectedUnixL2Error - linuxTolerance, expectedUnixL2Error + linuxTolerance);
+                var expectedUnixL2Error = 0.612726002827395; // Linux baseline
+                Assert.InRange(metrices.MeanSquaredError, expectedUnixL2Error - tolerance, expectedUnixL2Error + tolerance);
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                // The Mac case is just broken. Should be fixed later. Re-enable when done.
                 // Mac case
-                //var expectedMacL2Error = 0.61192207960271; // Mac baseline
-                //Assert.InRange(metrices.L2, expectedMacL2Error - 5e-3, expectedMacL2Error + 5e-3); // 1e-7 is too small for Mac so we try 1e-5
+                var expectedMacL2Error = 0.616389336408704; // Mac baseline
+                Assert.InRange(metrices.MeanSquaredError, expectedMacL2Error - tolerance, expectedMacL2Error + tolerance);
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 // Windows case
-                var expectedWindowsL2Error = 0.60226203382884; // Windows baseline
-                Assert.InRange(metrices.MeanSquaredError, expectedWindowsL2Error - windowsTolerance, expectedWindowsL2Error + windowsTolerance);
+                var expectedWindowsL2Error = 0.600329985097577; // Windows baseline
+                Assert.InRange(metrices.MeanSquaredError, expectedWindowsL2Error - tolerance, expectedWindowsL2Error + tolerance);
             }
 
             var modelWithValidation = pipeline.Fit(data, testData);

--- a/test/Microsoft.ML.Tests/TrainerEstimators/MatrixFactorizationTests.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/MatrixFactorizationTests.cs
@@ -128,8 +128,8 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 // Linux case
-                double expectedLinuxMacMeanSquaredError = 0.6127260028273948; // Linux baseline
-                Assert.InRange(metrices.MeanSquaredError, expectedLinuxMacMeanSquaredError - linuxTolerance, expectedLinuxMacMeanSquaredError + linuxTolerance);
+                double expectedLinuxMeanSquaredError = 0.6127260028273948; // Linux baseline
+                Assert.InRange(metrices.MeanSquaredError, expectedLinuxMeanSquaredError - linuxTolerance, expectedLinuxMeanSquaredError + linuxTolerance);
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {

--- a/test/Microsoft.ML.Tests/TrainerEstimators/MatrixFactorizationTests.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/MatrixFactorizationTests.cs
@@ -123,6 +123,9 @@ namespace Microsoft.ML.Tests.TrainerEstimators
 
             // Determine if the selected mean-squared error metric is reasonable on different platforms within the variation tolerance.
             // Windows and Mac tolerances are set at 1e-7, and Linux tolerance is set at 1e-5.
+            // Here, each build OS has a different MSE baseline metric. While these metrics differ between builds, each build is expected to
+            // produce the same metric. This is because of minor build differences and varying implementations of sub-functions, such as random
+            // variables that are first obtained with the default random numger generator in libMF C++ libraries.
             double windowsAndMacTolerance = Math.Pow(10, -7);
             double linuxTolerance = Math.Pow(10, -5);
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))

--- a/test/Microsoft.ML.Tests/TrainerEstimators/MatrixFactorizationTests.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/MatrixFactorizationTests.cs
@@ -123,18 +123,19 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             var metrices = mlContext.Recommendation().Evaluate(prediction, labelColumnName: labelColumnName, scoreColumnName: scoreColumnName);
 
             // Determine if the selected mean-squared error metric is reasonable on different platforms within the variation tolerance.
+            int variationTolerance = 7;
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 // Linux case
                 if (OsIsCentOS7())
                 {
-                    double expectedCentOS7LinuxMeanSquaredError = 0.612732360518435; // CentOS 7 Linux baseline
-                    Assert.Equal(metrices.MeanSquaredError, expectedCentOS7LinuxMeanSquaredError);
+                    double expectedCentOS7LinuxMeanSquaredError = 0.6127260028273948; // CentOS 7 Linux baseline
+                    Assert.Equal(metrices.MeanSquaredError, expectedCentOS7LinuxMeanSquaredError, variationTolerance);
                 }
                 else
                 {
-                    double expectedUbuntuLinuxMeanSquaredError = 0.612726002827395; // Ubuntu Linux baseline
-                    Assert.Equal(metrices.MeanSquaredError, expectedUbuntuLinuxMeanSquaredError);
+                    double expectedUbuntuLinuxMeanSquaredError = 0.612732360518435; // Ubuntu Linux baseline
+                    Assert.Equal(metrices.MeanSquaredError, expectedUbuntuLinuxMeanSquaredError, variationTolerance);
                 }    
                 
             }
@@ -142,13 +143,13 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             {
                 // Mac case
                 double expectedMacMeanSquaredError = 0.616389336408704; // Mac baseline
-                Assert.Equal(metrices.MeanSquaredError, expectedMacMeanSquaredError);
+                Assert.Equal(metrices.MeanSquaredError, expectedMacMeanSquaredError, variationTolerance);
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 // Windows case
                 double expectedWindowsMeanSquaredError = 0.600329985097577; // Windows baseline
-                Assert.Equal(metrices.MeanSquaredError, expectedWindowsMeanSquaredError);
+                Assert.Equal(metrices.MeanSquaredError, expectedWindowsMeanSquaredError, variationTolerance);
             }
 
             var modelWithValidation = pipeline.Fit(data, testData);

--- a/test/Microsoft.ML.Tests/TrainerEstimators/MatrixFactorizationTests.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/MatrixFactorizationTests.cs
@@ -123,19 +123,18 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             var metrices = mlContext.Recommendation().Evaluate(prediction, labelColumnName: labelColumnName, scoreColumnName: scoreColumnName);
 
             // Determine if the selected mean-squared error metric is reasonable on different platforms within the variation tolerance.
-            int variationTolerance = 7;
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 // Linux case
                 if (OsIsCentOS7())
                 {
                     double expectedCentOS7LinuxMeanSquaredError = 0.612732360518435; // CentOS 7 Linux baseline
-                    Assert.Equal(metrices.MeanSquaredError, expectedCentOS7LinuxMeanSquaredError, variationTolerance);
+                    Assert.Equal(metrices.MeanSquaredError, expectedCentOS7LinuxMeanSquaredError);
                 }
                 else
                 {
                     double expectedUbuntuLinuxMeanSquaredError = 0.612726002827395; // Ubuntu Linux baseline
-                    Assert.Equal(metrices.MeanSquaredError, expectedUbuntuLinuxMeanSquaredError, variationTolerance);
+                    Assert.Equal(metrices.MeanSquaredError, expectedUbuntuLinuxMeanSquaredError);
                 }    
                 
             }
@@ -143,13 +142,13 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             {
                 // Mac case
                 double expectedMacMeanSquaredError = 0.616389336408704; // Mac baseline
-                Assert.Equal(metrices.MeanSquaredError, expectedMacMeanSquaredError, variationTolerance);
+                Assert.Equal(metrices.MeanSquaredError, expectedMacMeanSquaredError);
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 // Windows case
                 double expectedWindowsMeanSquaredError = 0.600329985097577; // Windows baseline
-                Assert.Equal(metrices.MeanSquaredError, expectedWindowsMeanSquaredError, variationTolerance);
+                Assert.Equal(metrices.MeanSquaredError, expectedWindowsMeanSquaredError);
             }
 
             var modelWithValidation = pipeline.Fit(data, testData);

--- a/test/Microsoft.ML.Tests/TrainerEstimators/MatrixFactorizationTests.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/MatrixFactorizationTests.cs
@@ -838,7 +838,5 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             for (int i = 0; i < predictions.Count(); ++i)
                 Assert.Equal(predictions[i].Score, valuesAtSecondColumn[i], 3);
         }
-
-        }
     }
 }


### PR DESCRIPTION
Fixes #4874 

This PR updates the libmf submodule, where its recent changes in libmf [PR #41](https://github.com/cjlin1/libmf/pull/41) and [PR #42](https://github.com/cjlin1/libmf/pull/42) address the shuffling of values in a given matrix. 

The C++ function `void random_shuffle(_RanIt _First, _RanIt _Last)` is implemented differently on Windows vs. MacOS vs. Linux. This resulted in inconsistent results on MacOS and more-predictable yet still inconsistent results on Linux. As a result, a given matrix factorization problem, even with a constant seed, produced differing MSEs between each run on each system. The libmf codebase has been updated to prevent this, and baseline MSE values in the unit test `MatrixFactorizationSimpleTrainAndPredict()` have been updated to reflect this.