### PR TITLE
Error message for non-parsable datasets in AutoML

### DIFF
--- a/src/Microsoft.ML.AutoML/ColumnInference/ColumnInferenceApi.cs
+++ b/src/Microsoft.ML.AutoML/ColumnInference/ColumnInferenceApi.cs
@@ -119,7 +119,7 @@ namespace Microsoft.ML.AutoML
 
             if (!splitInference.IsSuccess)
             {
-                throw new InferenceException(InferenceExceptionType.ColumnSplit, 
+                throw new InferenceException(InferenceExceptionType.ColumnSplit,
                     "Unable to split the file provided into multiple, consistent columns. " +
                     "Readable formats include delimited files such as CSV/TSV. " +
                     "Check for a consistent number of columns and proper escaping and quoting.");

--- a/src/Microsoft.ML.AutoML/ColumnInference/ColumnInferenceApi.cs
+++ b/src/Microsoft.ML.AutoML/ColumnInference/ColumnInferenceApi.cs
@@ -119,7 +119,10 @@ namespace Microsoft.ML.AutoML
 
             if (!splitInference.IsSuccess)
             {
-                throw new InferenceException(InferenceExceptionType.ColumnSplit, "Unable to split the file provided into multiple, consistent columns.");
+                throw new InferenceException(InferenceExceptionType.ColumnSplit, 
+                    "Unable to split the file provided into multiple, consistent columns. " +
+                    "Readable formats include delimited files such as CSV/TSV. " +
+                    "Check for a consistent number of columns and proper escaping and quoting.");
             }
 
             return splitInference;


### PR DESCRIPTION
Fixes: #5129

> I'd recommend improving the current error message:
> https://github.com/dotnet/machinelearning/blob/e5a19af589dfb1468cd99628e82f6b49fb125323/src/Microsoft.ML.AutoML/ColumnInference/ColumnInferenceApi.cs#L120-L123
> 
> It currently says, `"Unable to split the file provided into multiple, consistent columns."`, which is rather uninformative and non-actionable.
> 
> Perhaps, as I think @briacht is suggesting, have it list the acceptable file formats we can parse: `"Unable to split the file provided into multiple, consistent columns. Readable formats include delimited files such as CSV/TSV. Check for a consistent number of columns and proper escaping and quoting."`.
> 
> This messaging now includes, the problem, and next steps for the user.
> 
> I mention delimited as AutoML supports more than CSV/TSV as it tries tab, comma, space, semi-colon as the separator ([src](https://github.com/dotnet/machinelearning/blob/e50c4d20012e0d62852f404ae443afca7dad043e/src/Microsoft.ML.AutoML/ColumnInference/TextFileContents.cs#L40)). If we run into other common separators, we can trivially augment this list. One candidate is the vertical bar `|`.