### PR TITLE
Created DoubleParser.OptionFlags to be used by TextLoader

### DIFF
--- a/src/Microsoft.ML.AutoML/ColumnInference/ColumnTypeInference.cs
+++ b/src/Microsoft.ML.AutoML/ColumnInference/ColumnTypeInference.cs
@@ -82,7 +82,7 @@ namespace Microsoft.ML.AutoML
                         bool value;
                         // (note: Conversions.Instance.TryParse parses an empty string as a Boolean)
                         return !string.IsNullOrEmpty(x.ToString()) &&
-                            Conversions.Instance.TryParse(in x, out value);
+                            Conversions.DefaultInstance.TryParse(in x, out value);
                     }))
                 {
                     return true;
@@ -164,7 +164,7 @@ namespace Microsoft.ML.AutoML
                         col.SuggestedType = BooleanDataViewType.Instance;
                         bool first;
 
-                        col.HasHeader = !Conversions.Instance.TryParse(in col.RawData[0], out first);
+                        col.HasHeader = !Conversions.DefaultInstance.TryParse(in col.RawData[0], out first);
                     }
                 }
             }
@@ -179,7 +179,7 @@ namespace Microsoft.ML.AutoML
                             .All(x =>
                             {
                                 float value;
-                                return Conversions.Instance.TryParse(in x, out value);
+                                return Conversions.DefaultInstance.TryParse(in x, out value);
                             })
                             )
                         {

--- a/src/Microsoft.ML.Core/Utilities/DoubleParser.cs
+++ b/src/Microsoft.ML.Core/Utilities/DoubleParser.cs
@@ -23,8 +23,6 @@ namespace Microsoft.ML.Internal.Utilities
             // a number and its decimal part). If this isn't set, then
             // default behavior is to use "." as decimal marker.
             UseCommaAsDecimalMarker = 0x01,
-
-            All = UseCommaAsDecimalMarker
         }
 
         private const ulong TopBit = 0x8000000000000000UL;

--- a/src/Microsoft.ML.Core/Utilities/DoubleParser.cs
+++ b/src/Microsoft.ML.Core/Utilities/DoubleParser.cs
@@ -42,6 +42,23 @@ namespace Microsoft.ML.Internal.Utilities
             {
                 DecimalMarker = decimalMarker;
             }
+
+            // Need the methods below to use this class
+            // as Key in the dictionary used in TextLoader
+            public bool Equals(Options other)
+            {
+                return other.DecimalMarker == DecimalMarker;
+            }
+
+            public override bool Equals(object o)
+            {
+                return Equals(o as Options);
+            }
+
+            public override int GetHashCode()
+            {
+                return DecimalMarker.GetHashCode();
+            }
         }
 
         private const ulong TopBit = 0x8000000000000000UL;

