### PR TITLE
Add public generic methods to TextLoader catalog that accept Options objects

### DIFF
--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
@@ -1453,6 +1453,23 @@ namespace Microsoft.ML.Data
            bool trimWhitespace = Defaults.TrimWhitespace,
            IMultiStreamSource dataSample = null)
         {
+            Options options = new Options
+            {
+                HasHeader = hasHeader,
+                Separators = new[] { separator },
+                AllowQuoting = allowQuoting,
+                AllowSparse = supportSparse,
+                TrimWhitespace = trimWhitespace
+            };
+
+            return CreateTextLoader<TInput>(host, options, dataSample);
+        }
+
+        internal static TextLoader CreateTextLoader<TInput>(IHostEnvironment host,
+           Options options = null,
+           IMultiStreamSource dataSample = null)
+        {
+            options = options ?? new Options();
             var userType = typeof(TInput);
 
             var fieldInfos = userType.GetFields(BindingFlags.Public | BindingFlags.Instance);
@@ -1506,15 +1523,7 @@ namespace Microsoft.ML.Data
                 columns.Add(column);
             }
 
-            Options options = new Options
-            {
-                HasHeader = hasHeader,
-                Separators = new[] { separator },
-                AllowQuoting = allowQuoting,
-                AllowSparse = supportSparse,
-                TrimWhitespace = trimWhitespace,
-                Columns = columns.ToArray()
-            };
+            options.Columns = columns.ToArray();
 
             return new TextLoader(host, options, dataSample: dataSample);
         }

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
@@ -98,6 +98,19 @@ namespace Microsoft.ML
                 allowSparse, trimWhitespace, dataSample: dataSample);
 
         /// <summary>
+        /// Create a text loader <see cref="TextLoader"/> by inferencing the dataset schema from a data model type.
+        /// </summary>
+        /// <param name="catalog">The <see cref="DataOperationsCatalog"/> catalog.</param>
+        /// <param name="options">Defines the settings of the load operation. Defines the settings of the load operation. No need to specify a Columns field,
+        /// as columns will be infered by this method.</param>
+        /// <param name="dataSample">The optional location of a data sample. The sample can be used to infer information
+        /// about the columns, such as slot names.</param>
+        public static TextLoader CreateTextLoader<TInput>(this DataOperationsCatalog catalog,
+            TextLoader.Options options,
+            IMultiStreamSource dataSample = null)
+            => TextLoader.CreateTextLoader<TInput>(CatalogUtils.GetEnvironment(catalog), options, dataSample);
+
+        /// <summary>
         /// Load a <see cref="IDataView"/> from a text file using <see cref="TextLoader"/>.
         /// Note that <see cref="IDataView"/>'s are lazy, so no actual loading happens here, just schema validation.
         /// </summary>
@@ -148,6 +161,35 @@ namespace Microsoft.ML
         /// Note that <see cref="IDataView"/>'s are lazy, so no actual loading happens here, just schema validation.
         /// </summary>
         /// <param name="catalog">The <see cref="DataOperationsCatalog"/> catalog.</param>
+        /// <param name="path">Specifies a file from which to load.</param>
+        /// <param name="options">Defines the settings of the load operation.</param>
+        /// <example>
+        /// <format type="text/markdown">
+        /// <![CDATA[
+        /// [!code-csharp[LoadFromTextFile](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/SaveAndLoadFromText.cs)]
+        /// ]]>
+        /// </format>
+        /// </example>
+        public static IDataView LoadFromTextFile(this DataOperationsCatalog catalog, string path,
+            TextLoader.Options options = null)
+        {
+            Contracts.CheckNonEmpty(path, nameof(path));
+            if (!File.Exists(path))
+            {
+                throw Contracts.ExceptParam(nameof(path), "File does not exist at path: {0}", path);
+            }
+
+            var env = catalog.GetEnvironment();
+            var source = new MultiFileSource(path);
+
+            return new TextLoader(env, options, dataSample: source).Load(source);
+        }
+
+        /// <summary>
+        /// Load a <see cref="IDataView"/> from a text file using <see cref="TextLoader"/>.
+        /// Note that <see cref="IDataView"/>'s are lazy, so no actual loading happens here, just schema validation.
+        /// </summary>
+        /// <param name="catalog">The <see cref="DataOperationsCatalog"/> catalog.</param>
         /// <param name="path">The path to the file.</param>
         /// <param name="separatorChar">Column separator character. Default is '\t'</param>
         /// <param name="hasHeader">Whether the file has a header with feature names. Note: If a TextLoader is created with hasHeader = true but without a
