### PR TITLE
add random seed when create random temp folder to avoid conflict

### DIFF
--- a/src/Microsoft.ML.Core/Data/Repository.cs
+++ b/src/Microsoft.ML.Core/Data/Repository.cs
@@ -118,7 +118,7 @@ namespace Microsoft.ML
 
         private static string GetShortTempDir()
         {
-            var rnd = RandomUtils.Create(Environment.TickCount);
+            var rnd = RandomUtils.Create(Guid.NewGuid().GetHashCode());
             string path;
             do
             {

--- a/src/Microsoft.ML.Core/Data/Repository.cs
+++ b/src/Microsoft.ML.Core/Data/Repository.cs
@@ -118,7 +118,7 @@ namespace Microsoft.ML
 
         private static string GetShortTempDir()
         {
-            var rnd = RandomUtils.Create();
+            var rnd = RandomUtils.Create(Environment.TickCount);
             string path;
             do
             {

--- a/src/Microsoft.ML.Core/Data/Repository.cs
+++ b/src/Microsoft.ML.Core/Data/Repository.cs
@@ -118,15 +118,8 @@ namespace Microsoft.ML
 
         private static string GetShortTempDir()
         {
-            var rnd = RandomUtils.Create(Guid.NewGuid().GetHashCode());
-            string path;
-            do
-            {
-                path = Path.Combine(Path.GetTempPath(), "TLC_" + rnd.Next().ToString("X"));
-                path = Path.GetFullPath(path);
-                Directory.CreateDirectory(path);
-            }
-            while (!EnsureDirectory(path));
+            var path = Path.Combine(Path.GetFullPath(Path.GetTempPath()), "ml_dotnet");
+            Directory.CreateDirectory(path);
             return path;
         }
 

--- a/src/Microsoft.ML.Core/Data/Repository.cs
+++ b/src/Microsoft.ML.Core/Data/Repository.cs
@@ -118,7 +118,7 @@ namespace Microsoft.ML
 
         private static string GetShortTempDir()
         {
-            var path = Path.Combine(Path.GetFullPath(Path.GetTempPath()), "ml_dotnet");
+            var path = Path.Combine(Path.GetFullPath(Path.GetTempPath()), "ml_dotnet", Path.GetRandomFileName());
             Directory.CreateDirectory(path);
             return path;
         }

--- a/src/Microsoft.ML.Core/Data/Repository.cs
+++ b/src/Microsoft.ML.Core/Data/Repository.cs
@@ -123,20 +123,6 @@ namespace Microsoft.ML
             return path;
         }
 
-        private static bool EnsureDirectory(string path)
-        {
-            path = Path.GetFullPath(Path.Combine(path, ".lock"));
-            try
-            {
-                using (var stream = new FileStream(path, FileMode.CreateNew))
-                    return true;
-            }
-            catch
-            {
-                return false;
-            }
-        }
-
         ~Repository()
         {
             if (!Disposed)


### PR DESCRIPTION
address issue: https://github.com/dotnet/machinelearning/issues/5210

We are create random temp folder during model load, sometimes there are file name conflict when load models in multi-threading as the random temp folder name is not seeded.

