### PR TITLE
Fixed OnnxTransformer output column mapping.

### DIFF
--- a/src/Microsoft.ML.OnnxTransformer/OnnxTransform.cs
+++ b/src/Microsoft.ML.OnnxTransformer/OnnxTransform.cs
@@ -342,10 +342,10 @@ namespace Microsoft.ML.Transforms.Onnx
 
         /// <summary>
         /// In the case that the ML.Net user wants a subset of columns or lists the columns in a different order then specified in the ONNX model,
-        /// we need to map from the ONNX model index to the ML.Net column index. This method does that mapping for us.
+        /// we need to map from the ML.Net dataview column index to the ONNX model output index. This method does that mapping.
         /// </summary>
         /// <param name="iinfo">The index of the ML.Net column requested.</param>
-        /// <returns>The index o fht e</returns>
+        /// <returns>The index of ONNX output.</returns>
         internal int MapDataViewColumnToOnnxOutputTensor(int iinfo)
         {
             return Model.ModelInfo.OutputNames.IndexOf(Outputs[iinfo]);

--- a/test/Microsoft.ML.OnnxTransformerTest/OnnxTransformTests.cs
+++ b/test/Microsoft.ML.OnnxTransformerTest/OnnxTransformTests.cs
@@ -336,8 +336,6 @@ namespace Microsoft.ML.Tests
         public void OnnxModelOutputDifferentOrder()
         {
             var modelFile = Path.Combine(Directory.GetCurrentDirectory(), "twoinput", "twoinput.onnx");
-            var env = new ConsoleEnvironment(seed: 1);
-            var samplevector = GetSampleArrayData();
 
             var dataView = ML.Data.LoadFromEnumerable(
                 new TestDataMulti[] {
@@ -369,27 +367,11 @@ namespace Microsoft.ML.Tests
                     Assert.Equal(30, bufferb.GetValues().ToArray().Sum());
                 }
             }
-        }
 
-        [OnnxFact]
-        public void OnnxModelOutputSubset()
-        {
-            var modelFile = Path.Combine(Directory.GetCurrentDirectory(), "twoinput", "twoinput.onnx");
-            var env = new ConsoleEnvironment(seed: 1);
-            var samplevector = GetSampleArrayData();
-
-            var dataView = ML.Data.LoadFromEnumerable(
-                new TestDataMulti[] {
-                    new TestDataMulti()
-                    {
-                        ina = new float[] {1,2,3,4,5},
-                        inb = new float[] {1,2,3,4,5}
-                    }
-                });
             // The model returns the output columns in the order outa, outb. We are doing only a subset, outb, to make sure the mapping works.
-            var onnx = ML.Transforms.ApplyOnnxModel(new[] { "outb"}, new[] { "ina", "inb" }, modelFile).Fit(dataView).Transform(dataView);
+            onnx = ML.Transforms.ApplyOnnxModel(new[] { "outb" }, new[] { "ina", "inb" }, modelFile).Fit(dataView).Transform(dataView);
 
-            var outbCol = onnx.Schema["outb"];
+            outbCol = onnx.Schema["outb"];
             using (var curs = onnx.GetRowCursor(outbCol))
             {
                 var getScoresb = curs.GetGetter<VBuffer<float>>(outbCol);

--- a/test/Microsoft.ML.OnnxTransformerTest/OnnxTransformTests.cs
+++ b/test/Microsoft.ML.OnnxTransformerTest/OnnxTransformTests.cs
@@ -333,6 +333,78 @@ namespace Microsoft.ML.Tests
         }
 
         [OnnxFact]
+        public void OnnxModelOutputDifferentOrder()
+        {
+            var modelFile = Path.Combine(Directory.GetCurrentDirectory(), "twoinput", "twoinput.onnx");
+            var env = new ConsoleEnvironment(seed: 1);
+            var samplevector = GetSampleArrayData();
+
+            var dataView = ML.Data.LoadFromEnumerable(
+                new TestDataMulti[] {
+                    new TestDataMulti()
+                    {
+                        ina = new float[] {1,2,3,4,5},
+                        inb = new float[] {1,2,3,4,5}
+                    }
+                });
+            // The model returns the output columns in the order outa, outb. We are doing the opposite here, making sure the name mapping is correct.
+            var onnx = ML.Transforms.ApplyOnnxModel(new[] { "outb", "outa" }, new[] { "ina", "inb" }, modelFile).Fit(dataView).Transform(dataView);
+
+            var outaCol = onnx.Schema["outa"];
+            var outbCol = onnx.Schema["outb"];
+            using (var curs = onnx.GetRowCursor(outaCol, onnx.Schema["outb"]))
+            {
+                var getScoresa = curs.GetGetter<VBuffer<float>>(outaCol);
+                var getScoresb = curs.GetGetter<VBuffer<float>>(outbCol);
+                var buffera = default(VBuffer<float>);
+                var bufferb = default(VBuffer<float>);
+
+                while (curs.MoveNext())
+                {
+                    getScoresa(ref buffera);
+                    getScoresb(ref bufferb);
+                    Assert.Equal(5, buffera.Length);
+                    Assert.Equal(5, bufferb.Length);
+                    Assert.Equal(0, buffera.GetValues().ToArray().Sum());
+                    Assert.Equal(30, bufferb.GetValues().ToArray().Sum());
+                }
+            }
+        }
+
+        [OnnxFact]
+        public void OnnxModelOutputSubset()
+        {
+            var modelFile = Path.Combine(Directory.GetCurrentDirectory(), "twoinput", "twoinput.onnx");
+            var env = new ConsoleEnvironment(seed: 1);
+            var samplevector = GetSampleArrayData();
+
+            var dataView = ML.Data.LoadFromEnumerable(
+                new TestDataMulti[] {
+                    new TestDataMulti()
+                    {
+                        ina = new float[] {1,2,3,4,5},
+                        inb = new float[] {1,2,3,4,5}
+                    }
+                });
+            // The model returns the output columns in the order outa, outb. We are doing only a subset, outb, to make sure the mapping works.
+            var onnx = ML.Transforms.ApplyOnnxModel(new[] { "outb"}, new[] { "ina", "inb" }, modelFile).Fit(dataView).Transform(dataView);
+
+            var outbCol = onnx.Schema["outb"];
+            using (var curs = onnx.GetRowCursor(outbCol))
+            {
+                var getScoresb = curs.GetGetter<VBuffer<float>>(outbCol);
+                var bufferb = default(VBuffer<float>);
+
+                while (curs.MoveNext())
+                {
+                    getScoresb(ref bufferb);
+                    Assert.Equal(5, bufferb.Length);
+                    Assert.Equal(30, bufferb.GetValues().ToArray().Sum());
+                }
+            }
+        }
+
+        [OnnxFact]
         public void TestUnknownDimensions()
         {
             // model contains -1 in input and output shape dimensions


### PR DESCRIPTION
Our OnnxTransformer has overrides that let you specify a subset of output columns, all the output columns, or let it figure it out from the onnx model. The issue was that if you manually specified either a subset of the columns, or all the columns, and did it in an order different then the onnx model, our transformer would not do the mapping correctly and it would try and access the wrong column. This usually resulted in an error that the types didn't match, but when types matched it just returned wrong data.

This PR fixes that issue by doing the correct mapping regardless of the order they are provided in.