--- a/src/Microsoft.ML.Core/Utilities/DoubleParser.cs
+++ b/src/Microsoft.ML.Core/Utilities/DoubleParser.cs
@@ -12,25 +12,42 @@ namespace Microsoft.ML.Internal.Utilities
     [BestFriend]
     internal static class DoubleParser
     {
+        private class Defaults
+        {
+            internal const char DecimalMarker = '.';
+        }
+
+        [BestFriend]
+        internal class Options
+        {
+            public readonly char DecimalMarker;
+            public bool AreOptionsDefault
+            {
+                get {
+                    if (DecimalMarker != Defaults.DecimalMarker)
+                    {
+                        return false;
+                    }
+
+                    return true;
+                }
+            }
+
+            internal Options()
+            {
+                DecimalMarker = Defaults.DecimalMarker;
+            }
+
+            internal Options(char decimalMarker)
+            {
+                DecimalMarker = decimalMarker;
+            }
+        }
+
         private const ulong TopBit = 0x8000000000000000UL;
         private const ulong TopTwoBits = 0xC000000000000000UL;
         private const ulong TopThreeBits = 0xE000000000000000UL;
         private const char InfinitySymbol = '\u221E';
-
-        // Note for future development: DoubleParser is a static class and DecimalMarker is a
-        // static variable, which means only one instance of these can exist at once. As such,
-        // the value of DecimalMarker cannot vary when datasets with differing decimal markers
-        // are loaded together at once, which would result in not being able to accurately read
-        // the dataset with the differing decimal marker. Although this edge case where we attempt
-        // to load in datasets with different decimal markers at once is unlikely to occur, we
-        // should still be aware of this and plan to fix it in the future.
-
-        // The decimal marker that separates the integer part from the fractional part of a number
-        // written in decimal from can vary across different cultures as either '.' or ','. The
-        // default decimal marker in ML .NET is '.', however through this static char variable,
-        // we allow users to specify the decimal marker used in their datasets as ',' as well.
-        [BestFriend]
-        internal static char DecimalMarker = '.';
 
         // REVIEW: casting ulong to Double doesn't always do the right thing, for example
         // with 0x84595161401484A0UL. Hence the gymnastics several places in this code. Note that
@@ -85,9 +102,9 @@ namespace Microsoft.ML.Internal.Utilities
         /// <summary>
         /// This produces zero for an empty string.
         /// </summary>
-        public static bool TryParse(ReadOnlySpan<char> span, out Single value)
+        public static bool TryParse(ReadOnlySpan<char> span, out Single value, char decimalMarker = Defaults.DecimalMarker)
         {
-            var res = Parse(span, out value);
+            var res = Parse(span, out value, decimalMarker);
             Contracts.Assert(res != Result.Empty || value == 0);
             return res <= Result.Empty;
         }
@@ -95,14 +112,14 @@ namespace Microsoft.ML.Internal.Utilities
         /// <summary>
         /// This produces zero for an empty string.
         /// </summary>
-        public static bool TryParse(ReadOnlySpan<char> span, out Double value)
+        public static bool TryParse(ReadOnlySpan<char> span, out Double value, char decimalMarker = Defaults.DecimalMarker)
         {
-            var res = Parse(span, out value);
+            var res = Parse(span, out value, decimalMarker);
             Contracts.Assert(res != Result.Empty || value == 0);
             return res <= Result.Empty;
         }
 
-        public static Result Parse(ReadOnlySpan<char> span, out Single value)
+        public static Result Parse(ReadOnlySpan<char> span, out Single value, char decimalMarker = Defaults.DecimalMarker)
         {
             int ich = 0;
             for (; ; ich++)
@@ -133,7 +150,7 @@ namespace Microsoft.ML.Internal.Utilities
             }
 
             int ichEnd;
-            if (!DoubleParser.TryParse(span.Slice(ich, span.Length - ich), out value, out ichEnd))
+            if (!DoubleParser.TryParse(span.Slice(ich, span.Length - ich), out value, out ichEnd, decimalMarker))
             {
                 value = default(Single);
                 return Result.Error;
@@ -150,7 +167,7 @@ namespace Microsoft.ML.Internal.Utilities
             return Result.Good;
         }
 
-        public static Result Parse(ReadOnlySpan<char> span, out Double value)
+        public static Result Parse(ReadOnlySpan<char> span, out Double value, char decimalMarker = Defaults.DecimalMarker)
         {
             int ich = 0;
             for (; ; ich++)
@@ -181,7 +198,7 @@ namespace Microsoft.ML.Internal.Utilities
             }
 
             int ichEnd;
-            if (!DoubleParser.TryParse(span.Slice(ich, span.Length - ich), out value, out ichEnd))
+            if (!DoubleParser.TryParse(span.Slice(ich, span.Length - ich), out value, out ichEnd, decimalMarker))
             {
                 value = default(Double);
                 return Result.Error;
@@ -198,14 +215,14 @@ namespace Microsoft.ML.Internal.Utilities
             return Result.Good;
         }
 
-        public static bool TryParse(ReadOnlySpan<char> span, out Single value, out int ichEnd)
+        public static bool TryParse(ReadOnlySpan<char> span, out Single value, out int ichEnd, char decimalMarker = Defaults.DecimalMarker)
         {
             bool neg = false;
             ulong num = 0;
             long exp = 0;
 
             ichEnd = 0;
-            if (!TryParseCore(span, ref ichEnd, ref neg, ref num, ref exp))
+            if (!TryParseCore(span, ref ichEnd, ref neg, ref num, ref exp, decimalMarker))
                 return TryParseSpecial(span, ref ichEnd, out value);
 
             if (num == 0)
@@ -287,14 +304,14 @@ namespace Microsoft.ML.Internal.Utilities
             return true;
         }
 
-        public static bool TryParse(ReadOnlySpan<char> span, out Double value, out int ichEnd)
+        public static bool TryParse(ReadOnlySpan<char> span, out Double value, out int ichEnd, char decimalMarker = Defaults.DecimalMarker)
         {
             bool neg = false;
             ulong num = 0;
             long exp = 0;
 
             ichEnd = 0;
-            if (!TryParseCore(span, ref ichEnd, ref neg, ref num, ref exp))
+            if (!TryParseCore(span, ref ichEnd, ref neg, ref num, ref exp, decimalMarker))
                 return TryParseSpecial(span, ref ichEnd, out value);
 
             if (num == 0)
@@ -535,7 +552,7 @@ namespace Microsoft.ML.Internal.Utilities
             return false;
         }
 
-        private static bool TryParseCore(ReadOnlySpan<char> span, ref int ich, ref bool neg, ref ulong num, ref long exp)
+        private static bool TryParseCore(ReadOnlySpan<char> span, ref int ich, ref bool neg, ref ulong num, ref long exp, char decimalMarker)
         {
             Contracts.Assert(0 <= ich & ich <= span.Length);
             Contracts.Assert(!neg);
@@ -570,11 +587,11 @@ namespace Microsoft.ML.Internal.Utilities
                     break;
 
                 case '.':
-                    if (DecimalMarker != '.') // Decimal marker was not '.', but we encountered a '.', which must be an error.
+                    if (decimalMarker != '.') // Decimal marker was not '.', but we encountered a '.', which must be an error.
                         return false; // Since this was an error, return false, which will later make the caller to set NaN as the out value.
                     goto LPoint;
                 case ',':
-                    if (DecimalMarker != ',') // Same logic as above.
+                    if (decimalMarker != ',') // Same logic as above.
                         return false;
                     goto LPoint;
 
@@ -614,12 +631,12 @@ namespace Microsoft.ML.Internal.Utilities
             }
             Contracts.Assert(i < span.Length);
 
-            if (span[i] != DecimalMarker)
+            if (span[i] != decimalMarker)
                 goto LAfterDigits;
 
             LPoint:
             Contracts.Assert(i < span.Length);
-            Contracts.Assert(span[i] == DecimalMarker);
+            Contracts.Assert(span[i] == decimalMarker);
 
             // Get the digits after the decimal marker, which may be '.' or ','
             for (; ; )

--- a/src/Microsoft.ML.Data/Commands/ShowSchemaCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/ShowSchemaCommand.cs
@@ -234,7 +234,7 @@ namespace Microsoft.ML.Data
             Contracts.Assert(!(type is VectorDataViewType));
             Contracts.Assert(type.RawType == typeof(T));
 
-            var conv = Conversions.Instance.GetStringConversion<T>(type);
+            var conv = Conversions.DefaultInstance.GetStringConversion<T>(type);
 
             var value = default(T);
             var sb = default(StringBuilder);
@@ -272,7 +272,7 @@ namespace Microsoft.ML.Data
             Contracts.AssertValue(type);
             Contracts.Assert(type.ItemType.RawType == typeof(T));
 
-            var conv = Conversions.Instance.GetStringConversion<T>(type.ItemType);
+            var conv = Conversions.DefaultInstance.GetStringConversion<T>(type.ItemType);
 
             var value = default(VBuffer<T>);
             schema[col].Annotations.GetValue(kind, ref value);

--- a/src/Microsoft.ML.Data/Commands/TypeInfoCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/TypeInfoCommand.cs
@@ -79,7 +79,7 @@ namespace Microsoft.ML.Data.Commands
         {
             using (var ch = _host.Start("Run"))
             {
-                var conv = Conversions.Instance;
+                var conv = Conversions.DefaultInstance;
                 var comp = new SetOfKindsComparer();
                 var dstToSrcMap = new Dictionary<HashSet<InternalDataKind>, HashSet<InternalDataKind>>(comp);
                 var srcToDstMap = new Dictionary<InternalDataKind, HashSet<InternalDataKind>>();
@@ -143,7 +143,7 @@ namespace Microsoft.ML.Data.Commands
             ch.AssertValue(type);
             ch.Assert(type.IsStandardScalar());
 
-            var conv = Conversions.Instance;
+            var conv = Conversions.DefaultInstance;
             InPredicate<T> isNaDel;
             bool hasNaPred = conv.TryGetIsNAPredicate(type, out isNaDel);
             bool defaultIsNa = false;

--- a/src/Microsoft.ML.Data/Data/Conversion.cs
+++ b/src/Microsoft.ML.Data/Data/Conversion.cs
@@ -55,14 +55,14 @@ namespace Microsoft.ML.Data.Conversion
 
         // Default instance used by most of the codebase
         // Currently, only TextLoader would sometimes not use this instance
-        private static volatile Conversions _instance;
-        public static Conversions Instance // MYTODO: Should I rename this to "DefaultInstance"? It is used in over 99 places on the codebase
+        private static volatile Conversions _defaultInstance;
+        public static Conversions DefaultInstance
         {
             get
             {
-                return _instance ??
-                    Interlocked.CompareExchange(ref _instance, new Conversions(), null) ??
-                    _instance;
+                return _defaultInstance ??
+                    Interlocked.CompareExchange(ref _defaultInstance, new Conversions(), null) ??
+                    _defaultInstance;
             }
         }
 

--- a/src/Microsoft.ML.Data/Data/Conversion.cs
+++ b/src/Microsoft.ML.Data/Data/Conversion.cs
@@ -66,11 +66,11 @@ namespace Microsoft.ML.Data.Conversion
             }
         }
 
-        // Currently only TextLoader could use non-default DoubleParser Options
-        private DoubleParser.Options _doubleParserOptions;
-        public static Conversions CreateInstanceWithDoubleParserOptions(DoubleParser.Options doubleParserOptions)
+        // Currently only TextLoader could create instances using non-default DoubleParser.OptionFlags
+        private readonly DoubleParser.OptionFlags _doubleParserOptionFlags;
+        public static Conversions CreateInstanceWithDoubleParserOptions(DoubleParser.OptionFlags doubleParserOptionFlags)
         {
-            return new Conversions(doubleParserOptions);
+            return new Conversions(doubleParserOptionFlags);
         }
 
         // Maps from {src,dst} pair of DataKind to ValueMapper. The {src,dst} pair is
@@ -100,7 +100,7 @@ namespace Microsoft.ML.Data.Conversion
         // This has TryParseMapper<T> delegates for parsing values from text.
         private readonly Dictionary<Type, Delegate> _tryParseDelegates;
 
-        private Conversions(DoubleParser.Options doubleParserOptions = null)
+        private Conversions(DoubleParser.OptionFlags doubleParserOptionFlags = DoubleParser.OptionFlags.Default)
         {
             _delegatesStd = new Dictionary<(Type src, Type dst), Delegate>();
             _delegatesAll = new Dictionary<(Type src, Type dst), Delegate>();
@@ -110,10 +110,7 @@ namespace Microsoft.ML.Data.Conversion
             _hasZeroDelegates = new Dictionary<Type, Delegate>();
             _getNADelegates = new Dictionary<Type, Delegate>();
             _tryParseDelegates = new Dictionary<Type, Delegate>();
-            if (doubleParserOptions == null)
-                _doubleParserOptions = new DoubleParser.Options();
-            else
-                _doubleParserOptions = doubleParserOptions;
+            _doubleParserOptionFlags = doubleParserOptionFlags;
 
             // !!! WARNING !!!: Do NOT add any standard conversions without clearing from the IDV Type System
             // design committee. Any changes also require updating the IDV Type System Specification.
@@ -1345,7 +1342,7 @@ namespace Microsoft.ML.Data.Conversion
         public bool TryParse(in TX src, out R4 dst)
         {
             var span = src.Span;
-            if (DoubleParser.TryParse(span, out dst, _doubleParserOptions.DecimalMarker))
+            if (DoubleParser.TryParse(span, out dst, _doubleParserOptionFlags))
                 return true;
             dst = R4.NaN;
             return IsStdMissing(ref span);
@@ -1358,7 +1355,7 @@ namespace Microsoft.ML.Data.Conversion
         public bool TryParse(in TX src, out R8 dst)
         {
             var span = src.Span;
-            if (DoubleParser.TryParse(span, out dst, _doubleParserOptions.DecimalMarker))
+            if (DoubleParser.TryParse(span, out dst, _doubleParserOptionFlags))
                 return true;
             dst = R8.NaN;
             return IsStdMissing(ref span);
@@ -1642,7 +1639,7 @@ namespace Microsoft.ML.Data.Conversion
         public void Convert(in TX src, ref R4 value)
         {
             var span = src.Span;
-            if (DoubleParser.TryParse(span, out value, _doubleParserOptions.DecimalMarker))
+            if (DoubleParser.TryParse(span, out value, _doubleParserOptionFlags))
                 return;
             // Unparsable is mapped to NA.
             value = R4.NaN;
@@ -1650,7 +1647,7 @@ namespace Microsoft.ML.Data.Conversion
         public void Convert(in TX src, ref R8 value)
         {
             var span = src.Span;
-            if (DoubleParser.TryParse(span, out value, _doubleParserOptions.DecimalMarker))
+            if (DoubleParser.TryParse(span, out value, _doubleParserOptionFlags))
                 return;
             // Unparsable is mapped to NA.
             value = R8.NaN;

--- a/src/Microsoft.ML.Data/Data/Conversion.cs
+++ b/src/Microsoft.ML.Data/Data/Conversion.cs
@@ -53,10 +53,8 @@ namespace Microsoft.ML.Data.Conversion
 
         // REVIEW: Reconcile implementations with TypeUtils, and clarify the distinction.
 
-        // Options for the DoubleParser, currently the TextLoader would use non-default options
-        private DoubleParser.Options _doubleParserOptions;
-
         // Default instance used by most of the codebase
+        // Currently, only TextLoader would sometimes not use this instance
         private static volatile Conversions _instance;
         public static Conversions Instance // MYTODO: Should I rename this to "DefaultInstance"? It is used in over 99 places on the codebase
         {
@@ -68,6 +66,8 @@ namespace Microsoft.ML.Data.Conversion
             }
         }
 
+        // Currently only TextLoader could use non-default DoubleParser Options
+        private DoubleParser.Options _doubleParserOptions;
         public static Conversions CreateInstanceWithDoubleParserOptions(DoubleParser.Options doubleParserOptions)
         {
             return new Conversions(doubleParserOptions);

--- a/src/Microsoft.ML.Data/Data/DataViewUtils.cs
+++ b/src/Microsoft.ML.Data/Data/DataViewUtils.cs
@@ -1352,7 +1352,7 @@ namespace Microsoft.ML.Data
             var floatGetter = cursor.GetGetter<T>(cursor.Schema[i]);
             T v = default(T);
             ValueMapper<T, StringBuilder> conversion;
-            if (!Conversions.Instance.TryGetStringConversion<T>(colType, out conversion))
+            if (!Conversions.DefaultInstance.TryGetStringConversion<T>(colType, out conversion))
             {
                 var error = $"Cannot display {colType}";
                 conversion = (in T src, ref StringBuilder builder) =>
@@ -1383,7 +1383,7 @@ namespace Microsoft.ML.Data
             var vbuf = default(VBuffer<T>);
             const int previewValues = 100;
             ValueMapper<T, StringBuilder> conversion;
-            Conversions.Instance.TryGetStringConversion<T>(colType, out conversion);
+            Conversions.DefaultInstance.TryGetStringConversion<T>(colType, out conversion);
             StringBuilder dst = null;
             ValueGetter<ReadOnlyMemory<char>> getter =
                 (ref ReadOnlyMemory<char> value) =>

--- a/src/Microsoft.ML.Data/Data/RowCursorUtils.cs
+++ b/src/Microsoft.ML.Data/Data/RowCursorUtils.cs
@@ -94,7 +94,7 @@ namespace Microsoft.ML.Data
 
             var getter = row.GetGetter<TSrc>(row.Schema[col]);
             bool identity;
-            var conv = Conversions.Instance.GetStandardConversion<TSrc, TDst>(typeSrc, typeDst, out identity);
+            var conv = Conversions.DefaultInstance.GetStandardConversion<TSrc, TDst>(typeSrc, typeDst, out identity);
             if (identity)
             {
                 Contracts.Assert(typeof(TSrc) == typeof(TDst));
@@ -134,7 +134,7 @@ namespace Microsoft.ML.Data
             Contracts.Assert(typeof(TSrc) == typeSrc.RawType);
 
             var getter = row.GetGetter<TSrc>(row.Schema[col]);
-            var conv = Conversions.Instance.GetStringConversion<TSrc>(typeSrc);
+            var conv = Conversions.DefaultInstance.GetStringConversion<TSrc>(typeSrc);
 
             var src = default(TSrc);
             return
@@ -260,7 +260,7 @@ namespace Microsoft.ML.Data
 
             var getter = getterFact.GetGetter<VBuffer<TSrc>>();
             bool identity;
-            var conv = Conversions.Instance.GetStandardConversion<TSrc, TDst>(typeSrc.ItemType, typeDst, out identity);
+            var conv = Conversions.DefaultInstance.GetStandardConversion<TSrc, TDst>(typeSrc.ItemType, typeDst, out identity);
             if (identity)
             {
                 Contracts.Assert(typeof(TSrc) == typeof(TDst));

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
@@ -1113,7 +1113,6 @@ namespace Microsoft.ML.Data
         private readonly char _decimalMarker;
         private readonly Bindings _bindings;
 
-        private readonly DoubleParser.Options _doubleParserOptions;
         private readonly Parser _parser;
 
         private bool HasHeader
@@ -1238,7 +1237,6 @@ namespace Microsoft.ML.Data
                 throw _host.ExceptUserArg(nameof(Options.EscapeChar), "EscapeChar '{0}' can't be used both as EscapeChar and separator", _escapeChar);
 
             _bindings = new Bindings(this, cols, headerFile, dataSample);
-            _doubleParserOptions = new DoubleParser.Options(options.DecimalMarker);
             _parser = new Parser(this);
         }
 
@@ -1442,7 +1440,6 @@ namespace Microsoft.ML.Data
             host.CheckDecode(!_separators.Contains(_escapeChar));
 
             _bindings = new Bindings(ctx, this);
-            _doubleParserOptions = new DoubleParser.Options(_decimalMarker);
             _parser = new Parser(this);
         }
 

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
@@ -1113,6 +1113,7 @@ namespace Microsoft.ML.Data
         private readonly char _decimalMarker;
         private readonly Bindings _bindings;
 
+        private readonly DoubleParser.Options _doubleParserOptions;
         private readonly Parser _parser;
 
         private bool HasHeader
@@ -1237,6 +1238,7 @@ namespace Microsoft.ML.Data
                 throw _host.ExceptUserArg(nameof(Options.EscapeChar), "EscapeChar '{0}' can't be used both as EscapeChar and separator", _escapeChar);
 
             _bindings = new Bindings(this, cols, headerFile, dataSample);
+            _doubleParserOptions = new DoubleParser.Options(options.DecimalMarker);
             _parser = new Parser(this);
         }
 
@@ -1440,6 +1442,7 @@ namespace Microsoft.ML.Data
             host.CheckDecode(!_separators.Contains(_escapeChar));
 
             _bindings = new Bindings(ctx, this);
+            _doubleParserOptions = new DoubleParser.Options(_decimalMarker);
             _parser = new Parser(this);
         }
 
@@ -1631,7 +1634,6 @@ namespace Microsoft.ML.Data
             public DataViewRowCursor GetRowCursor(IEnumerable<DataViewSchema.Column> columnsNeeded, Random rand = null)
             {
                 _host.CheckValueOrNull(rand);
-                DoubleParser.DecimalMarker = _loader._decimalMarker;
                 var active = Utils.BuildArray(_loader._bindings.OutputSchema.Count, columnsNeeded);
                 return Cursor.Create(_loader, _files, active);
             }
@@ -1639,7 +1641,6 @@ namespace Microsoft.ML.Data
             public DataViewRowCursor[] GetRowCursorSet(IEnumerable<DataViewSchema.Column> columnsNeeded, int n, Random rand = null)
             {
                 _host.CheckValueOrNull(rand);
-                DoubleParser.DecimalMarker = _loader._decimalMarker;
                 var active = Utils.BuildArray(_loader._bindings.OutputSchema.Count, columnsNeeded);
                 return Cursor.CreateSet(_loader, _files, active, n);
             }

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderParser.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderParser.cs
@@ -62,7 +62,7 @@ namespace Microsoft.ML.Data
             private ValueCreatorCache(DoubleParser.OptionFlags doubleParserOptionFlags = DoubleParser.OptionFlags.Default)
             {
                 if (doubleParserOptionFlags == DoubleParser.OptionFlags.Default)
-                    _conv = Conversions.Instance;
+                    _conv = Conversions.DefaultInstance;
                 else
                     _conv = Conversions.CreateInstanceWithDoubleParserOptions(doubleParserOptionFlags);
 
@@ -258,7 +258,7 @@ namespace Microsoft.ML.Data
                 Contracts.Assert(typeof(TResult) == type.RawType);
                 _conv = conv;
                 _values = new TResult[Rows.Count];
-                HasNA = Conversions.Instance.TryGetIsNAPredicate(type, out var del);
+                HasNA = Conversions.DefaultInstance.TryGetIsNAPredicate(type, out var del);
             }
 
             public override void Reset(int irow, int size)
@@ -440,7 +440,7 @@ namespace Microsoft.ML.Data
                 _values = new VectorValue[Rows.Count];
                 for (int i = 0; i < _values.Length; i++)
                     _values[i] = new VectorValue(this);
-                HasNA = Conversions.Instance.TryGetIsNAPredicate(type, out var del);
+                HasNA = Conversions.DefaultInstance.TryGetIsNAPredicate(type, out var del);
             }
 
             public override void Reset(int irow, int size)
@@ -1043,7 +1043,7 @@ namespace Microsoft.ML.Data
                                 var spanT = Fields.Spans[Fields.Count - 1];
 
                                 int csrc;
-                                if (!Conversions.Instance.TryParse(in spanT, out csrc) || csrc <= 0)
+                                if (!Conversions.DefaultInstance.TryParse(in spanT, out csrc) || csrc <= 0)
                                 {
                                     _stats.LogBadFmt(ref scan, "Bad dimensionality or ambiguous sparse item. Use sparse=- for non-sparse file, and/or quote the value.");
                                     break;

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderParser.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderParser.cs
@@ -660,11 +660,12 @@ namespace Microsoft.ML.Data
                 _infos = parent._bindings.Infos;
                 _creator = new Func<RowSet, ColumnPipe>[_infos.Length];
 
+                var doubpleParserOptions = new DoubleParser.Options(parent._decimalMarker);
                 ValueCreatorCache cache;
-                if (parent._doubleParserOptions.AreOptionsDefault)
+                if (doubpleParserOptions.AreOptionsDefault)
                     cache = ValueCreatorCache.DefaultInstance;
                 else
-                    cache = ValueCreatorCache.CreateInstanceWithDoubleParserOptions(parent._doubleParserOptions);
+                    cache = ValueCreatorCache.CreateInstanceWithDoubleParserOptions(doubpleParserOptions);
 
                 var mapOne = new Dictionary<InternalDataKind, Func<RowSet, ColumnPipe>>();
                 var mapVec = new Dictionary<InternalDataKind, Func<RowSet, ColumnPipe>>();

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextSaver.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextSaver.cs
@@ -123,7 +123,7 @@ namespace Microsoft.ML.Data.IO
                     Conv = (ValueMapper<T, StringBuilder>)(Delegate)c;
                 }
                 else
-                    Conv = Conversions.Instance.GetStringConversion<T>(type);
+                    Conv = Conversions.DefaultInstance.GetStringConversion<T>(type);
 
                 var d = default(T);
                 Conv(in d, ref Sb);

--- a/src/Microsoft.ML.Data/DataView/LambdaColumnMapper.cs
+++ b/src/Microsoft.ML.Data/DataView/LambdaColumnMapper.cs
@@ -56,7 +56,7 @@ namespace Microsoft.ML.Data
                 ident = true;
                 conv = null;
             }
-            else if (!Conversions.Instance.TryGetStandardConversion(typeOrig, typeSrc, out conv, out ident))
+            else if (!Conversions.DefaultInstance.TryGetStandardConversion(typeOrig, typeSrc, out conv, out ident))
             {
                 throw env.ExceptParam(nameof(mapper),
                     "The type of column '{0}', '{1}', cannot be converted to the input type of the mapper '{2}'",

--- a/src/Microsoft.ML.Data/DataView/LambdaFilter.cs
+++ b/src/Microsoft.ML.Data/DataView/LambdaFilter.cs
@@ -47,7 +47,7 @@ namespace Microsoft.ML.Data
                 ident = true;
                 conv = null;
             }
-            else if (!Conversions.Instance.TryGetStandardConversion(typeOrig, typeSrc, out conv, out ident))
+            else if (!Conversions.DefaultInstance.TryGetStandardConversion(typeOrig, typeSrc, out conv, out ident))
             {
                 throw env.ExceptParam(nameof(predicate),
                     "The type of column '{0}', '{1}', cannot be converted to the input type of the predicate '{2}'",

--- a/src/Microsoft.ML.Data/DataView/Transposer.cs
+++ b/src/Microsoft.ML.Data/DataView/Transposer.cs
@@ -370,7 +370,7 @@ namespace Microsoft.ML.Data
 
             protected override ValueGetter<VBuffer<T>> GetGetterCore()
             {
-                var isDefault = Conversion.Conversions.Instance.GetIsDefaultPredicate<T>(_view.Schema[_col].Type);
+                var isDefault = Conversion.Conversions.DefaultInstance.GetIsDefaultPredicate<T>(_view.Schema[_col].Type);
                 bool valid = false;
                 VBuffer<T> cached = default(VBuffer<T>);
                 return
@@ -518,7 +518,7 @@ namespace Microsoft.ML.Data
                 Ch.Assert(itemType.RawType == typeof(T));
                 int vecLen = type.GetValueCount();
                 Ch.Assert(vecLen > 0);
-                InPredicate<T> isDefault = Conversion.Conversions.Instance.GetIsDefaultPredicate<T>(itemType);
+                InPredicate<T> isDefault = Conversion.Conversions.DefaultInstance.GetIsDefaultPredicate<T>(itemType);
                 int maxPossibleSize = _rbuff.Length * vecLen;
                 const int sparseThresholdRatio = 5;
                 int sparseThreshold = (maxPossibleSize + sparseThresholdRatio - 1) / sparseThresholdRatio;

--- a/src/Microsoft.ML.Data/Transforms/InvertHashUtils.cs
+++ b/src/Microsoft.ML.Data/Transforms/InvertHashUtils.cs
@@ -38,7 +38,7 @@ namespace Microsoft.ML.Data
             Contracts.Assert(0 <= col && col < schema.Count);
             var type = schema[col].Type.GetItemType();
             Contracts.Assert(type.RawType == typeof(T));
-            var conv = Conversion.Conversions.Instance;
+            var conv = Conversion.Conversions.DefaultInstance;
 
             // First: if not key, then get the standard string conversion.
             if (!(type is KeyDataViewType keyType))

--- a/src/Microsoft.ML.Data/Transforms/KeyToValue.cs
+++ b/src/Microsoft.ML.Data/Transforms/KeyToValue.cs
@@ -323,16 +323,16 @@ namespace Microsoft.ML.Transforms
 
                     // REVIEW: May want to include more specific information about what the specific value is for the default.
                     DataViewType outputItemType = TypeOutput.GetItemType();
-                    _na = Data.Conversion.Conversions.Instance.GetNAOrDefault<TValue>(outputItemType, out _naMapsToDefault);
+                    _na = Data.Conversion.Conversions.DefaultInstance.GetNAOrDefault<TValue>(outputItemType, out _naMapsToDefault);
 
                     if (_naMapsToDefault)
                     {
                         // Only initialize _isDefault if _defaultIsNA is true as this is the only case in which it is used.
-                        _isDefault = Data.Conversion.Conversions.Instance.GetIsDefaultPredicate<TValue>(outputItemType);
+                        _isDefault = Data.Conversion.Conversions.DefaultInstance.GetIsDefaultPredicate<TValue>(outputItemType);
                     }
 
                     bool identity;
-                    _convertToUInt = Data.Conversion.Conversions.Instance.GetStandardConversion<TKey, UInt32>(typeKey, NumberDataViewType.UInt32, out identity);
+                    _convertToUInt = Data.Conversion.Conversions.DefaultInstance.GetStandardConversion<TKey, UInt32>(typeKey, NumberDataViewType.UInt32, out identity);
                 }
 
                 private void MapKey(in TKey src, ref TValue dst)

--- a/src/Microsoft.ML.Data/Transforms/NAFilter.cs
+++ b/src/Microsoft.ML.Data/Transforms/NAFilter.cs
@@ -297,7 +297,7 @@ namespace Microsoft.ML.Transforms
                     Contracts.Assert(info.Type.RawType == typeof(T));
 
                     var getSrc = cursor.Input.GetGetter<T>(cursor.Input.Schema[info.Index]);
-                    var hasBad = Data.Conversion.Conversions.Instance.GetIsNAPredicate<T>(info.Type);
+                    var hasBad = Data.Conversion.Conversions.DefaultInstance.GetIsNAPredicate<T>(info.Type);
                     return new ValueOne<T>(cursor, getSrc, hasBad);
                 }
 
@@ -309,7 +309,7 @@ namespace Microsoft.ML.Transforms
                     Contracts.Assert(info.Type.RawType == typeof(VBuffer<T>));
 
                     var getSrc = cursor.Input.GetGetter<VBuffer<T>>(cursor.Input.Schema[info.Index]);
-                    var hasBad = Data.Conversion.Conversions.Instance.GetHasMissingPredicate<T>((VectorDataViewType)info.Type);
+                    var hasBad = Data.Conversion.Conversions.DefaultInstance.GetHasMissingPredicate<T>((VectorDataViewType)info.Type);
                     return new ValueVec<T>(cursor, getSrc, hasBad);
                 }
 

--- a/src/Microsoft.ML.Data/Transforms/RangeFilter.cs
+++ b/src/Microsoft.ML.Data/Transforms/RangeFilter.cs
@@ -430,7 +430,7 @@ namespace Microsoft.ML.Transforms
                         dst = _value;
                     };
                 bool identity;
-                _conv = Data.Conversion.Conversions.Instance.GetStandardConversion<T, ulong>(Parent._type, NumberDataViewType.UInt64, out identity);
+                _conv = Data.Conversion.Conversions.DefaultInstance.GetStandardConversion<T, ulong>(Parent._type, NumberDataViewType.UInt64, out identity);
             }
 
             protected override Delegate GetGetter()

--- a/src/Microsoft.ML.Data/Transforms/TypeConverting.cs
+++ b/src/Microsoft.ML.Data/Transforms/TypeConverting.cs
@@ -421,7 +421,7 @@ namespace Microsoft.ML.Transforms
 
                 // Ensure that the conversion is legal. We don't actually cache the delegate here. It will get
                 // re-fetched by the utils code when needed.
-                if (!Data.Conversion.Conversions.Instance.TryGetStandardConversion(srcType.GetItemType(), itemType, out Delegate del, out bool identity))
+                if (!Data.Conversion.Conversions.DefaultInstance.TryGetStandardConversion(srcType.GetItemType(), itemType, out Delegate del, out bool identity))
                     return false;
 
                 typeDst = itemType;
@@ -626,7 +626,7 @@ namespace Microsoft.ML.Transforms
                     throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", colInfo.InputColumnName);
                 if (!TypeConvertingTransformer.GetNewType(Host, col.ItemType, colInfo.OutputKind.ToInternalDataKind(), colInfo.OutputKeyCount, out PrimitiveDataViewType newType))
                     throw Host.ExceptParam(nameof(inputSchema), $"Can't convert {colInfo.InputColumnName} into {newType.ToString()}");
-                if (!Data.Conversion.Conversions.Instance.TryGetStandardConversion(col.ItemType, newType, out Delegate del, out bool identity))
+                if (!Data.Conversion.Conversions.DefaultInstance.TryGetStandardConversion(col.ItemType, newType, out Delegate del, out bool identity))
                     throw Host.ExceptParam(nameof(inputSchema), $"Don't know how to convert {colInfo.InputColumnName} into {newType.ToString()}");
                 var metadata = new List<SchemaShape.Column>();
                 if (col.ItemType is BooleanDataViewType && newType is NumberDataViewType)

--- a/src/Microsoft.ML.Data/Transforms/ValueMapping.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueMapping.cs
@@ -495,7 +495,7 @@ namespace Microsoft.ML.Transforms
                         // Try to parse the text as a key value between 1 and ulong.MaxValue. If this succeeds and res>0,
                         // we update max and min accordingly. If res==0 it means the value is missing, in which case we ignore it for
                         // computing max and min.
-                        if (Data.Conversion.Conversions.Instance.TryParseKey(in value, ulong.MaxValue - 1, out res))
+                        if (Data.Conversion.Conversions.DefaultInstance.TryParseKey(in value, ulong.MaxValue - 1, out res))
                         {
                             if (res < keyMin && res != 0)
                                 keyMin = res;
@@ -504,7 +504,7 @@ namespace Microsoft.ML.Transforms
                         }
                         // If parsing as key did not succeed, the value can still be 0, so we try parsing it as a ulong. If it succeeds,
                         // then the value is 0, and we update min accordingly.
-                        else if (Microsoft.ML.Data.Conversion.Conversions.Instance.TryParse(in value, out res))
+                        else if (Microsoft.ML.Data.Conversion.Conversions.DefaultInstance.TryParse(in value, out res))
                         {
                             keyMin = 0;
                         }
@@ -863,7 +863,7 @@ namespace Microsoft.ML.Transforms
                     // First check if there is a String->ValueType conversion method. If so, call the conversion method with an
                     // empty string, the returned value will be the new missing value.
                     // NOTE this will return NA for R4 and R8 types.
-                    if (Data.Conversion.Conversions.Instance.TryGetStandardConversion<ReadOnlyMemory<char>, TValue>(
+                    if (Data.Conversion.Conversions.DefaultInstance.TryGetStandardConversion<ReadOnlyMemory<char>, TValue>(
                                                                         TextDataViewType.Instance,
                                                                         ValueColumn.Type,
                                                                         out conv,

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformerImpl.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformerImpl.cs
@@ -67,7 +67,7 @@ namespace Microsoft.ML.Transforms
                 // of building our term dictionary. For the other types (practically, only the UX types),
                 // we should ignore nothing.
                 InPredicate<T> mapsToMissing;
-                if (!Data.Conversion.Conversions.Instance.TryGetIsNAPredicate(type, out mapsToMissing))
+                if (!Data.Conversion.Conversions.DefaultInstance.TryGetIsNAPredicate(type, out mapsToMissing))
                     mapsToMissing = (in T val) => false;
                 return new Impl<T>(type, mapsToMissing, sorted);
             }
@@ -207,7 +207,7 @@ namespace Microsoft.ML.Transforms
             public override void ParseAddTermArg(ref ReadOnlyMemory<char> terms, IChannel ch)
             {
                 T val;
-                var tryParse = Data.Conversion.Conversions.Instance.GetTryParseConversion<T>(ItemType);
+                var tryParse = Data.Conversion.Conversions.DefaultInstance.GetTryParseConversion<T>(ItemType);
                 for (bool more = true; more;)
                 {
                     ReadOnlyMemory<char> term;
@@ -233,7 +233,7 @@ namespace Microsoft.ML.Transforms
             public override void ParseAddTermArg(string[] terms, IChannel ch)
             {
                 T val;
-                var tryParse = Data.Conversion.Conversions.Instance.GetTryParseConversion<T>(ItemType);
+                var tryParse = Data.Conversion.Conversions.DefaultInstance.GetTryParseConversion<T>(ItemType);
                 foreach (var sterm in terms)
                 {
                     ReadOnlyMemory<char> term = sterm.AsMemory();
@@ -748,7 +748,7 @@ namespace Microsoft.ML.Transforms
                 {
                     writer.WriteLine("# Number of terms of type '{0}' = {1}", ItemType, Count);
                     StringBuilder sb = null;
-                    var stringMapper = Data.Conversion.Conversions.Instance.GetStringConversion<T>(ItemType);
+                    var stringMapper = Data.Conversion.Conversions.DefaultInstance.GetStringConversion<T>(ItemType);
                     for (int i = 0; i < _values.Count; ++i)
                     {
                         T val = _values.GetItem(i);
@@ -1046,7 +1046,7 @@ namespace Microsoft.ML.Transforms
                         return;
                     if (IsTextMetadata && !(TypedMap.ItemType is TextDataViewType))
                     {
-                        var conv = Data.Conversion.Conversions.Instance;
+                        var conv = Data.Conversion.Conversions.DefaultInstance;
                         var stringMapper = conv.GetStringConversion<T>(TypedMap.ItemType);
 
                         ValueGetter<VBuffer<ReadOnlyMemory<char>>> getter =
@@ -1112,7 +1112,7 @@ namespace Microsoft.ML.Transforms
                     var srcType = TypedMap.ItemType as KeyDataViewType;
                     _host.AssertValue(srcType);
                     var dstType = new KeyDataViewType(typeof(uint), srcType.Count);
-                    var convInst = Data.Conversion.Conversions.Instance;
+                    var convInst = Data.Conversion.Conversions.DefaultInstance;
                     ValueMapper<T, uint> conv;
                     bool identity;
                     // If we can't convert this type to U4, don't try to pass along the metadata.
@@ -1192,7 +1192,7 @@ namespace Microsoft.ML.Transforms
                     var srcType = TypedMap.ItemType as KeyDataViewType;
                     _host.AssertValue(srcType);
                     var dstType = new KeyDataViewType(typeof(uint), srcType.Count);
-                    var convInst = Data.Conversion.Conversions.Instance;
+                    var convInst = Data.Conversion.Conversions.DefaultInstance;
                     ValueMapper<T, uint> conv;
                     bool identity;
                     // If we can't convert this type to U4, don't try.

--- a/src/Microsoft.ML.FastTree/FastTree.cs
+++ b/src/Microsoft.ML.FastTree/FastTree.cs
@@ -1289,7 +1289,7 @@ namespace Microsoft.ML.Trainers.FastTree
 
             private ValueMapper<VBuffer<T1>, VBuffer<T2>> GetCopier<T1, T2>(DataViewType itemType1, DataViewType itemType2)
             {
-                var conv = Conversions.Instance.GetStandardConversion<T1, T2>(itemType1, itemType2, out bool identity);
+                var conv = Conversions.DefaultInstance.GetStandardConversion<T1, T2>(itemType1, itemType2, out bool identity);
                 if (identity)
                 {
                     ValueMapper<VBuffer<T1>, VBuffer<T1>> identityResult =
@@ -1368,7 +1368,7 @@ namespace Microsoft.ML.Trainers.FastTree
                         BinFinder finder = new BinFinder();
                         FeaturesToContentMap fmap = new FeaturesToContentMap(examples.Schema);
 
-                        var hasMissingPred = Conversions.Instance.GetHasMissingPredicate<float>(((ITransposeDataView)trans).GetSlotType(featIdx));
+                        var hasMissingPred = Conversions.DefaultInstance.GetHasMissingPredicate<float>(((ITransposeDataView)trans).GetSlotType(featIdx));
                         // There is no good mechanism to filter out rows with missing feature values on transposed data.
                         // So, we instead perform one featurization pass which, if successful, will remain one pass but,
                         // if we ever encounter missing values will become a "detect missing features" pass, which will

--- a/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
+++ b/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
@@ -733,8 +733,8 @@ namespace Microsoft.ML.Data
             // key-types we just upfront convert it to the most general type (ulong) and work from there.
             KeyDataViewType dstType = new KeyDataViewType(typeof(ulong), type.Count);
             bool identity;
-            var converter = Conversions.Instance.GetStandardConversion<TInput, ulong>(type, dstType, out identity);
-            var isNa = Conversions.Instance.GetIsNAPredicate<TInput>(type);
+            var converter = Conversions.DefaultInstance.GetStandardConversion<TInput, ulong>(type, dstType, out identity);
+            var isNa = Conversions.DefaultInstance.GetIsNAPredicate<TInput>(type);
 
             ValueMapper<TInput, Single> mapper;
             if (seed == 0)

--- a/src/Microsoft.ML.Mkl.Components/SymSgdClassificationTrainer.cs
+++ b/src/Microsoft.ML.Mkl.Components/SymSgdClassificationTrainer.cs
@@ -254,7 +254,7 @@ namespace Microsoft.ML.Trainers
 
             VBuffer<float> maybeSparseWeights = default;
             VBufferUtils.CreateMaybeSparseCopy(in weights, ref maybeSparseWeights,
-                Conversions.Instance.GetIsDefaultPredicate<float>(NumberDataViewType.Single));
+                Conversions.DefaultInstance.GetIsDefaultPredicate<float>(NumberDataViewType.Single));
             var predictor = new LinearBinaryModelParameters(Host, in maybeSparseWeights, bias);
             return new ParameterMixingCalibratedModelParameters<LinearBinaryModelParameters, PlattCalibrator>(Host, predictor, new PlattCalibrator(Host, -1, 0));
         }

--- a/src/Microsoft.ML.Parquet/PartitionedFileLoader.cs
+++ b/src/Microsoft.ML.Parquet/PartitionedFileLoader.cs
@@ -626,7 +626,7 @@ namespace Microsoft.ML.Data
                 Ch.Check(col >= 0 && col < _colValues.Length);
                 Ch.AssertValue(type);
 
-                var conv = Conversions.Instance.GetStandardConversion(TextDataViewType.Instance, type) as ValueMapper<ReadOnlyMemory<char>, TValue>;
+                var conv = Conversions.DefaultInstance.GetStandardConversion(TextDataViewType.Instance, type) as ValueMapper<ReadOnlyMemory<char>, TValue>;
                 if (conv == null)
                 {
                     throw Ch.Except("Invalid TValue: '{0}' of the conversion.", typeof(TValue));

--- a/src/Microsoft.ML.StandardTrainers/Standard/SdcaBinary.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/SdcaBinary.cs
@@ -1525,7 +1525,7 @@ namespace Microsoft.ML.Trainers
             VBuffer<float> maybeSparseWeights = default;
             // below should be `in weights[0]`, but can't because of https://github.com/dotnet/roslyn/issues/29371
             VBufferUtils.CreateMaybeSparseCopy(weights[0], ref maybeSparseWeights,
-                Conversions.Instance.GetIsDefaultPredicate<float>(NumberDataViewType.Single));
+                Conversions.DefaultInstance.GetIsDefaultPredicate<float>(NumberDataViewType.Single));
 
             return new LinearBinaryModelParameters(Host, in maybeSparseWeights, bias[0]);
         }
@@ -1813,7 +1813,7 @@ namespace Microsoft.ML.Trainers
             VBuffer<float> maybeSparseWeights = default;
             // below should be `in weights[0]`, but can't because of https://github.com/dotnet/roslyn/issues/29371
             VBufferUtils.CreateMaybeSparseCopy(weights[0], ref maybeSparseWeights,
-                Conversions.Instance.GetIsDefaultPredicate<float>(NumberDataViewType.Single));
+                Conversions.DefaultInstance.GetIsDefaultPredicate<float>(NumberDataViewType.Single));
 
             var predictor = new LinearBinaryModelParameters(Host, in maybeSparseWeights, bias[0]);
             if (Info.NeedCalibration)
@@ -2210,7 +2210,7 @@ namespace Microsoft.ML.Trainers
 
             VBuffer<float> maybeSparseWeights = default;
             VBufferUtils.CreateMaybeSparseCopy(weights, ref maybeSparseWeights,
-                Conversions.Instance.GetIsDefaultPredicate<float>(NumberDataViewType.Single));
+                Conversions.DefaultInstance.GetIsDefaultPredicate<float>(NumberDataViewType.Single));
 
             return new LinearBinaryModelParameters(Host, in maybeSparseWeights, bias);
         }

--- a/src/Microsoft.ML.StandardTrainers/Standard/SdcaRegression.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/SdcaRegression.cs
@@ -150,7 +150,7 @@ namespace Microsoft.ML.Trainers
             VBuffer<float> maybeSparseWeights = default;
             // below should be `in weights[0]`, but can't because of https://github.com/dotnet/roslyn/issues/29371
             VBufferUtils.CreateMaybeSparseCopy(weights[0], ref maybeSparseWeights,
-                Conversions.Instance.GetIsDefaultPredicate<float>(NumberDataViewType.Single));
+                Conversions.DefaultInstance.GetIsDefaultPredicate<float>(NumberDataViewType.Single));
 
             return new LinearRegressionModelParameters(Host, in maybeSparseWeights, bias[0]);
         }

--- a/src/Microsoft.ML.TimeSeries/SlidingWindowTransformBase.cs
+++ b/src/Microsoft.ML.TimeSeries/SlidingWindowTransformBase.cs
@@ -100,7 +100,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
             int index;
             sch.TryGetColumnIndex(InputColumnName, out index);
             DataViewType col = sch[index].Type;
-            TInput nanValue = Data.Conversion.Conversions.Instance.GetNAOrDefault<TInput>(col);
+            TInput nanValue = Data.Conversion.Conversions.DefaultInstance.GetNAOrDefault<TInput>(col);
 
             // We store the nan_value here to avoid getting it each time a state is instanciated.
             return nanValue;

--- a/src/Microsoft.ML.Transforms/CountFeatureSelection.cs
+++ b/src/Microsoft.ML.Transforms/CountFeatureSelection.cs
@@ -399,8 +399,8 @@ namespace Microsoft.ML.Transforms
                         getter(ref t);
                         VBufferEditor.CreateFromBuffer(ref _buffer).Values[0] = t;
                     };
-                _isDefault = Data.Conversion.Conversions.Instance.GetIsDefaultPredicate<T>(type);
-                if (!Data.Conversion.Conversions.Instance.TryGetIsNAPredicate<T>(type, out _isMissing))
+                _isDefault = Data.Conversion.Conversions.DefaultInstance.GetIsDefaultPredicate<T>(type);
+                if (!Data.Conversion.Conversions.DefaultInstance.TryGetIsNAPredicate<T>(type, out _isMissing))
                     _isMissing = (in T value) => false;
             }
 
@@ -410,8 +410,8 @@ namespace Microsoft.ML.Transforms
                 var size = type.Size;
                 _count = new long[size];
                 _fillBuffer = () => getter(ref _buffer);
-                _isDefault = Data.Conversion.Conversions.Instance.GetIsDefaultPredicate<T>(type.ItemType);
-                if (!Data.Conversion.Conversions.Instance.TryGetIsNAPredicate<T>(type.ItemType, out _isMissing))
+                _isDefault = Data.Conversion.Conversions.DefaultInstance.GetIsDefaultPredicate<T>(type.ItemType);
+                if (!Data.Conversion.Conversions.DefaultInstance.TryGetIsNAPredicate<T>(type.ItemType, out _isMissing))
                     _isMissing = (in T value) => false;
             }
 

--- a/src/Microsoft.ML.Transforms/Expression/BuiltinFunctions.cs
+++ b/src/Microsoft.ML.Transforms/Expression/BuiltinFunctions.cs
@@ -844,21 +844,21 @@ namespace Microsoft.ML.Transforms
         public static BL ToBL(TX a)
         {
             BL res = default(BL);
-            Conversions.Instance.Convert(in a, ref res);
+            Conversions.DefaultInstance.Convert(in a, ref res);
             return res;
         }
 
         public static I4 ToI4(TX a)
         {
             I4 res = default(I4);
-            Conversions.Instance.Convert(in a, ref res);
+            Conversions.DefaultInstance.Convert(in a, ref res);
             return res;
         }
 
         public static I8 ToI8(TX a)
         {
             I8 res = default(I8);
-            Conversions.Instance.Convert(in a, ref res);
+            Conversions.DefaultInstance.Convert(in a, ref res);
             return res;
         }
 
@@ -880,7 +880,7 @@ namespace Microsoft.ML.Transforms
         public static R4 ToR4(TX a)
         {
             R4 res = default(R4);
-            Conversions.Instance.Convert(in a, ref res);
+            Conversions.DefaultInstance.Convert(in a, ref res);
             return res;
         }
 
@@ -902,7 +902,7 @@ namespace Microsoft.ML.Transforms
         public static R8 ToR8(TX a)
         {
             R8 res = default(R8);
-            Conversions.Instance.Convert(in a, ref res);
+            Conversions.DefaultInstance.Convert(in a, ref res);
             return res;
         }
 

--- a/src/Microsoft.ML.Transforms/ExpressionTransformer.cs
+++ b/src/Microsoft.ML.Transforms/ExpressionTransformer.cs
@@ -609,7 +609,7 @@ namespace Microsoft.ML.Transforms
             var src0 = default(VBuffer<T0>);
 
             var dstDef = fn(default(T0));
-            var isDef = Conversions.Instance.GetIsDefaultPredicate<TDst>(outputColumnItemType);
+            var isDef = Conversions.DefaultInstance.GetIsDefaultPredicate<TDst>(outputColumnItemType);
             if (isDef(in dstDef))
             {
                 // Sparsity is preserved.
@@ -668,7 +668,7 @@ namespace Microsoft.ML.Transforms
             ectx.Assert(inputColumns.Length == 2);
             ectx.Assert(perm.Length == 2);
 
-            var isDef = Conversions.Instance.GetIsDefaultPredicate<TDst>(outputColumnItemType);
+            var isDef = Conversions.DefaultInstance.GetIsDefaultPredicate<TDst>(outputColumnItemType);
             var fn = (Func<T0, T1, TDst>)del;
             var getSrc0 = input.GetGetter<VBuffer<T0>>(inputColumns[perm[0]]);
             var getSrc1 = input.GetGetter<T1>(inputColumns[perm[1]]);
@@ -728,7 +728,7 @@ namespace Microsoft.ML.Transforms
             ectx.Assert(inputColumns.Length == 3);
             ectx.Assert(perm.Length == 3);
 
-            var isDef = Conversions.Instance.GetIsDefaultPredicate<TDst>(outputColumnItemType);
+            var isDef = Conversions.DefaultInstance.GetIsDefaultPredicate<TDst>(outputColumnItemType);
             var fn = (Func<T0, T1, T2, TDst>)del;
             var getSrc0 = input.GetGetter<VBuffer<T0>>(inputColumns[perm[0]]);
             var getSrc1 = input.GetGetter<T1>(inputColumns[perm[1]]);
@@ -791,7 +791,7 @@ namespace Microsoft.ML.Transforms
             ectx.Assert(inputColumns.Length == 4);
             ectx.Assert(perm.Length == 4);
 
-            var isDef = Conversions.Instance.GetIsDefaultPredicate<TDst>(outputColumnItemType);
+            var isDef = Conversions.DefaultInstance.GetIsDefaultPredicate<TDst>(outputColumnItemType);
             var fn = (Func<T0, T1, T2, T3, TDst>)del;
             var getSrc0 = input.GetGetter<VBuffer<T0>>(inputColumns[perm[0]]);
             var getSrc1 = input.GetGetter<T1>(inputColumns[perm[1]]);
@@ -857,7 +857,7 @@ namespace Microsoft.ML.Transforms
             ectx.Assert(inputColumns.Length == 5);
             ectx.Assert(perm.Length == 5);
 
-            var isDef = Conversions.Instance.GetIsDefaultPredicate<TDst>(outputColumnItemType);
+            var isDef = Conversions.DefaultInstance.GetIsDefaultPredicate<TDst>(outputColumnItemType);
             var fn = (Func<T0, T1, T2, T3, T4, TDst>)del;
             var getSrc0 = input.GetGetter<VBuffer<T0>>(inputColumns[perm[0]]);
             var getSrc1 = input.GetGetter<T1>(inputColumns[perm[1]]);

--- a/src/Microsoft.ML.Transforms/HashJoiningTransform.cs
+++ b/src/Microsoft.ML.Transforms/HashJoiningTransform.cs
@@ -619,7 +619,7 @@ namespace Microsoft.ML.Transforms
 
             // Default case: convert to text and hash as a string.
             var sb = default(StringBuilder);
-            var conv = Data.Conversion.Conversions.Instance.GetStringConversion<TSrc>();
+            var conv = Data.Conversion.Conversions.DefaultInstance.GetStringConversion<TSrc>();
             return
                 (in TSrc value, uint seed) =>
                 {

--- a/src/Microsoft.ML.Transforms/MissingValueDroppingTransformer.cs
+++ b/src/Microsoft.ML.Transforms/MissingValueDroppingTransformer.cs
@@ -46,7 +46,7 @@ namespace Microsoft.ML.Transforms
                     throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", inputColumnName);
                 if (originalColumn.Kind == SchemaShape.Column.VectorKind.Scalar)
                     throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", originalColumn.Name, "Vector", "Scalar");
-                if (!Data.Conversion.Conversions.Instance.TryGetIsNAPredicate(originalColumn.ItemType, out _))
+                if (!Data.Conversion.Conversions.DefaultInstance.TryGetIsNAPredicate(originalColumn.ItemType, out _))
                     throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", originalColumn.Name, "Single, Double or Key", originalColumn.ItemType.ToString());
                 var col = new SchemaShape.Column(outputColumnName, SchemaShape.Column.VectorKind.VariableVector, originalColumn.ItemType, originalColumn.IsKey, originalColumn.Annotations);
                 resultDic[outputColumnName] = col;
@@ -195,7 +195,7 @@ namespace Microsoft.ML.Transforms
                     var srcCol = inputSchema[_srcCols[i]];
                     if (!(srcCol.Type is VectorDataViewType))
                         throw _parent.Host.Except($"Column '{srcCol.Name}' is not a vector column");
-                    if (!Data.Conversion.Conversions.Instance.TryGetIsNAPredicate(srcCol.Type.GetItemType(), out _isNAs[i]))
+                    if (!Data.Conversion.Conversions.DefaultInstance.TryGetIsNAPredicate(srcCol.Type.GetItemType(), out _isNAs[i]))
                         throw _parent.Host.Except($"Column '{srcCol.Name}' is of type {srcCol.Type.GetItemType()}, which does not support missing values");
                     _srcTypes[i] = srcCol.Type;
                     _types[i] = new VectorDataViewType((PrimitiveDataViewType)srcCol.Type.GetItemType());

--- a/src/Microsoft.ML.Transforms/MissingValueHandlingTransformer.cs
+++ b/src/Microsoft.ML.Transforms/MissingValueHandlingTransformer.cs
@@ -163,7 +163,7 @@ namespace Microsoft.ML.Transforms
                     throw h.Except("Column '{0}' does not exist", column.Source);
                 var replaceType = input.Schema[inputCol].Type;
                 var replaceItemType = replaceType.GetItemType();
-                if (!Data.Conversion.Conversions.Instance.TryGetStandardConversion(BooleanDataViewType.Instance, replaceItemType, out Delegate conv, out bool identity))
+                if (!Data.Conversion.Conversions.DefaultInstance.TryGetStandardConversion(BooleanDataViewType.Instance, replaceItemType, out Delegate conv, out bool identity))
                 {
                     throw h.Except("Cannot concatenate indicator column of type '{0}' to input column of type '{1}'",
                         BooleanDataViewType.Instance, replaceItemType);

--- a/src/Microsoft.ML.Transforms/MissingValueIndicatorTransformer.cs
+++ b/src/Microsoft.ML.Transforms/MissingValueIndicatorTransformer.cs
@@ -229,7 +229,7 @@ namespace Microsoft.ML.Transforms
 
             private static Delegate GetIsNADelegate<T>(DataViewType type)
             {
-                return Data.Conversion.Conversions.Instance.GetIsNAPredicate<T>(type.GetItemType());
+                return Data.Conversion.Conversions.DefaultInstance.GetIsNAPredicate<T>(type.GetItemType());
             }
 
             protected override Delegate MakeGetter(DataViewRow input, int iinfo, Func<int, bool> activeOutput, out Action disposer)
@@ -534,7 +534,7 @@ namespace Microsoft.ML.Transforms
             var result = inputSchema.ToDictionary(x => x.Name);
             foreach (var colPair in Transformer.Columns)
             {
-                if (!inputSchema.TryFindColumn(colPair.inputColumnName, out var col) || !Data.Conversion.Conversions.Instance.TryGetIsNAPredicate(col.ItemType, out Delegate del))
+                if (!inputSchema.TryFindColumn(colPair.inputColumnName, out var col) || !Data.Conversion.Conversions.DefaultInstance.TryGetIsNAPredicate(col.ItemType, out Delegate del))
                     throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", colPair.inputColumnName);
                 var metadata = new List<SchemaShape.Column>();
                 if (col.Annotations.TryFindColumn(AnnotationUtils.Kinds.SlotNames, out var slotMeta))

--- a/src/Microsoft.ML.Transforms/MissingValueReplacing.cs
+++ b/src/Microsoft.ML.Transforms/MissingValueReplacing.cs
@@ -162,7 +162,7 @@ namespace Microsoft.ML.Transforms
         private static string TestType<T>(DataViewType type)
         {
             Contracts.Assert(type.GetItemType().RawType == typeof(T));
-            if (!Data.Conversion.Conversions.Instance.TryGetIsNAPredicate(type.GetItemType(), out InPredicate<T> isNA))
+            if (!Data.Conversion.Conversions.DefaultInstance.TryGetIsNAPredicate(type.GetItemType(), out InPredicate<T> isNA))
             {
                 return string.Format("Type '{0}' is not supported by {1} since it doesn't have an NA value",
                     type, LoadName);
@@ -254,7 +254,7 @@ namespace Microsoft.ML.Transforms
             Host.Assert(srcType != null);
             Host.Assert(srcType.Size == src.Length);
             VBufferUtils.Densify<T>(ref src);
-            InPredicate<T> defaultPred = Data.Conversion.Conversions.Instance.GetIsDefaultPredicate<T>(srcType.ItemType);
+            InPredicate<T> defaultPred = Data.Conversion.Conversions.DefaultInstance.GetIsDefaultPredicate<T>(srcType.ItemType);
             _repIsDefault[iinfo] = new BitArray(srcType.Size);
             var srcValues = src.GetValues();
             for (int slot = 0; slot < srcValues.Length; slot++)
@@ -366,7 +366,7 @@ namespace Microsoft.ML.Transforms
         {
             Host.Assert(values.Length == type.GetVectorSize());
             BitArray defaultSlots = new BitArray(values.Length);
-            InPredicate<T> defaultPred = Data.Conversion.Conversions.Instance.GetIsDefaultPredicate<T>(type.GetItemType());
+            InPredicate<T> defaultPred = Data.Conversion.Conversions.DefaultInstance.GetIsDefaultPredicate<T>(type.GetItemType());
             T[] typedValues = (T[])values;
             for (int slot = 0; slot < values.Length; slot++)
             {
@@ -394,7 +394,7 @@ namespace Microsoft.ML.Transforms
         }
 
         private Delegate GetIsNADelegate<T>(DataViewType type)
-            => Data.Conversion.Conversions.Instance.GetIsNAPredicate<T>(type.GetItemType());
+            => Data.Conversion.Conversions.DefaultInstance.GetIsNAPredicate<T>(type.GetItemType());
 
         /// <summary>
         /// Converts a string to its respective value in the corresponding type.
@@ -413,7 +413,7 @@ namespace Microsoft.ML.Transforms
             {
                 // Handles converting input strings to correct types.
                 var srcTxt = srcStr.AsMemory();
-                var strToT = Data.Conversion.Conversions.Instance.GetStandardConversion<ReadOnlyMemory<char>, T>(TextDataViewType.Instance, dstType.GetItemType(), out bool identity);
+                var strToT = Data.Conversion.Conversions.DefaultInstance.GetStandardConversion<ReadOnlyMemory<char>, T>(TextDataViewType.Instance, dstType.GetItemType(), out bool identity);
                 strToT(in srcTxt, ref val);
                 // Make sure that the srcTxt can legitimately be converted to dstType, throw error otherwise.
                 if (isNA(in val))
@@ -667,7 +667,7 @@ namespace Microsoft.ML.Transforms
             {
                 var getSrc = input.GetGetter<VBuffer<T>>(input.Schema[ColMapNewToOld[iinfo]]);
                 var isNA = (InPredicate<T>)_isNAs[iinfo];
-                var isDefault = Data.Conversion.Conversions.Instance.GetIsDefaultPredicate<T>(_infos[iinfo].TypeSrc.GetItemType());
+                var isDefault = Data.Conversion.Conversions.DefaultInstance.GetIsDefaultPredicate<T>(_infos[iinfo].TypeSrc.GetItemType());
 
                 var src = default(VBuffer<T>);
                 ValueGetter<VBuffer<T>> getter;

--- a/src/Microsoft.ML.Transforms/MutualInformationFeatureSelection.cs
+++ b/src/Microsoft.ML.Transforms/MutualInformationFeatureSelection.cs
@@ -766,7 +766,7 @@ namespace Microsoft.ML.Transforms
             /// </summary>
             private static ValueMapper<VBuffer<T>, VBuffer<int>> BinKeys<T>(DataViewType colType)
             {
-                var conv = Data.Conversion.Conversions.Instance.GetStandardConversion<T, uint>(colType, NumberDataViewType.UInt32, out bool identity);
+                var conv = Data.Conversion.Conversions.DefaultInstance.GetStandardConversion<T, uint>(colType, NumberDataViewType.UInt32, out bool identity);
                 ValueMapper<T, int> mapper;
                 if (identity)
                 {

--- a/src/Microsoft.ML.Transforms/SvmLight/SvmLightLoader.cs
+++ b/src/Microsoft.ML.Transforms/SvmLight/SvmLightLoader.cs
@@ -142,8 +142,8 @@ namespace Microsoft.ML.Data
             public InputMapper()
             {
                 _seps = new char[] { ' ', '\t' };
-                _tryFloatParse = Conversions.Instance.GetTryParseConversion<float>(NumberDataViewType.Single);
-                _tryLongParse = Conversions.Instance.GetTryParseConversion<long>(NumberDataViewType.Int64);
+                _tryFloatParse = Conversions.DefaultInstance.GetTryParseConversion<float>(NumberDataViewType.Single);
+                _tryLongParse = Conversions.DefaultInstance.GetTryParseConversion<long>(NumberDataViewType.Int64);
             }
 
             public void MapInput(Input input, IntermediateInput intermediate)
@@ -306,7 +306,7 @@ namespace Microsoft.ML.Data
                 var inputValues = input.FeatureKeys.GetValues();
                 for (int i = 0; i < inputValues.Length; i++)
                 {
-                    if (Conversions.Instance.TryParse(in inputValues[i], out uint index))
+                    if (Conversions.DefaultInstance.TryParse(in inputValues[i], out uint index))
                     {
                         if (index < _offset)
                         {
@@ -671,7 +671,7 @@ namespace Microsoft.ML.Data
         private static uint InferMax(IHostEnvironment env, IDataView view)
         {
             ulong keyMax = 0;
-            var parser = Conversions.Instance.GetTryParseConversion<ulong>(NumberDataViewType.UInt64);
+            var parser = Conversions.DefaultInstance.GetTryParseConversion<ulong>(NumberDataViewType.UInt64);
             var col = view.Schema.GetColumnOrNull(nameof(IntermediateInput.FeatureKeys));
             env.Assert(col.HasValue);
 

--- a/src/Microsoft.ML.Transforms/UngroupTransform.cs
+++ b/src/Microsoft.ML.Transforms/UngroupTransform.cs
@@ -633,7 +633,7 @@ namespace Microsoft.ML.Transforms
                 // cachedIndex == row.Count || _pivotColPosition <= row.Indices[cachedIndex].
                 int cachedIndex = 0;
                 VBuffer<T> row = default(VBuffer<T>);
-                T naValue = Data.Conversion.Conversions.Instance.GetNAOrDefault<T>(itemType);
+                T naValue = Data.Conversion.Conversions.DefaultInstance.GetNAOrDefault<T>(itemType);
                 return
                     (ref T value) =>
                     {

--- a/test/Microsoft.ML.AutoML.Tests/ConversionTests.cs
+++ b/test/Microsoft.ML.AutoML.Tests/ConversionTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.ML.AutoML.Test
             foreach(var missingValue in missingValues)
             {
                 float value;
-                var success = Conversions.Instance.TryParse(missingValue.AsMemory(), out value);
+                var success = Conversions.DefaultInstance.TryParse(missingValue.AsMemory(), out value);
                 _output.WriteLine($"{missingValue} parsed as {value}");
                 Assert.True(success);
                 //Assert.Equal(float.NaN, value);
@@ -51,7 +51,7 @@ namespace Microsoft.ML.AutoML.Test
 
             foreach (var value in values)
             {
-                var success = Conversions.Instance.TryParse(value.AsMemory(), out float _);
+                var success = Conversions.DefaultInstance.TryParse(value.AsMemory(), out float _);
                 Assert.False(success);
             }
         }
@@ -70,7 +70,7 @@ namespace Microsoft.ML.AutoML.Test
 
             foreach (var missingValue in missingValues)
             {
-                var success = Conversions.Instance.TryParse(missingValue.AsMemory(), out bool _);
+                var success = Conversions.DefaultInstance.TryParse(missingValue.AsMemory(), out bool _);
                 Assert.True(success);
             }
         }
@@ -88,7 +88,7 @@ namespace Microsoft.ML.AutoML.Test
 
             foreach (var value in values)
             {
-                var success = Conversions.Instance.TryParse(value.AsMemory(), out bool _);
+                var success = Conversions.DefaultInstance.TryParse(value.AsMemory(), out bool _);
                 Assert.False(success);
             }
         }

--- a/test/Microsoft.ML.Core.Tests/UnitTests/DataTypes.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/DataTypes.cs
@@ -18,14 +18,14 @@ namespace Microsoft.ML.RunTests
         {
         }
 
-        private readonly static Conversions _conv = Conversions.Instance;
+        private readonly static Conversions _conv = Conversions.DefaultInstance;
 
         [Fact]
         public void R4ToSBtoR4()
         {
-            var r4ToSB = Conversions.Instance.GetStringConversion<float>(NumberDataViewType.Single);
+            var r4ToSB = Conversions.DefaultInstance.GetStringConversion<float>(NumberDataViewType.Single);
 
-            var txToR4 = Conversions.Instance.GetStandardConversion< ReadOnlyMemory<char>, float>(
+            var txToR4 = Conversions.DefaultInstance.GetStandardConversion< ReadOnlyMemory<char>, float>(
                 TextDataViewType.Instance, NumberDataViewType.Single, out bool identity2);
 
             Assert.NotNull(r4ToSB);
@@ -47,9 +47,9 @@ namespace Microsoft.ML.RunTests
         [Fact]
         public void R8ToSBtoR8()
         {
-            var r8ToSB = Conversions.Instance.GetStringConversion<double>(NumberDataViewType.Double);
+            var r8ToSB = Conversions.DefaultInstance.GetStringConversion<double>(NumberDataViewType.Double);
 
-            var txToR8 = Conversions.Instance.GetStandardConversion<ReadOnlyMemory<char>, double>(
+            var txToR8 = Conversions.DefaultInstance.GetStandardConversion<ReadOnlyMemory<char>, double>(
                 TextDataViewType.Instance, NumberDataViewType.Double, out bool identity2);
 
             Assert.NotNull(r8ToSB);
@@ -232,7 +232,7 @@ namespace Microsoft.ML.RunTests
         public void DTToDT()
         {
             bool identity;
-            var dtToDT = Conversions.Instance.GetStandardConversion<DateTime, DateTime>(
+            var dtToDT = Conversions.DefaultInstance.GetStandardConversion<DateTime, DateTime>(
                 DateTimeDataViewType.Instance, DateTimeDataViewType.Instance, out identity);
 
             Assert.NotNull(dtToDT);
@@ -252,7 +252,7 @@ namespace Microsoft.ML.RunTests
         {
             Assert.True(typeof(TDst) == dstType.RawType);
 
-            return Conversions.Instance.GetStandardConversion<TSrc, TDst>(
+            return Conversions.DefaultInstance.GetStandardConversion<TSrc, TDst>(
                 TextDataViewType.Instance, dstType, out bool identity);
         }
     }

--- a/test/Microsoft.ML.Tests/ExpressionLanguageTests/ExpressionLanguageTests.cs
+++ b/test/Microsoft.ML.Tests/ExpressionLanguageTests/ExpressionLanguageTests.cs
@@ -291,7 +291,7 @@ namespace Microsoft.ML.Tests
                         src =>
                         {
                             bool v;
-                            bool tmp = Conversions.Instance.TryParse(in src, out v);
+                            bool tmp = Conversions.DefaultInstance.TryParse(in src, out v);
                             args[i] = v;
                             return tmp;
                         };
@@ -300,7 +300,7 @@ namespace Microsoft.ML.Tests
                         src =>
                         {
                             int v;
-                            bool tmp = Conversions.Instance.TryParse(in src, out v);
+                            bool tmp = Conversions.DefaultInstance.TryParse(in src, out v);
                             args[i] = v;
                             return tmp;
                         };
@@ -309,7 +309,7 @@ namespace Microsoft.ML.Tests
                         src =>
                         {
                             long v;
-                            bool tmp = Conversions.Instance.TryParse(in src, out v);
+                            bool tmp = Conversions.DefaultInstance.TryParse(in src, out v);
                             args[i] = v;
                             return tmp;
                         };
@@ -318,7 +318,7 @@ namespace Microsoft.ML.Tests
                         src =>
                         {
                             float v;
-                            bool tmp = Conversions.Instance.TryParse(in src, out v);
+                            bool tmp = Conversions.DefaultInstance.TryParse(in src, out v);
                             args[i] = v;
                             return tmp;
                         };
@@ -327,7 +327,7 @@ namespace Microsoft.ML.Tests
                         src =>
                         {
                             double v;
-                            bool tmp = Conversions.Instance.TryParse(in src, out v);
+                            bool tmp = Conversions.DefaultInstance.TryParse(in src, out v);
                             args[i] = v;
                             return tmp;
                         };
@@ -353,35 +353,35 @@ namespace Microsoft.ML.Tests
                         src =>
                         {
                             var v = (bool)src;
-                            Conversions.Instance.Convert(in v, ref sb);
+                            Conversions.DefaultInstance.Convert(in v, ref sb);
                         };
                 case InternalDataKind.I4:
                     return
                         src =>
                         {
                             var v = (int)src;
-                            Conversions.Instance.Convert(in v, ref sb);
+                            Conversions.DefaultInstance.Convert(in v, ref sb);
                         };
                 case InternalDataKind.I8:
                     return
                         src =>
                         {
                             var v = (long)src;
-                            Conversions.Instance.Convert(in v, ref sb);
+                            Conversions.DefaultInstance.Convert(in v, ref sb);
                         };
                 case InternalDataKind.R4:
                     return
                         src =>
                         {
                             var v = (Single)src;
-                            Conversions.Instance.Convert(in v, ref sb);
+                            Conversions.DefaultInstance.Convert(in v, ref sb);
                         };
                 case InternalDataKind.R8:
                     return
                         src =>
                         {
                             var v = (Double)src;
-                            Conversions.Instance.Convert(in v, ref sb);
+                            Conversions.DefaultInstance.Convert(in v, ref sb);
                         };
                 case InternalDataKind.TX:
                     return

--- a/test/Microsoft.ML.Tests/TextLoaderTests.cs
+++ b/test/Microsoft.ML.Tests/TextLoaderTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using Microsoft.ML.Data;
 using Microsoft.ML.Model;
 using Microsoft.ML.RunTests;
@@ -1021,10 +1022,10 @@ namespace Microsoft.ML.EntryPoints.Tests
             var optionsPeriod = new TextLoader.Options()
             {
                 Columns = new[]
-                        {
-                    new TextLoader.Column("Label", DataKind.UInt32, 0),
-                    new TextLoader.Column("Features", DataKind.Single, new[] { new TextLoader.Range(1, 4) })
-                },
+            {
+                        new TextLoader.Column("Label", DataKind.UInt32, 0),
+                        new TextLoader.Column("Features", DataKind.Single, new[] { new TextLoader.Range(1, 4) })
+                    },
                 DecimalMarker = '.'
             };
 
@@ -1032,72 +1033,91 @@ namespace Microsoft.ML.EntryPoints.Tests
             {
                 Columns = new[]
                         {
-                    new TextLoader.Column("Label", DataKind.UInt32, 0),
-                    new TextLoader.Column("Features", DataKind.Single, new[] { new TextLoader.Range(1, 4) })
-                },
+                        new TextLoader.Column("Label", DataKind.UInt32, 0),
+                        new TextLoader.Column("Features", DataKind.Single, new[] { new TextLoader.Range(1, 4) })
+                    },
                 DecimalMarker = ','
             };
 
-            IDataView dataViewPeriod;
-            IDataView dataViewComma;
-
-            if(useCorrectPeriod)
-                dataViewPeriod = mlContext.Data.LoadFromTextFile(periodPath, optionsPeriod);
-            else
-                dataViewPeriod = mlContext.Data.LoadFromTextFile(commaPath, optionsPeriod);
-
-            if(useCorrectComma)
-                dataViewComma = mlContext.Data.LoadFromTextFile(commaPath, optionsComma);
-            else
-                dataViewComma = mlContext.Data.LoadFromTextFile(periodPath, optionsComma);
-
-            VBuffer<Single> featuresPeriod = default;
-            VBuffer<Single> featuresComma = default;
-
-            using (var cursorPeriod = dataViewPeriod.GetRowCursor(dataViewPeriod.Schema))
-            using(var cursorComma = dataViewComma.GetRowCursor(dataViewComma.Schema))
+            for (int j = 0; j < 2; j++)
             {
-                var delegatePeriod = cursorPeriod.GetGetter<VBuffer<Single>>(dataViewPeriod.Schema["Features"]);
-                var delegateComma = cursorComma.GetGetter<VBuffer<Single>>(dataViewPeriod.Schema["Features"]);
-                while (cursorPeriod.MoveNext() && cursorComma.MoveNext())
+                // Run various times inside the same test, to also test that TextLoader is only creating 1
+                // Custom instance of ValueCreatorCache
+
+                IDataView dataViewPeriod;
+                IDataView dataViewComma;
+
+                if (useCorrectPeriod)
+                    dataViewPeriod = mlContext.Data.LoadFromTextFile(periodPath, optionsPeriod);
+                else
+                    dataViewPeriod = mlContext.Data.LoadFromTextFile(commaPath, optionsPeriod);
+
+                if (useCorrectComma)
+                    dataViewComma = mlContext.Data.LoadFromTextFile(commaPath, optionsComma);
+                else
+                    dataViewComma = mlContext.Data.LoadFromTextFile(periodPath, optionsComma);
+
+                VBuffer<Single> featuresPeriod = default;
+                VBuffer<Single> featuresComma = default;
+
+
+                using (var cursorPeriod = dataViewPeriod.GetRowCursor(dataViewPeriod.Schema))
+                using (var cursorComma = dataViewComma.GetRowCursor(dataViewComma.Schema))
                 {
-                    delegatePeriod(ref featuresPeriod);
-                    delegateComma(ref featuresComma);
-
-                    var featuresPeriodArray = featuresPeriod.GetValues().ToArray();
-                    var featuresCommaArray = featuresComma.GetValues().ToArray();
-                    Assert.Equal(featuresPeriodArray.Length, featuresCommaArray.Length);
-
-                    for(int i = 0; i < featuresPeriodArray.Length; i++)
+                    var delegatePeriod = cursorPeriod.GetGetter<VBuffer<Single>>(dataViewPeriod.Schema["Features"]);
+                    var delegateComma = cursorComma.GetGetter<VBuffer<Single>>(dataViewPeriod.Schema["Features"]);
+                    while (cursorPeriod.MoveNext() && cursorComma.MoveNext())
                     {
-                        if(useCorrectPeriod && useCorrectComma)
+                        delegatePeriod(ref featuresPeriod);
+                        delegateComma(ref featuresComma);
+
+                        var featuresPeriodArray = featuresPeriod.GetValues().ToArray();
+                        var featuresCommaArray = featuresComma.GetValues().ToArray();
+                        Assert.Equal(featuresPeriodArray.Length, featuresCommaArray.Length);
+
+                        for (int i = 0; i < featuresPeriodArray.Length; i++)
                         {
-                            // Check that none of the two files loadad NaNs
-                            // As both of them should have been loaded correctly
-                            Assert.Equal(featuresPeriodArray[i], featuresCommaArray[i]);
-                            Assert.NotEqual(Single.NaN, featuresPeriodArray[i]);
-                        }
-                        else if (!useCorrectPeriod && !useCorrectComma)
-                        {
-                            // Check that everything was loaded as NaN
-                            // Because the wrong decimal marker was used for both loaders
-                            Assert.Equal(featuresPeriodArray[i], featuresCommaArray[i]);
-                            Assert.Equal(Single.NaN, featuresPeriodArray[i]);
-                        }
-                        else if(!useCorrectPeriod && useCorrectComma)
-                        {
-                            // Check that only the file with commas was loaded correctly
-                            Assert.Equal(Single.NaN, featuresPeriodArray[i]);
-                            Assert.NotEqual(Single.NaN, featuresCommaArray[i]);
-                        }
-                        else
-                        {
-                            // Check that only the file with periods was loaded correctly
-                            Assert.NotEqual(Single.NaN, featuresPeriodArray[i]);
-                            Assert.Equal(Single.NaN, featuresCommaArray[i]);
+                            if (useCorrectPeriod && useCorrectComma)
+                            {
+                                // Check that none of the two files loadad NaNs
+                                // As both of them should have been loaded correctly
+                                Assert.Equal(featuresPeriodArray[i], featuresCommaArray[i]);
+                                Assert.NotEqual(Single.NaN, featuresPeriodArray[i]);
+                            }
+                            else if (!useCorrectPeriod && !useCorrectComma)
+                            {
+                                // Check that everything was loaded as NaN
+                                // Because the wrong decimal marker was used for both loaders
+                                Assert.Equal(featuresPeriodArray[i], featuresCommaArray[i]);
+                                Assert.Equal(Single.NaN, featuresPeriodArray[i]);
+                            }
+                            else if (!useCorrectPeriod && useCorrectComma)
+                            {
+                                // Check that only the file with commas was loaded correctly
+                                Assert.Equal(Single.NaN, featuresPeriodArray[i]);
+                                Assert.NotEqual(Single.NaN, featuresCommaArray[i]);
+                            }
+                            else
+                            {
+                                // Check that only the file with periods was loaded correctly
+                                Assert.NotEqual(Single.NaN, featuresPeriodArray[i]);
+                                Assert.Equal(Single.NaN, featuresCommaArray[i]);
+                            }
                         }
                     }
                 }
+
+                // Check how many custom instances there are of TextLoader.ValueCreatorCache
+                var vccType = typeof(TextLoader).GetNestedType("ValueCreatorCache", BindingFlags.NonPublic | BindingFlags.Static);
+                var customInstancesInfo = vccType.GetField("_customInstances", BindingFlags.NonPublic | BindingFlags.Static);
+                var customInstancesValue = customInstancesInfo.GetValue(null);
+                var customInstancesCount = (int)customInstancesValue.GetType().GetProperty("Count").GetValue(customInstancesValue, null);
+
+                // Regardless of useCorrectPeriod and useCorrectComma
+                // Since we always created a TextLoader with Comma as DecimalMarker
+                // There should always be 1, and only 1, custom instance of ValueCreatorCache
+                // Even after running multiple times the loop above.
+                Assert.Equal(1, customInstancesCount);
             }
         }
 

--- a/test/Microsoft.ML.Tests/TextLoaderTests.cs
+++ b/test/Microsoft.ML.Tests/TextLoaderTests.cs
@@ -1023,20 +1023,20 @@ namespace Microsoft.ML.EntryPoints.Tests
             var optionsPeriod = new TextLoader.Options()
             {
                 Columns = new[]
-            {
+                {
                         new TextLoader.Column("Label", DataKind.UInt32, 0),
                         new TextLoader.Column("Features", DataKind.Single, new[] { new TextLoader.Range(1, 4) })
-                    },
+                },
                 DecimalMarker = '.'
             };
 
             var optionsComma = new TextLoader.Options()
             {
                 Columns = new[]
-                        {
+                {
                         new TextLoader.Column("Label", DataKind.UInt32, 0),
                         new TextLoader.Column("Features", DataKind.Single, new[] { new TextLoader.Range(1, 4) })
-                    },
+                },
                 DecimalMarker = ','
             };
 

--- a/test/Microsoft.ML.Tests/TextLoaderTests.cs
+++ b/test/Microsoft.ML.Tests/TextLoaderTests.cs
@@ -1120,7 +1120,7 @@ namespace Microsoft.ML.EntryPoints.Tests
                 // There should always be 1, and only 1, custom instance of ValueCreatorCache, corresponding to the comma option
                 // Even after running multiple times the loop above.
                 Assert.Equal(1, customInstancesCount);
-                Assert.True((bool)customInstancesContainsMethod.Invoke(customInstancesObject, new[] { new DoubleParser.Options(',') }));
+                Assert.True((bool)customInstancesContainsMethod.Invoke(customInstancesObject, new[] { (object) DoubleParser.OptionFlags.UseCommaAsDecimalMarker }));
             }
         }
 


### PR DESCRIPTION
As mentioned on https://github.com/dotnet/machinelearning/pull/5145#issuecomment-632255971 , PR #5145 opened the possibility of an issue to occur when running, _at the same time_, different cursors coming from different `TextLoaders `with different `DecimalMarkers`, as race conditions could occur. Although [we originally agreed](https://github.com/dotnet/machinelearning/pull/5145#issuecomment-632467994) to accept that fringe scenario, this PR fixes that problem, and adds a test for that scenario.

This PR also addresses the general problem, that if we add new options to `TextLoader `that need to affect how we parse Single/Doubles, then there was no direct/thread-safe way to make these options affect how `DoubleParser `works... For example, issue #4132 would require adding a new `TextLoader.Option` "impute" that needs to affect how `DoubleParser `works. Other case would be the offline suggestion of also adding a `ThousandsMarker` option to be able to parse `10,332.05` or `10.332,05` into `10332.05` depending on that option.

### General explanation of the PR
Without this PR the behavior was that `TextLoader.Parser` would use the singleton `TextLoader.ValueCreatorCache.Instance` to get the delegates to parse the fields loaded from a file. In turn, the `ValueCreatorCache` singleton would have gotten those delegates from the singleton `Conversion.Instance`, whose methods for parsing text to single/doubles would, then, call static methods in `DoubleParser`.

**I am assuming that the only reason to have both `ValueCreatorCache` and `Conversion `follow the singleton pattern was for performance reasons, so that they didn't have to create the delegates every time somewhere in the code their instances were needed**

With this PR:
1. I created a new `DoubleParser.OptionFlags` enum that is used by `TextLoader`, and gets propagated through `ValueCreatorCache `up to `Conversion `in order to call the static `DoubleParser `methods with the correct options.
2. I added code to `ValueCreatorCache `and `Conversion `to let them create other instances besides its default instance. Most of the codebase would still use their default instance, so this PR doesn't affect performance or behavior there. It's only in `TextLoader`, and only in the case when using custom options for `DoubleParser`, that a custom instance of `ValueCreatorCache `and `Conversion `gets created. So then performance would only be somewhat affected when creating those instances for that particular case. To have minimum impact in performance, I also added a `ConcurrentDictionary `to hold the `_customInstances `of `ValueCreatorCache `(i.e. those which were created using non-default `DoubleParser.OptionFlags`)... this way, when using custom options, the custom instance of `ValueCreatorCache `and Conversion would only be created once, and would be reused afterwards.