### PR TITLE
Fix sample tests results preview

### DIFF
--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/Calibrators/FixedPlatt.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/Calibrators/FixedPlatt.cs
@@ -29,27 +29,27 @@ namespace Samples.Dynamic.Trainers.BinaryClassification.Calibrators
                 .AveragedPerceptron();
 
             // Fit the pipeline, and get a transformer that knows how to score new
-            // data.  
+            // data.
             var transformer = pipeline.Fit(trainTestData.TrainSet);
             // Fit this pipeline to the training data.
             // Let's score the new data. The score will give us a numerical
             // estimation of the chance that the particular sample bears positive
-            // sentiment. This estimate is relative to the numbers obtained. 
+            // sentiment. This estimate is relative to the numbers obtained.
             var scoredData = transformer.Transform(trainTestData.TestSet);
             var outScores = mlContext.Data
                 .CreateEnumerable<ScoreValue>(scoredData, reuseRowObject: false);
 
             PrintScore(outScores, 5);
             // Preview of scoredDataPreview.RowView
-            // Score   4.18144
-            // Score  -14.10248
-            // Score   2.731951
-            // Score  -2.554229
-            // Score   5.36571
+            // Score  -0.09044361
+            // Score  -9.105377
+            // Score  -11.049
+            // Score  -3.061928
+            // Score  -6.375817
 
             // Let's train a calibrator estimator on this scored dataset. The
             // trained calibrator estimator produces a transformer that can
-            // transform the scored data by adding a new column names "Probability". 
+            // transform the scored data by adding a new column names "Probability".
             var calibratorEstimator = mlContext.BinaryClassification.Calibrators
                 .Platt(slope: -1f, offset: -0.05f);
 
@@ -59,18 +59,18 @@ namespace Samples.Dynamic.Trainers.BinaryClassification.Calibrators
             // new column names "Probability". This column is a calibrated version
             // of the "Score" column, meaning its values are a valid probability
             // value in the [0, 1] interval representing the chance that the
-            // respective sample bears positive sentiment. 
+            // respective sample bears positive sentiment.
             var finalData = calibratorTransformer.Transform(scoredData);
             var outScoresAndProbabilities = mlContext.Data
                 .CreateEnumerable<ScoreAndProbabilityValue>(finalData,
                 reuseRowObject: false);
 
             PrintScoreAndProbability(outScoresAndProbabilities, 5);
-            // Score   4.18144   Probability 0.9856767
-            // Score  -14.10248  Probability 7.890148E-07
-            // Score   2.731951  Probability 0.9416927
-            // Score  -2.554229  Probability 0.07556222
-            // Score   5.36571   Probability 0.9955735
+            // Score -0.09044361  Probability 0.4898905
+            // Score -9.105377    Probability 0.0001167479
+            // Score -11.049      Probability 1.671815E-05
+            // Score -3.061928    Probability 0.04688989
+            // Score -6.375817    Probability 0.001786307
         }
 
         private static void PrintScore(IEnumerable<ScoreValue> values, int numRows)
