### PR TITLE
Fixed version format of built packages

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -71,9 +71,8 @@
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <IncludeBuildNumberInPackageVersion Condition="'$(IncludeBuildNumberInPackageVersion)' == '' and '$(StabilizePackageVersion)' != 'true'">true</IncludeBuildNumberInPackageVersion>
 
-    <VersionSuffix></VersionSuffix>
-    <VersionSuffix Condition="'$(StabilizePackageVersion)' != 'true'">$(PreReleaseLabel)</VersionSuffix>
-    <VersionSuffix Condition="'$(IncludeBuildNumberInPackageVersion)' == 'true'">$(VersionSuffix)-$(BuildNumberMajor)-$(BuildNumberMinor)</VersionSuffix>
+    <VersionSuffix Condition="'$(IncludeBuildNumberInPackageVersion)' == 'true'">$(BuildNumberMajor)-$(BuildNumberMinor)</VersionSuffix>
+    <NoPackageAnalysis>true</NoPackageAnalysis>
   </PropertyGroup>
 
   <!-- SourceLink properties used by dotnet/buildtools - need to be set before importing $(ToolsDir)versioning.props -->

--- a/build/BranchInfo.props
+++ b/build/BranchInfo.props
@@ -31,12 +31,10 @@
     <MajorVersion>1</MajorVersion>
     <MinorVersion>5</MinorVersion>
     <PatchVersion>1</PatchVersion>
-    <PreReleaseLabel></PreReleaseLabel>
   </PropertyGroup>
   <PropertyGroup Condition="'$(IsStableProject)' != 'true'">
     <MajorVersion>0</MajorVersion>
     <MinorVersion>17</MinorVersion>
     <PatchVersion>1</PatchVersion>
-    <PreReleaseLabel></PreReleaseLabel>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Since we are no longer using the pre-release tag, our package versions at the daily build have had an improper version string with two hyphens in a row. This PR fixes that issue. 
Our version format is not SemVer 2.0.0 compatible because according SemVer v2, the build metadata has to be separated by +. However this causes build warnings and attempting to fix the warnings causes the msbuild Pack task to not include build number in the package name. 
That issue has to be resolved separately. 