### PR TITLE
Update Ubuntu build and reenable TextNormalizingOnnxConversionTest() on Linux

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -8,7 +8,7 @@ resources:
     image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-mlnet-8bba86b-20190314145033
   
   - container: UbuntuContainer
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-mlnet-207e097-20190312152303
+    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-mlnet-20200515184230-2c829e8
 
 jobs:
 - template: /build/ci/job-template.yml

--- a/test/Microsoft.ML.Tests/OnnxConversionTest.cs
+++ b/test/Microsoft.ML.Tests/OnnxConversionTest.cs
@@ -462,7 +462,7 @@ namespace Microsoft.ML.Tests
 
             // Compare model scores produced by ML.NET and ONNX's runtime.
             // Skipping test in Linux platforms temporarily
-            if (IsOnnxRuntimeSupported() && !RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            if (IsOnnxRuntimeSupported())
             {
                 // Evaluate the saved ONNX model using the data used to train the ML.NET pipeline.
                 var onnxEstimator = mlContext.Transforms.ApplyOnnxModel(onnxModelPath);


### PR DESCRIPTION
This PR updates our Ubuntu CI builds with the correct installation pattern for `libomp-dev`, and the correct updating of its locale setting, which enables us to re-activate the unit test TextNormalizingOnnxConversionTest().