@@ -84,7 +84,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification.Calibrators
 
         {
             foreach (var value in values.Take(numRows))
-                Console.WriteLine("{0, -10} {1, -10} {2, -10} {3, -10}", "Score", 
+                Console.WriteLine("{0, -10} {1, -10} {2, -10} {3, -10}", "Score",
                     value.Score, "Probability", value.Probability);
         }
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/Calibrators/Isotonic.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/Calibrators/Isotonic.cs
@@ -29,27 +29,27 @@ namespace Samples.Dynamic.Trainers.BinaryClassification.Calibrators
                 .AveragedPerceptron();
 
             // Fit the pipeline, and get a transformer that knows how to score new
-            // data.  
+            // data.
             var transformer = pipeline.Fit(trainTestData.TrainSet);
             // Fit this pipeline to the training data.
             // Let's score the new data. The score will give us a numerical
             // estimation of the chance that the particular sample bears positive
-            // sentiment. This estimate is relative to the numbers obtained. 
+            // sentiment. This estimate is relative to the numbers obtained.
             var scoredData = transformer.Transform(trainTestData.TestSet);
             var outScores = mlContext.Data
                 .CreateEnumerable<ScoreValue>(scoredData, reuseRowObject: false);
 
             PrintScore(outScores, 5);
             // Preview of scoredDataPreview.RowView
-            // Score   4.18144
-            // Score  -14.10248
-            // Score   2.731951
-            // Score  -2.554229
-            // Score   5.36571
+            // Score  -0.09044361
+            // Score  -9.105377
+            // Score  -11.049
+            // Score  -3.061928
+            // Score  -6.375817
 
             // Let's train a calibrator estimator on this scored dataset. The
             // trained calibrator estimator produces a transformer that can
-            // transform the scored data by adding a new column names "Probability". 
+            // transform the scored data by adding a new column names "Probability".
             var calibratorEstimator = mlContext.BinaryClassification.Calibrators
                 .Isotonic();
 
@@ -59,18 +59,18 @@ namespace Samples.Dynamic.Trainers.BinaryClassification.Calibrators
             // new column names "Probability". This column is a calibrated version
             // of the "Score" column, meaning its values are a valid probability
             // value in the [0, 1] interval representing the chance that the
-            // respective sample bears positive sentiment. 
+            // respective sample bears positive sentiment.
             var finalData = calibratorTransformer.Transform(scoredData);
             var outScoresAndProbabilities = mlContext.Data
                 .CreateEnumerable<ScoreAndProbabilityValue>(finalData,
                 reuseRowObject: false);
 
             PrintScoreAndProbability(outScoresAndProbabilities, 5);
-            // Score   4.18144   Probability 0.8
-            // Score  -14.10248  Probability 1E-15
-            // Score   2.731951  Probability 0.7370371
-            // Score  -2.554229  Probability 0.2063954
-            // Score   5.36571   Probability 0.8958333
+            // Score -0.09044361  Probability 0.4473684
+            // Score -9.105377    Probability 0.02122641
+            // Score -11.049      Probability 0.005328597
+            // Score -3.061928    Probability 0.2041801
+            // Score -6.375817    Probability 0.05836574
         }
 
         private static void PrintScore(IEnumerable<ScoreValue> values, int numRows)

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/Calibrators/Naive.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/Calibrators/Naive.cs
@@ -29,27 +29,27 @@ namespace Samples.Dynamic.Trainers.BinaryClassification.Calibrators
                 .AveragedPerceptron();
 
             // Fit the pipeline, and get a transformer that knows how to score new
-            // data.  
+            // data.
             var transformer = pipeline.Fit(trainTestData.TrainSet);
             // Fit this pipeline to the training data.
             // Let's score the new data. The score will give us a numerical
             // estimation of the chance that the particular sample bears positive
-            // sentiment. This estimate is relative to the numbers obtained. 
+            // sentiment. This estimate is relative to the numbers obtained.
             var scoredData = transformer.Transform(trainTestData.TestSet);
             var outScores = mlContext.Data
                 .CreateEnumerable<ScoreValue>(scoredData, reuseRowObject: false);
 
             PrintScore(outScores, 5);
             // Preview of scoredDataPreview.RowView
-            // Score   4.18144
-            // Score  -14.10248
-            // Score   2.731951
-            // Score  -2.554229
-            // Score   5.36571
+            // Score  -0.09044361
+            // Score  -9.105377
+            // Score  -11.049
+            // Score  -3.061928
+            // Score  -6.375817
 
             // Let's train a calibrator estimator on this scored dataset. The
             // trained calibrator estimator produces a transformer that can
-            // transform the scored data by adding a new column names "Probability". 
+            // transform the scored data by adding a new column names "Probability".
             var calibratorEstimator = mlContext.BinaryClassification.Calibrators
                 .Naive();
 
@@ -59,18 +59,18 @@ namespace Samples.Dynamic.Trainers.BinaryClassification.Calibrators
             // new column names "Probability". This column is a calibrated version
             // of the "Score" column, meaning its values are a valid probability
             // value in the [0, 1] interval representing the chance that the
