### PR TITLE
Adding support for MurmurHash KeyDataTypes 

### DIFF
--- a/src/Microsoft.ML.Data/Transforms/Hashing.cs
+++ b/src/Microsoft.ML.Data/Transforms/Hashing.cs
@@ -1382,8 +1382,7 @@ namespace Microsoft.ML.Transforms
                     isZeroNode.AddAttribute("to", NumberDataViewType.Int64.RawType);
                 }
 
-                // Numeric input types are limited to those supported by the Onnxruntime MurmurHash operator, which currently only supports
-                // uints and ints. Thus, ulongs, longs, doubles and floats are not supported.
+                // Since these numeric types are not supported by Onnxruntime, we cast them to UInt32.
                 if (srcType == NumberDataViewType.UInt16 || srcType == NumberDataViewType.Int16 ||
                     srcType == NumberDataViewType.SByte || srcType == NumberDataViewType.Byte ||
                     srcType == BooleanDataViewType.Instance)
@@ -1393,15 +1392,9 @@ namespace Microsoft.ML.Transforms
                     castNode.AddAttribute("to", NumberDataViewType.UInt32.RawType);
                     murmurNode = ctx.CreateNode(opType, castOutput, murmurOutput, ctx.GetNodeName(opType), "com.microsoft");
                 }
-                else if (srcType == NumberDataViewType.UInt32 || srcType == NumberDataViewType.Int32 || srcType == NumberDataViewType.UInt64 ||
-                         srcType == NumberDataViewType.Int64 || srcType == NumberDataViewType.Single || srcType == NumberDataViewType.Double || srcType == TextDataViewType.Instance)
-
-                {
-                    murmurNode = ctx.CreateNode(opType, srcVariable, murmurOutput, ctx.GetNodeName(opType), "com.microsoft");
-                }
                 else
                 {
-                    return false;
+                    murmurNode = ctx.CreateNode(opType, srcVariable, murmurOutput, ctx.GetNodeName(opType), "com.microsoft");
                 }
 
                 murmurNode.AddAttribute("positive", 1);

--- a/src/Microsoft.ML.Data/Transforms/Hashing.cs
+++ b/src/Microsoft.ML.Data/Transforms/Hashing.cs
@@ -1355,8 +1355,6 @@ namespace Microsoft.ML.Transforms
                 OnnxNode isZeroNode;
 
                 var srcType = _srcTypes[iinfo].GetItemType();
-                if (srcType is KeyDataViewType)
-                    return false;
                 if (_parent._columns[iinfo].Combine)
                     return false;
 

--- a/test/Microsoft.ML.Tests/OnnxConversionTest.cs
+++ b/test/Microsoft.ML.Tests/OnnxConversionTest.cs
@@ -1195,6 +1195,55 @@ namespace Microsoft.ML.Tests
             Done();
         }
 
+        private class HashData
+        {
+            public uint Value { get; set; }
+        }
+
+        [Fact]
+        public void MurmurHashKeyTest()
+        {
+            var mlContext = new MLContext();
+
+            var samples = new[]
+            {
+                new HashData {Value = 232},
+                new HashData {Value = 42},
+                new HashData {Value = 0},
+            };
+
+            IDataView data = mlContext.Data.LoadFromEnumerable(samples);
+
+            var hashEstimator = mlContext.Transforms.Conversion.MapValueToKey("Value").Append(mlContext.Transforms.Conversion.Hash(new[]
+            {
+                new HashingEstimator.ColumnOptions(
+                    "ValueHashed",
+                    "Value")
+            }));
+            var model = hashEstimator.Fit(data);
+            var transformedData = model.Transform(data);
+            var onnxModel = mlContext.Model.ConvertToOnnxProtobuf(model, data);
+
+            var onnxFileName = "MurmurHashV2.onnx";
+            var onnxTextName = "MurmurHashV2.txt";
+            var onnxModelPath = GetOutputPath(onnxFileName);
+            var onnxTextPath = GetOutputPath(onnxTextName);
+
+            SaveOnnxModel(onnxModel, onnxModelPath, onnxTextPath);
+
+            if (IsOnnxRuntimeSupported())
+            {
+                // Evaluate the saved ONNX model using the data used to train the ML.NET pipeline.
+                string[] inputNames = onnxModel.Graph.Input.Select(valueInfoProto => valueInfoProto.Name).ToArray();
+                string[] outputNames = onnxModel.Graph.Output.Select(valueInfoProto => valueInfoProto.Name).ToArray();
+                var onnxEstimator = mlContext.Transforms.ApplyOnnxModel(outputNames, inputNames, onnxModelPath);
+                var onnxTransformer = onnxEstimator.Fit(data);
+                var onnxResult = onnxTransformer.Transform(data);
+                CompareSelectedColumns<uint>("ValueHashed", "ValueHashed", transformedData, onnxResult);
+            }
+            Done();
+        }
+
         [Theory]
         [CombinatorialData]
         // Due to lack of Onnxruntime support, long/ulong, double, floats, and OrderedHashing are not supported.

--- a/test/Microsoft.ML.Tests/OnnxConversionTest.cs
+++ b/test/Microsoft.ML.Tests/OnnxConversionTest.cs
@@ -1246,9 +1246,6 @@ namespace Microsoft.ML.Tests
 
         [Theory]
         [CombinatorialData]
-        // Due to lack of Onnxruntime support, long/ulong, double, floats, and OrderedHashing are not supported.
-        // An InvalidOperationException stating that the onnx pipeline can't be fully converted is thrown
-        // when users try to convert the items mentioned above.
         public void MurmurHashScalarTest(
             [CombinatorialValues(DataKind.SByte, DataKind.Int16, DataKind.Int32, DataKind.Int64, DataKind.Byte,
             DataKind.UInt16, DataKind.UInt32, DataKind.UInt64, DataKind.Single, DataKind.Double, DataKind.String, DataKind.Boolean)] DataKind type,
@@ -1301,7 +1298,7 @@ namespace Microsoft.ML.Tests
 
         [Theory]
         [CombinatorialData]
-        // Due to lack of Onnxruntime support, long/ulong, double, floats, and OrderedHashing are not supported.
+        // Due to lack of Onnxruntime support, OrderedHashing is not supported.
         // An InvalidOperationException stating that the onnx pipeline can't be fully converted is thrown
         // when users try to convert the items mentioned above.
         public void MurmurHashVectorTest(


### PR DESCRIPTION
ML.NET's behavior is to map zero input values to zero, instead of hashes. 
- Adding that behavior to the onnx export and a test. 

TODO:  rebase once other murmurhash PR are merged 

