### PR TITLE
Updated installation of libomp on Mac trusted CI builds

### DIFF
--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -46,7 +46,7 @@ phases:
   queue:
     name: Hosted macOS
   steps:
-  - script: brew update && brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/f5b1ac99a7fba27c19cee0bc4f036775c889b359/Formula/libomp.rb && brew link libomp --force
+  - script: brew update && brew install $(Build.SourcesDirectory)/build/libomp.rb && brew link libomp --force
     displayName: Install build dependencies
   # Only build native assets to avoid conflicts.
   - script: ./build.sh -buildNative -$(BuildConfig) -skipRIDAgnosticAssets

--- a/docs/building/unix-instructions.md
+++ b/docs/building/unix-instructions.md
@@ -52,5 +52,5 @@ On macOS a few components are needed which are not provided by a default develop
 
 One way of obtaining CMake and other required libraries is via [Homebrew](https://brew.sh):
 ```sh
-$ brew install cmake https://raw.githubusercontent.com/Homebrew/homebrew-core/f5b1ac99a7fba27c19cee0bc4f036775c889b359/Formula/libomp.rb mono-libgdiplus gettext && brew link gettext --force
+$ brew update && brew install cmake https://raw.githubusercontent.com/dotnet/machinelearning/master/build/libomp.rb mono-libgdiplus gettext && brew link gettext --force && brew link libomp --force
 ```


### PR DESCRIPTION
This PR fixes the error our Mac trusted CI builds were showing with regards to the installation of `libomp` with Homebrew, and mirrors the changes done in #5141.