-            // respective sample bears positive sentiment. 
+            // respective sample bears positive sentiment.
             var finalData = calibratorTransformer.Transform(scoredData);
             var outScoresAndProbabilities = mlContext.Data
                 .CreateEnumerable<ScoreAndProbabilityValue>(finalData,
                 reuseRowObject: false);
 
             PrintScoreAndProbability(outScoresAndProbabilities, 5);
-            // Score   4.18144   Probability 0.775
-            // Score  -14.10248  Probability 0.01923077
-            // Score   2.731951  Probability 0.7738096
-            // Score  -2.554229  Probability 0.2011494
-            // Score   5.36571   Probability 0.9117647
+            // Score -0.09044361  Probability 0.4705882
+            // Score -9.105377    Probability 0.01574803
+            // Score -11.049      Probability 0
+            // Score -3.061928    Probability 0.2539683
+            // Score -6.375817    Probability 0.06766918
         }
 
         private static void PrintScore(IEnumerable<ScoreValue> values, int numRows)

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/Calibrators/Platt.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/Calibrators/Platt.cs
@@ -29,27 +29,27 @@ namespace Samples.Dynamic.Trainers.BinaryClassification.Calibrators
                 .AveragedPerceptron();
 
             // Fit the pipeline, and get a transformer that knows how to score new
-            // data.  
+            // data.
             var transformer = pipeline.Fit(trainTestData.TrainSet);
             // Fit this pipeline to the training data.
             // Let's score the new data. The score will give us a numerical
             // estimation of the chance that the particular sample bears positive
-            // sentiment. This estimate is relative to the numbers obtained. 
+            // sentiment. This estimate is relative to the numbers obtained.
             var scoredData = transformer.Transform(trainTestData.TestSet);
             var outScores = mlContext.Data
                 .CreateEnumerable<ScoreValue>(scoredData, reuseRowObject: false);
 
             PrintScore(outScores, 5);
             // Preview of scoredDataPreview.RowView
-            // Score   4.18144
-            // Score  -14.10248
-            // Score   2.731951
-            // Score  -2.554229
-            // Score   5.36571
+            // Score  -0.09044361
+            // Score  -9.105377
+            // Score  -11.049
+            // Score  -3.061928
+            // Score  -6.375817
 
             // Let's train a calibrator estimator on this scored dataset. The
             // trained calibrator estimator produces a transformer that can
-            // transform the scored data by adding a new column names "Probability". 
+            // transform the scored data by adding a new column names "Probability".
             var calibratorEstimator = mlContext.BinaryClassification.Calibrators
                 .Platt();
 
@@ -59,18 +59,18 @@ namespace Samples.Dynamic.Trainers.BinaryClassification.Calibrators
             // new column names "Probability". This column is a calibrated version
             // of the "Score" column, meaning its values are a valid probability
             // value in the [0, 1] interval representing the chance that the
-            // respective sample bears positive sentiment. 
+            // respective sample bears positive sentiment.
             var finalData = calibratorTransformer.Transform(scoredData);
             var outScoresAndProbabilities = mlContext.Data
                 .CreateEnumerable<ScoreAndProbabilityValue>(finalData,
                 reuseRowObject: false);
 
             PrintScoreAndProbability(outScoresAndProbabilities, 5);
-            // Score   4.18144   Probability 0.8511352
-            // Score  -14.10248  Probability 0.001633563
-            // Score   2.731951  Probability 0.7496456
-            // Score  -2.554229  Probability 0.2206048
-            // Score   5.36571   Probability 0.9065308
+            // Score -0.09044361  Probability 0.423026
+            // Score -9.105377    Probability 0.02139676
+            // Score -11.049      Probability 0.01014891
+            // Score -3.061928    Probability 0.1872233
+            // Score -6.375817    Probability 0.05956031
         }
 
         private static void PrintScore(IEnumerable<ScoreValue> values, int numRows)


### PR DESCRIPTION
Since LoadFeaturizedAdultDataset() has been modified by https://github.com/dotnet/machinelearning/commit/9244e683d85f1c1c16eef4fcd2a5af42d56ac048#diff-eb95ea0c54ebcf8d695d8d73d5849b0cR138, any other sample tests that references LoadFeaturizedAdultDataset() will result in a different score. Change score preview to match.
Also remove unnecessary spaces.
