### PR TITLE
Add two-variable scenario in Tensor shape inference for TensorflowTransform

### DIFF
--- a/build/Dependencies.props
+++ b/build/Dependencies.props
@@ -55,7 +55,7 @@
     <MicrosoftExtensionsTestPackageVersion>3.0.1</MicrosoftExtensionsTestPackageVersion>
     <MicrosoftMLTestDatabasesPackageVersion>0.0.6-test</MicrosoftMLTestDatabasesPackageVersion>
     <MicrosoftMLTestModelsPackageVersion>0.0.6-test</MicrosoftMLTestModelsPackageVersion>
-    <MicrosoftMLTensorFlowTestModelsVersion>0.0.11-test</MicrosoftMLTensorFlowTestModelsVersion>
+    <MicrosoftMLTensorFlowTestModelsVersion>0.0.12-test</MicrosoftMLTensorFlowTestModelsVersion>
     <MicrosoftMLOnnxTestModelsVersion>0.0.6-test</MicrosoftMLOnnxTestModelsVersion>
     <SystemDataSqlClientVersion>4.6.1</SystemDataSqlClientVersion>
     <XunitCombinatorialVersion>1.2.7</XunitCombinatorialVersion>

--- a/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
@@ -530,7 +530,7 @@ namespace Microsoft.ML.Transforms
                         if (typeValueCount % valCount != 0)
                             throw Contracts.Except($"Input shape mismatch: Input '{_parent.Inputs[i]}' has shape {originalShape.ToString()}, but input data is of length {typeValueCount}.");
 
-                        //This cover the 2-variable senario e.g. [?,?,?,3] where we can assume W = H and typeDims provides the information of [W, H, C]
+                        //This cover the 2-variable senario e.g. [?,?,?,3] where we can assume typeDims provides the information of [W, H, C]
                         var originalShapeDims = originalShape.dims;
                         var originalShapeNdim = originalShape.ndim;
                         if (numOfUnkDim == typeDims.Length && originalShapeNdim == numOfUnkDim + 1)

--- a/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
@@ -509,7 +509,6 @@ namespace Microsoft.ML.Transforms
                     var shape = originalShape.dims;
 
                     var colTypeDims = vecType.Dimensions.Select(dim => (int)dim).ToArray();
-                    var typeDims = (type as VectorDataViewType).Dimensions;
                     if (shape == null || (shape.Length == 0))
                         _fullySpecifiedShapes[i] = new TensorShape(colTypeDims);
                     else
@@ -533,13 +532,13 @@ namespace Microsoft.ML.Transforms
                         //This cover the 2-variable senario e.g. [?,?,?,3] where we can assume typeDims provides the information of [W, H, C]
                         var originalShapeDims = originalShape.dims;
                         var originalShapeNdim = originalShape.ndim;
