### PR TITLE
Fixed onnx export for key types other than uint

### DIFF
--- a/src/Microsoft.ML.Data/Transforms/Hashing.cs
+++ b/src/Microsoft.ML.Data/Transforms/Hashing.cs
@@ -1388,7 +1388,7 @@ namespace Microsoft.ML.Transforms
                 // Since these numeric types are not supported by Onnxruntime, we cast them to UInt32.
                 if (srcType == NumberDataViewType.UInt16 || srcType == NumberDataViewType.Int16 ||
                     srcType == NumberDataViewType.SByte || srcType == NumberDataViewType.Byte ||
-                    srcType == BooleanDataViewType.Instance)
+                    srcType == BooleanDataViewType.Instance || srcType is KeyDataViewType)
                 {
                     castOutput = ctx.AddIntermediateVariable(NumberDataViewType.UInt32, "CastOutput", true);
                     castNode = ctx.CreateNode("Cast", srcVariable, castOutput, ctx.GetNodeName(opType), "");

--- a/src/Microsoft.ML.Data/Transforms/Hashing.cs
+++ b/src/Microsoft.ML.Data/Transforms/Hashing.cs
@@ -1359,7 +1359,7 @@ namespace Microsoft.ML.Transforms
                 OnnxNode murmurNode;
                 OnnxNode isZeroNode;
 
-                var srcType = _srcTypes[iinfo].GetItemType();
+                var srcType = _srcTypes[iinfo].GetItemType().RawType;
                 if (_parent._columns[iinfo].Combine)
                     return false;
 
@@ -1386,9 +1386,9 @@ namespace Microsoft.ML.Transforms
                 }
 
                 // Since these numeric types are not supported by Onnxruntime, we cast them to UInt32.
-                if (srcType == NumberDataViewType.UInt16 || srcType == NumberDataViewType.Int16 ||
-                    srcType == NumberDataViewType.SByte || srcType == NumberDataViewType.Byte ||
-                    srcType == BooleanDataViewType.Instance || srcType is KeyDataViewType)
+                if (srcType == typeof(ushort) || srcType == typeof(short) ||
+                    srcType == typeof(sbyte) || srcType == typeof(byte) ||
+                    srcType == typeof(bool))
                 {
                     castOutput = ctx.AddIntermediateVariable(NumberDataViewType.UInt32, "CastOutput", true);
                     castNode = ctx.CreateNode("Cast", srcVariable, castOutput, ctx.GetNodeName(opType), "");

--- a/src/Microsoft.ML.OnnxTransformer/OnnxTransform.cs
+++ b/src/Microsoft.ML.OnnxTransformer/OnnxTransform.cs
@@ -389,13 +389,16 @@ namespace Microsoft.ML.Transforms.Onnx
                     if (vectorType != null && vectorType.Size == 0)
                         throw Host.Except($"Variable length input columns not supported");
 
-                    if (type.GetItemType() != inputNodeInfo.DataViewType.GetItemType())
+                    var itemType = type.GetItemType();
+                    var nodeItemType = inputNodeInfo.DataViewType.GetItemType();
+                    if (itemType != nodeItemType)
                     {
                         // If the ONNX model input node expects a type that mismatches with the type of the input IDataView column that is provided
                         // then throw an exception.
                         // This is done except in the case where the ONNX model input node expects a UInt32 but the input column is actually KeyDataViewType
                         // This is done to support a corner case originated in NimbusML. For more info, see: https://github.com/microsoft/NimbusML/issues/426
-                        if (!(type.GetItemType() is KeyDataViewType && type.GetItemType().RawType == inputNodeInfo.DataViewType.GetItemType().RawType))
+                        var isKeyType = itemType is KeyDataViewType;
+                        if (!isKeyType || itemType.RawType != nodeItemType.RawType)
                             throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", _parent.Inputs[i], inputNodeInfo.DataViewType.GetItemType().ToString(), type.ToString());
                     }
 

--- a/src/Microsoft.ML.OnnxTransformer/OnnxTransform.cs
+++ b/src/Microsoft.ML.OnnxTransformer/OnnxTransform.cs
@@ -395,7 +395,7 @@ namespace Microsoft.ML.Transforms.Onnx
                         // then throw an exception.
                         // This is done except in the case where the ONNX model input node expects a UInt32 but the input column is actually KeyDataViewType
                         // This is done to support a corner case originated in NimbusML. For more info, see: https://github.com/microsoft/NimbusML/issues/426
-                        if (!(type.GetItemType() is KeyDataViewType && inputNodeInfo.DataViewType.GetItemType().RawType == typeof(UInt32)))
+                        if (!(type.GetItemType() is KeyDataViewType && type.GetItemType().RawType == inputNodeInfo.DataViewType.GetItemType().RawType))
                             throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", _parent.Inputs[i], inputNodeInfo.DataViewType.GetItemType().ToString(), type.ToString());
                     }
 

--- a/test/Microsoft.ML.Tests/OnnxConversionTest.cs
+++ b/test/Microsoft.ML.Tests/OnnxConversionTest.cs
@@ -1202,7 +1202,7 @@ namespace Microsoft.ML.Tests
         [Theory]
         [CombinatorialData]
         public void MurmurHashKeyTest(
-            [CombinatorialValues(/*DataKind.Byte, DataKind.UInt16, */DataKind.UInt32/*, DataKind.UInt64*/)]DataKind keyType)
+            [CombinatorialValues(DataKind.Byte, DataKind.UInt16, DataKind.UInt32, DataKind.UInt64)]DataKind keyType)
         {
             var dataFile = DeleteOutputPath("KeysToOnnx.txt");
             File.WriteAllLines(dataFile,


### PR DESCRIPTION
In PR #5152 @yaeldekel modified the test for onnx export for key types and disabled the test for types other than uint because of a bug in onnx export for those other types. This PR takes the test from @yaeldekel's PR and adds the fix for the onnx export bug.  