@@ -191,16 +233,11 @@ namespace Microsoft.ML
         /// </summary>
         /// <param name="catalog">The <see cref="DataOperationsCatalog"/> catalog.</param>
         /// <param name="path">Specifies a file from which to load.</param>
-        /// <param name="options">Defines the settings of the load operation.</param>
-        /// <example>
-        /// <format type="text/markdown">
-        /// <![CDATA[
-        /// [!code-csharp[LoadFromTextFile](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/SaveAndLoadFromText.cs)]
-        /// ]]>
-        /// </format>
-        /// </example>
-        public static IDataView LoadFromTextFile(this DataOperationsCatalog catalog, string path,
-            TextLoader.Options options = null)
+        /// <param name="options">Defines the settings of the load operation. No need to specify a Columns field,
+        /// as columns will be infered by this method.</param>
+        /// <returns>The data view.</returns>
+        public static IDataView LoadFromTextFile<TInput>(this DataOperationsCatalog catalog, string path,
+            TextLoader.Options options)
         {
             Contracts.CheckNonEmpty(path, nameof(path));
             if (!File.Exists(path))
@@ -208,10 +245,8 @@ namespace Microsoft.ML
                 throw Contracts.ExceptParam(nameof(path), "File does not exist at path: {0}", path);
             }
 
-            var env = catalog.GetEnvironment();
-            var source = new MultiFileSource(path);
-
-            return new TextLoader(env, options, dataSample: source).Load(source);
+            return TextLoader.CreateTextLoader<TInput>(CatalogUtils.GetEnvironment(catalog), options)
+                .Load(new MultiFileSource(path));
         }
 
         /// <summary>

--- a/test/Microsoft.ML.Functional.Tests/Prediction.cs
+++ b/test/Microsoft.ML.Functional.Tests/Prediction.cs
@@ -36,9 +36,14 @@ namespace Microsoft.ML.Functional.Tests
         {
             var mlContext = new MLContext(seed: 1);
 
+            var options = new TextLoader.Options
+            {
+                HasHeader = TestDatasets.Sentiment.fileHasHeader,
+                Separators = new[] { TestDatasets.Sentiment.fileSeparator }
+            };
+
             var data = mlContext.Data.LoadFromTextFile<TweetSentiment>(TestCommon.GetDataPath(DataDir, TestDatasets.Sentiment.trainFilename),
-                hasHeader: TestDatasets.Sentiment.fileHasHeader,
-                separatorChar: TestDatasets.Sentiment.fileSeparator);
+                options);
 
             // Create a training pipeline.
             var pipeline = mlContext.Transforms.Text.FeaturizeText("Features", "SentimentText")

--- a/test/Microsoft.ML.Tests/TextLoaderTests.cs
+++ b/test/Microsoft.ML.Tests/TextLoaderTests.cs
@@ -704,8 +704,10 @@ namespace Microsoft.ML.EntryPoints.Tests
             public string Type;
         }
 