-                        if (numOfUnkDim == typeDims.Length && originalShapeNdim == numOfUnkDim + 1 && typeDims.Length == 3)
+                        if (numOfUnkDim == colTypeDims.Length && originalShapeNdim == numOfUnkDim + 1 && colTypeDims.Length == 3)
                         {
                             for (int ishape = 1; ishape < originalShapeNdim; ++ishape)
                             {
                                 if (originalShapeDims[ishape] == -1)
                                 {
-                                    originalShapeDims[ishape] = typeDims.IndexOf(ishape - 1);
+                                    originalShapeDims[ishape] = colTypeDims[ishape - 1];
                                     valCount *= originalShapeDims[ishape];
                                     numOfUnkDim--;
                                 }

--- a/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
@@ -529,20 +529,16 @@ namespace Microsoft.ML.Transforms
                         if (typeValueCount % valCount != 0)
                             throw Contracts.Except($"Input shape mismatch: Input '{_parent.Inputs[i]}' has shape {originalShape.ToString()}, but input data is of length {typeValueCount}.");
 
-                        //This cover the 2-variable senario e.g. [?,?,?,3] where we can assume typeDims provides the information of [W, H, C]
+                        // This cover the 2-variable senario e.g. [?, ?, ?, C] where we can assume typeDims provides the information of [W, H, C]
+                        // The shape will become [?, W, H, C]
                         var originalShapeDims = originalShape.dims;
                         var originalShapeNdim = originalShape.ndim;
-                        if (numOfUnkDim == 3 && colTypeDims.Length == 3 && originalShapeNdim == numOfUnkDim + 1)
+                        if (numOfUnkDim == 3 && colTypeDims.Length == 3 && originalShapeNdim == numOfUnkDim + 1 && originalShapeDims[1] == -1)
                         {
-                            for (int ishape = 1; ishape < originalShapeNdim; ++ishape)
-                            {
-                                if (originalShapeDims[ishape] == -1)
-                                {
-                                    originalShapeDims[ishape] = colTypeDims[ishape - 1];
-                                    valCount *= originalShapeDims[ishape];
-                                    numOfUnkDim--;
-                                }
-                            }
+                            originalShapeDims[1] = colTypeDims[0];
+                            originalShapeDims[2] = colTypeDims[1];
+                            valCount *= originalShapeDims[1] * originalShapeDims[2];
+                            numOfUnkDim -= 2;
                         }
 
                         // If the shape is multi-dimensional, we should be able to create the length of the vector by plugging

--- a/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
@@ -533,10 +533,8 @@ namespace Microsoft.ML.Transforms
                         //This cover the 2-variable senario e.g. [?,?,?,3] where we can assume typeDims provides the information of [W, H, C]
                         var originalShapeDims = originalShape.dims;
                         var originalShapeNdim = originalShape.ndim;
-                        if (numOfUnkDim == typeDims.Length && originalShapeNdim == numOfUnkDim + 1)
+                        if (numOfUnkDim == typeDims.Length && originalShapeNdim == numOfUnkDim + 1 && typeDims.Length == 3)
                         {
-                            if (typeDims.Length != 3)
-                                throw Contracts.Except($"Input '{_parent.Inputs[i]}' Schema does not provide enough information for tensor shape inferencing");
                             for (int ishape = 1; ishape < originalShapeNdim; ++ishape)
                             {
                                 if (originalShapeDims[ishape] == -1)

--- a/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
@@ -570,61 +570,6 @@ namespace Microsoft.ML.Transforms
                             l[ishape] = _fullySpecifiedShapes[i].dims[ishape - 1];
                         _fullySpecifiedShapes[i] = new TensorShape(l);
                     }
-
-                    /*if (shape == null || (shape.Length == 0))
-                        _fullySpecifiedShapes[i] = new TensorShape(colTypeDims);
-                    else
-                    {
-                        // If the column is one dimension we make sure that the total size of the TF shape matches.
-                        // Compute the total size of the known dimensions of the shape.
-                        int valCount = 1;
-                        int numOfUnkDim = 0;
-                        foreach (var s in shape)
-                        {
-                            if (s > 0)
-                                valCount *= s;
-                            else
-                                numOfUnkDim++;
-                        }
-                        // The column length should be divisible by this, so that the other dimensions can be integral.
-                        int typeValueCount = type.GetValueCount();
-                        var typeDims = (type as VectorDataViewType).Dimensions;
-
-                        if (typeValueCount % valCount != 0)
-                            throw Contracts.Except($"Input shape mismatch: Input '{_parent.Inputs[i]}' has shape {originalShape.ToString()}, but input data is of length {typeValueCount}.");
-
-                        int[] originalShapeDims = originalShape.dims;
-                        if (typeDims.Length == originalShape.ndim)
-                        {
-                            int shapeNDim = originalShape.ndim + (_parent._addBatchDimensionInput ? 1 : 0);
-                            int[] l = new int[shapeNDim];
-                            l[0] = 1;
-                            for (int rishape = shapeNDim - 1; rishape >= 0; --rishape)
-                            {
-                                if (originalShapeDims[rishape] != -1 && originalShapeDims[rishape] != typeDims.IndexOf(rishape))
-                                    throw Contracts.Except($"Input shape mismatch: Input '{_parent.Inputs[i]}' has shape {originalShape.ToString()}, but input data is of shape {typeDims.ToString()}."); //bugbug
-                                l[rishape] = typeDims.IndexOf(rishape);
-                            }
-                            _fullySpecifiedShapes[i] = new TensorShape(l);
-                        }
-                        else if (typeDims.Length + 1 == originalShape.ndim && _parent._addBatchDimensionInput)
-                        {
-                            int shapeNDim = originalShape.ndim;
-                            int[] l = new int[shapeNDim];
-                            l[0] = 1;
-                            for (int ishape = 1; ishape < shapeNDim; ++ishape)
-                            {
-                                if (originalShapeDims[ishape] != -1 && originalShapeDims[ishape] != typeDims.ElementAt(ishape - 1))
-                                    throw Contracts.Except($"Input shape mismatch: Input '{_parent.Inputs[i]}' has shape {originalShape.ToString()}, but input data is of shape {typeDims.ToString()}."); //bugbug
-                                l[ishape] = typeDims.IndexOf(ishape - 1);
-                            }
-                            _fullySpecifiedShapes[i] = new TensorShape(l);
-                        }
-                        else
-                        {
-                            throw Contracts.Except($"Input dimension number mismatch: Input '{_parent.Inputs[i]}' has {originalShape.ndim} dimensions, but input data has {typeDims.Length}.");
-                        }
-                    }*/
                 }
 
                 _runners = new ConcurrentBag<Runner>();

--- a/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
@@ -532,7 +532,7 @@ namespace Microsoft.ML.Transforms
                         //This cover the 2-variable senario e.g. [?,?,?,3] where we can assume typeDims provides the information of [W, H, C]
                         var originalShapeDims = originalShape.dims;
                         var originalShapeNdim = originalShape.ndim;
-                        if (numOfUnkDim == colTypeDims.Length && originalShapeNdim == numOfUnkDim + 1 && colTypeDims.Length == 3)
+                        if (numOfUnkDim == 3 && colTypeDims.Length == 3 && originalShapeNdim == numOfUnkDim + 1)
                         {
                             for (int ishape = 1; ishape < originalShapeNdim; ++ishape)
                             {

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
-using System.Net;
 using System.Runtime.InteropServices;
 using Microsoft.ML.Data;
 using Microsoft.ML.Vision;

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -1905,7 +1905,7 @@ namespace Microsoft.ML.Scenarios
         [TensorFlowFact]
         public void TensorflowPlaceholderShapeInferenceTest()
         {
-            //download the file
+            //download the pb file
             string gitPath = "https://github.com/dotnet/machinelearning-testdata/raw/ddf00f8d60ff1b4bb1f3e33639bec318e67fd32e/Microsoft.ML.TensorFlow.TestModels/cifar_model/frozen_model_variadic_input_shape.pb";
             using (WebClient client = new WebClient())
             {

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -1905,12 +1905,6 @@ namespace Microsoft.ML.Scenarios
         [TensorFlowFact]
         public void TensorflowPlaceholderShapeInferenceTest()
         {
-            //download the pb file
-            string gitPath = "https://github.com/dotnet/machinelearning-testdata/raw/ddf00f8d60ff1b4bb1f3e33639bec318e67fd32e/Microsoft.ML.TensorFlow.TestModels/cifar_model/frozen_model_variadic_input_shape.pb";
-            using (WebClient client = new WebClient())
-            {
-                client.DownloadFile(new Uri($"{gitPath}"), "cifar_model/frozen_model_variadic_input_shape.pb");
-            }
             //frozen_model_variadic_input_shape.pb is modified by frozen_model.pb 
             //the shape of placeholder is changed from [?, w, h, c] to [?, ?, ?, c]
             string modelLocation = "cifar_model/frozen_model_variadic_input_shape.pb";

--- a/test/Microsoft.ML.Tests/TensorFlowEstimatorTests.cs
+++ b/test/Microsoft.ML.Tests/TensorFlowEstimatorTests.cs
@@ -14,7 +14,6 @@ using Microsoft.ML.Transforms;
 using Microsoft.ML.TensorFlow;
 using Xunit;
 using Xunit.Abstractions;
-using static Microsoft.ML.Scenarios.TensorFlowScenariosTests;
 
 namespace Microsoft.ML.Tests
 {

--- a/test/Microsoft.ML.Tests/TensorFlowEstimatorTests.cs
+++ b/test/Microsoft.ML.Tests/TensorFlowEstimatorTests.cs
@@ -274,7 +274,7 @@ namespace Microsoft.ML.Tests
             }
         }
 
-        [TensorFlowFact]
+        /*[TensorFlowFact]
         public void MyTest()
         {
             var mlContext = new MLContext(seed: 1);
@@ -298,7 +298,7 @@ namespace Microsoft.ML.Tests
 
             var transformer = pipeline.Fit(data);
 
-            /*var modelLocation = "cifar_model/frozen_model.pb";
+            *//*var modelLocation = "cifar_model/frozen_model.pb";
 
             var mlContext = new MLContext(seed: 1);
             var imageHeight = 32;
@@ -317,7 +317,7 @@ namespace Microsoft.ML.Tests
                 .Append(ML.Transforms.ExtractPixels("Input", interleavePixelColors: true))
                 .Append(ML.Model.LoadTensorFlowModel(modelLocation).ScoreTensorFlowModel("Output", "Input"));
 
-            TestEstimatorCore(pipe, data);*/
-        }
+            TestEstimatorCore(pipe, data);*//*
+        }*/
     }
 }

--- a/test/Microsoft.ML.Tests/TensorFlowEstimatorTests.cs
+++ b/test/Microsoft.ML.Tests/TensorFlowEstimatorTests.cs
@@ -273,51 +273,5 @@ namespace Microsoft.ML.Tests
                 }
             }
         }
