### PR TITLE
Update TexFileSample to use FileShare.ReadWrite

### DIFF
--- a/src/Microsoft.ML.AutoML/ColumnInference/TextFileSample.cs
+++ b/src/Microsoft.ML.AutoML/ColumnInference/TextFileSample.cs
@@ -73,7 +73,7 @@ namespace Microsoft.ML.AutoML
 
         public static TextFileSample CreateFromFullFile(string path)
         {
-            using (var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
             {
                 return CreateFromFullStream(fs);
             }


### PR DESCRIPTION
Associated issue is in Model Builder repo Issue [530](https://github.com/dotnet/machinelearning-modelbuilder/issues/530) (let me know if I need to open one here). 

Basic problem is when .csv training files are open in excel customers cannot train in Model Builder. The root cause is incorrect `FileShare` setting on the FileStream. `FileAccess` specifies how we want to use the file. `FileShare` specifies how we allow other programs to use the file. Even though we're opening files as FileAccess.Read, setting to FileShare.Read means we won't allow other programs to write. This blocks us from reading a file already opened as ReadWrite by Excel. If found [this](https://stackoverflow.com/questions/897796/how-do-i-open-an-already-opened-file-with-a-net-streamreader) stack overflow to have the best explanation. 

I'm not familiar with how the TextLoad code works, so there may be other spots this should be updated. If anyone has advice let me know, or we can proceed with this change and see if other come up later. 