-        [Fact]
-        public void LoaderColumnsFromIrisData()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void LoaderColumnsFromIrisData(bool useOptionsObject)
         {
             var dataPath = GetDataPath(TestDatasets.irisData.trainFilename);
             var mlContext = new MLContext(1);
@@ -719,7 +721,12 @@ namespace Microsoft.ML.EntryPoints.Tests
             var irisFirstRowValues = irisFirstRow.Values.GetEnumerator();
 
             // Simple load
-            var dataIris = mlContext.Data.CreateTextLoader<Iris>(separatorChar: ',').Load(dataPath);
+            IDataView dataIris;
+            if (useOptionsObject)
+                dataIris = mlContext.Data.CreateTextLoader<Iris>(new TextLoader.Options() { Separator = ",", AllowQuoting = false }).Load(dataPath);
+            else
+                dataIris = mlContext.Data.CreateTextLoader<Iris>(separatorChar: ',').Load(dataPath);
+
             var previewIris = dataIris.Preview(1);
 
             Assert.Equal(5, previewIris.ColumnView.Length);
@@ -735,7 +742,12 @@ namespace Microsoft.ML.EntryPoints.Tests
             Assert.Equal("Iris-setosa", previewIris.RowView[0].Values[index].Value.ToString());
 
             // Load with start and end indexes
-            var dataIrisStartEnd = mlContext.Data.CreateTextLoader<IrisStartEnd>(separatorChar: ',').Load(dataPath);
+            IDataView dataIrisStartEnd;
+            if (useOptionsObject)
+                dataIrisStartEnd = mlContext.Data.CreateTextLoader<IrisStartEnd>(new TextLoader.Options() { Separator = ",", AllowQuoting = false }).Load(dataPath);
+            else
+                dataIrisStartEnd = mlContext.Data.CreateTextLoader<IrisStartEnd>(separatorChar: ',').Load(dataPath);
+
             var previewIrisStartEnd = dataIrisStartEnd.Preview(1);
 
             Assert.Equal(2, previewIrisStartEnd.ColumnView.Length);
@@ -752,7 +764,12 @@ namespace Microsoft.ML.EntryPoints.Tests
             }
 
             // load setting the distinct columns. Loading column 0 and 2
-            var dataIrisColumnIndices = mlContext.Data.CreateTextLoader<IrisColumnIndices>(separatorChar: ',').Load(dataPath);
+            IDataView dataIrisColumnIndices;
+            if (useOptionsObject)
+                dataIrisColumnIndices = mlContext.Data.CreateTextLoader<IrisColumnIndices>(new TextLoader.Options() { Separator = ",", AllowQuoting = false }).Load(dataPath);
+            else
+                dataIrisColumnIndices = mlContext.Data.CreateTextLoader<IrisColumnIndices>(separatorChar: ',').Load(dataPath);
+
             var previewIrisColumnIndices = dataIrisColumnIndices.Preview(1);
 
             Assert.Equal(2, previewIrisColumnIndices.ColumnView.Length);


### PR DESCRIPTION
The `TextLoaderSaverCatalog` contains 2 overloads of non-generic `CreateTextLoader` and `LoadFromTextFile`; one overload accepts a [given set of a parameters ](https://github.com/dotnet/machinelearning/blob/3da9e1e7a64f3485b811b99eaab05276a310192c/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs#L51-L58) and the other overload [accepts a TexLoader.Options object](https://github.com/dotnet/machinelearning/blob/3da9e1e7a64f3485b811b99eaab05276a310192c/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs#L83-L86).

The generic methods for `CreateTextLoader<TInput>` and `LoadFromTextFile<TInput>` only [have 1 method](https://github.com/dotnet/machinelearning/blob/3da9e1e7a64f3485b811b99eaab05276a310192c/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs#L112-L120) that accepts a given set of parameters. So in this PR I add another overload for those 2 methods that also accepts an Options object.

The reason to do this is that if we add new parameters to TextLoader (for example, as done in #5125) then they're only accessible through a TextLoader.Options (so without this PR `CreateTextLoader<TInput>` and `LoadFromTextFile<TInput>` won't be able to use the new options). Notice that we can't simply add a new parameter to the existing `CreateTextLoader<TInput>` and `LoadFromTextFile<TInput>` methods, since that is considered a breaking API change, and we can't do those until ML.NET version 2.