-
-        /*[TensorFlowFact]
-        public void MyTest()
-        {
-            var mlContext = new MLContext(seed: 1);
-
-            var modelFile = "C:\\Users\\Administrator\\Desktop\\MLNET\\PotatoDetector.pb";
-
-            var dataFile = GetDataPath("images/images.tsv");
-            var imageFolder = Path.GetDirectoryName(dataFile);
-
-            var data = ML.Data.LoadFromTextFile(dataFile, new[] {
-                new TextLoader.Column("imagePath", DataKind.String, 0),
-                new TextLoader.Column("name", DataKind.String, 1)
-            });
-
-            var pipeline = mlContext.Transforms
-             .LoadImages("image_tensor", imageFolder, "imagePath")
-              .Append(mlContext.Transforms.ResizeImages(outputColumnName: "image_tensor", imageWidth: 500, imageHeight: 500))
-                .Append(mlContext.Transforms.ExtractPixels(outputColumnName: "image_tensor", interleavePixelColors: true, outputAsFloatArray: false))
-                .Append(mlContext.Model.LoadTensorFlowModel(modelFile)
-              .ScoreTensorFlowModel(outputColumnNames: new[] { "detection_boxes", "detection_scores", "num_detections" }, inputColumnNames: new[] { "image_tensor" }, addBatchDimensionInput: false));
-
-            var transformer = pipeline.Fit(data);
-
-            *//*var modelLocation = "cifar_model/frozen_model.pb";
-
-            var mlContext = new MLContext(seed: 1);
-            var imageHeight = 32;
-            var imageWidth = 32;
-            var dataFile = GetDataPath("images/images.tsv");
-            var imageFolder = Path.GetDirectoryName(dataFile);
-
-            var data = ML.Data.LoadFromTextFile(dataFile, new[] {
-                new TextLoader.Column("imagePath", DataKind.String, 0),
-                new TextLoader.Column("name", DataKind.String, 1)
-            });
-
-            // Note that CamelCase column names are there to match the TF graph node names.
-            var pipe = ML.Transforms.LoadImages("Input", imageFolder, "imagePath")
-                .Append(ML.Transforms.ResizeImages("Input", imageHeight, imageWidth))
-                .Append(ML.Transforms.ExtractPixels("Input", interleavePixelColors: true))
-                .Append(ML.Model.LoadTensorFlowModel(modelLocation).ScoreTensorFlowModel("Output", "Input"));
-
-            TestEstimatorCore(pipe, data);*//*
-        }*/
     }
 }


### PR DESCRIPTION
fix [4364](https://github.com/dotnet/machinelearning/issues/4364)

There are a couple of image related scenarios that tensor shape inferencing should handle (tensor usually has shape [W,H,C] or [N,W,H,C] and usually W = H), the first three are covered by current implementation. This PR added the fourth one.
1, [?, ?, C]
2, [?, W, H, C]
3, [N, ?, ?, C]
4, [?, ?, ?, C] (added in this PR)

There was another [PR](https://github.com/dotnet/machinelearning/pull/4509) that attempted to resolve this in the past and it considered scenarios like [?, W, ?, C] or [?, ?, H, C] but I am not sure(and never seen) these could be any deep learning scenarios. We can discuss this since I could be wrong and I will add those scenarios if necessary. 