### PR TITLE
Added cross entropy and learning rate scheduler support to validation training, simplified metric reporting

### DIFF
--- a/src/Microsoft.ML.Vision/ImageClassificationTrainer.cs
+++ b/src/Microsoft.ML.Vision/ImageClassificationTrainer.cs
@@ -952,7 +952,8 @@ namespace Microsoft.ML.Vision
                 if (validationNeeded)
                 {
                     validationEvalRunner = new Runner(_session, runnerInputTensorNames.ToArray(),
-                        new[] { _evaluationStep.name, _crossEntropy.name }, new[] { _trainStep.name });
+                        runnerOutputTensorNames.Count() > 0 ? runnerOutputTensorNames.ToArray() : null,
+                        new[] { _trainStep.name });
                 }
 
                 runner = new Runner(_session, runnerInputTensorNames.ToArray(),

--- a/src/Microsoft.ML.Vision/ImageClassificationTrainer.cs
+++ b/src/Microsoft.ML.Vision/ImageClassificationTrainer.cs
@@ -948,8 +948,7 @@ namespace Microsoft.ML.Vision
                 if (validationNeeded)
                 {
                     validationEvalRunner = new Runner(_session, runnerInputTensorNames.ToArray(),
-                        runnerOutputTensorNames.Count() > 0 ? runnerOutputTensorNames.ToArray() : null,
-                        new[] { _trainStep.name });
+                        new[] { _evaluationStep.name, _crossEntropy.name }, new[] { _trainStep.name });
                 }
 
                 runner = new Runner(_session, runnerInputTensorNames.ToArray(),

--- a/src/Microsoft.ML.Vision/ImageClassificationTrainer.cs
+++ b/src/Microsoft.ML.Vision/ImageClassificationTrainer.cs
@@ -169,8 +169,12 @@ namespace Microsoft.ML.Vision
             /// </summary>
             public override string ToString()
             {
-                return $"Phase: Training, Dataset used: {DatasetUsed.ToString(),10}, Batch Processed Count: {BatchProcessedCount,3}, Learning Rate: {LearningRate,10} " +
-                    $"Epoch: {Epoch,3}, Accuracy: {Accuracy,10}, Cross-Entropy: {CrossEntropy,10}";
+                if (DatasetUsed == ImageClassificationMetrics.Dataset.Train)
+                    return $"Phase: Training, Dataset used: {DatasetUsed.ToString(),10}, Batch Processed Count: {BatchProcessedCount,3}, Learning Rate: {LearningRate,10} " +
+                        $"Epoch: {Epoch,3}, Accuracy: {Accuracy,10}, Cross-Entropy: {CrossEntropy,10}";
+                else
+                    return $"Phase: Training, Dataset used: {DatasetUsed.ToString(),10}, Batch Processed Count: {BatchProcessedCount,3}, " +
+                        $"Epoch: {Epoch,3}, Accuracy: {Accuracy,10}, Cross-Entropy: {CrossEntropy,10}";
             }
         }
 
