### PR TITLE
Fix Microsoft.ML.DataView references

### DIFF
--- a/pkg/Microsoft.ML.DataView/Microsoft.ML.DataView.nupkgproj
+++ b/pkg/Microsoft.ML.DataView/Microsoft.ML.DataView.nupkgproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
     <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
   </ItemGroup>
 


### PR DESCRIPTION
The assembly in the package references Collections.Immutable, but the nuget package doesn't. This can cause errors if someone just references the Microsoft.ML.DataView package.

Fixing by adding the reference.

See the .csproj here:

https://github.com/dotnet/machinelearning/blob/212081c62855a835e0612887f705a8f87a899624/src/Microsoft.ML.DataView/Microsoft.ML.DataView.csproj#L8-L11