### PR TITLE
fixed Microsoft.MLFeaturizer version in nuget and csproj

### DIFF
--- a/pkg/Microsoft.ML.Featurizers/Microsoft.ML.Featurizers.nupkgproj
+++ b/pkg/Microsoft.ML.Featurizers/Microsoft.ML.Featurizers.nupkgproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <ProjectReference Include="../Microsoft.ML/Microsoft.ML.nupkgproj" />
 
-    <PackageReference Include="Microsoft.MLFeaturizers" Version="0.3.5" />
+    <PackageReference Include="Microsoft.MLFeaturizers" Version="0.4.1" />
   </ItemGroup>
   
 </Project>

--- a/src/Microsoft.ML.Featurizers/Microsoft.ML.Featurizers.csproj
+++ b/src/Microsoft.ML.Featurizers/Microsoft.ML.Featurizers.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.MLFeaturizers" Version="0.4.0-preview.2" />
+    <PackageReference Include="Microsoft.MLFeaturizers" Version="0.4.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes issue #5222 

When I updated the Microsoft.MLFeaturizers version in the csproj file, I didn't do it in the .nuget package. This fixes the version discrepancy and updates them from the preview they were on to the latest full release.