@@ -1025,9 +1029,9 @@ namespace Microsoft.ML.Vision
 
                     // Evaluate.
                     TrainAndEvaluateClassificationLayerCore(epoch, learningRate, featureFileStartOffset,
-                        metrics, labelTensorShape, featureTensorShape, batchSize, validationSetLabelReader,
-                        validationSetFeatureReader, labelBuffer, featuresBuffer, labelBufferSizeInBytes,
-                        featureBufferSizeInBytes, featureFileRecordSize, _options.LearningRateScheduler,
+                        metrics, labelTensorShape, featureTensorShape, batchSize,
+                        validationSetLabelReader, validationSetFeatureReader, labelBuffer, featuresBuffer,
+                        labelBufferSizeInBytes, featureBufferSizeInBytes, featureFileRecordSize, null,
                         trainState, validationEvalRunner, featureBufferPtr, labelBufferPtr,
                         (outputTensors, metrics) =>
                             {

--- a/src/Microsoft.ML.Vision/ImageClassificationTrainer.cs
+++ b/src/Microsoft.ML.Vision/ImageClassificationTrainer.cs
@@ -170,7 +170,7 @@ namespace Microsoft.ML.Vision
             public override string ToString()
             {
                 if (DatasetUsed == ImageClassificationMetrics.Dataset.Train)
-                    return $"Phase: Training, Dataset used: {DatasetUsed.ToString(),10}, Batch Processed Count: {BatchProcessedCount,3}" +
+                    return $"Phase: Training, Dataset used: {DatasetUsed.ToString(),10}, Batch Processed Count: {BatchProcessedCount,3}, " +
                         $"Epoch: {Epoch,3}, Accuracy: {Accuracy,10}, Cross-Entropy: {CrossEntropy,10}, Learning Rate: {LearningRate,10}";
                 else
                     return $"Phase: Training, Dataset used: {DatasetUsed.ToString(),10}, Batch Processed Count: {BatchProcessedCount,3}, " +

--- a/src/Microsoft.ML.Vision/ImageClassificationTrainer.cs
+++ b/src/Microsoft.ML.Vision/ImageClassificationTrainer.cs
@@ -170,8 +170,8 @@ namespace Microsoft.ML.Vision
             public override string ToString()
             {
                 if (DatasetUsed == ImageClassificationMetrics.Dataset.Train)
-                    return $"Phase: Training, Dataset used: {DatasetUsed.ToString(),10}, Batch Processed Count: {BatchProcessedCount,3}, Learning Rate: {LearningRate,10} " +
-                        $"Epoch: {Epoch,3}, Accuracy: {Accuracy,10}, Cross-Entropy: {CrossEntropy,10}";
+                    return $"Phase: Training, Dataset used: {DatasetUsed.ToString(),10}, Batch Processed Count: {BatchProcessedCount,3}" +
+                        $"Epoch: {Epoch,3}, Accuracy: {Accuracy,10}, Cross-Entropy: {CrossEntropy,10}, Learning Rate: {LearningRate,10}";
                 else
                     return $"Phase: Training, Dataset used: {DatasetUsed.ToString(),10}, Batch Processed Count: {BatchProcessedCount,3}, " +
                         $"Epoch: {Epoch,3}, Accuracy: {Accuracy,10}, Cross-Entropy: {CrossEntropy,10}";
@@ -951,9 +951,8 @@ namespace Microsoft.ML.Vision
 
                 if (validationNeeded)
                 {
-                    validationEvalRunner = new Runner(_session, runnerInputTensorNames.ToArray(),
-                        runnerOutputTensorNames.Count() > 0 ? runnerOutputTensorNames.ToArray() : null,
-                        new[] { _trainStep.name });
+                    validationEvalRunner = new Runner(_session, new[] { _bottleneckInput.name, _labelTensor.name },
+                        new[] { _evaluationStep.name, _crossEntropy.name });
                 }
 
                 runner = new Runner(_session, runnerInputTensorNames.ToArray(),

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -1532,7 +1532,18 @@ namespace Microsoft.ML.Scenarios
                 Epoch = epoch,
                 BatchSize = 10,
                 LearningRate = 0.01f,
-                MetricsCallback = (metric) => Console.WriteLine(metric),
+                MetricsCallback = (metric) =>
+                {
+                    //Check that learning rate in metrics from both the training and validation phases decays
+                    if (metric.Train != null)
+                    {
+                        // At epoch 50, validation training starts with default learning rate, which decays
+                        // at each successive epoch
+                        if (epoch > 1 && epoch != 50)
+                            Assert.True(metric.Train.LearningRate < 0.01f);
+                    }
+                    Console.WriteLine(metric);
+                },
                 ValidationSet = validationSet,
                 WorkspacePath = workspacePath,
                 TrainSetBottleneckCachedValuesFileName = trainSetBottleneckCachedValuesFileName,

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -1522,7 +1522,6 @@ namespace Microsoft.ML.Scenarios
 
             float[] crossEntropyTraining = new float[epoch];
             float[] crossEntropyValidation = new float[epoch];
-            float baseLearningRate = 0.01f;
             var options = new ImageClassificationTrainer.Options()
             {
                 FeatureColumnName = "Image",
@@ -1533,7 +1532,7 @@ namespace Microsoft.ML.Scenarios
                 Arch = ImageClassificationTrainer.Architecture.ResnetV2101,
                 Epoch = epoch,
                 BatchSize = 10,
-                LearningRate = baseLearningRate,
+                LearningRate = 0.01f,
                 MetricsCallback = (metric) =>
                 {
                     if (metric.Train != null)


### PR DESCRIPTION
Fix #4807 

In this PR, I've added cross entropy metric calculation & reporting during validation training in the Image Classification Trainer. Now, validation training can obtain cross entropy values for each epoch during validation training.

I have attached below screenshots of training and validation metrics with this [repro](https://github.com/dotnet/machinelearning-samples/compare/master...gartangh:validation_metrics).

Before (note that learning rate is constant, even when the given `ExponentialLRDecay` is used, and cross entropy during validation is reported as 0):
![before_2](https://user-images.githubusercontent.com/5262061/85540803-455e8680-b5cc-11ea-9928-dab19fd901a6.png)

After:
![_after](https://user-images.githubusercontent.com/5262061/86318215-2ec8b880-bbe6-11ea-86e1-72e77b4ed3a3.png)

I have also edited `ToString()` to report accuracy and cross entropy for the validation phase as well. Reporting learning rate decay during validation isn't necessary, as no learning rate decay occurs in validation.

I have also added tests to verify the proper decaying of the cross-entropy rate with this PR.
