### PR TITLE
Enabling Ranking Cross Validation

### DIFF
--- a/src/Microsoft.ML.AutoML/API/ColumnInference.cs
+++ b/src/Microsoft.ML.AutoML/API/ColumnInference.cs
@@ -118,6 +118,7 @@ namespace Microsoft.ML.AutoML
         public ColumnInformation()
         {
             LabelColumnName = DefaultColumnNames.Label;
+            GroupIdColumnName = DefaultColumnNames.GroupId;
             CategoricalColumnNames = new Collection<string>();
             NumericColumnNames = new Collection<string>();
             TextColumnNames = new Collection<string>();

--- a/src/Microsoft.ML.AutoML/API/ColumnInference.cs
+++ b/src/Microsoft.ML.AutoML/API/ColumnInference.cs
@@ -60,6 +60,7 @@ namespace Microsoft.ML.AutoML
 
         /// <summary>
         /// The dataset column to use as a group ID for computation.
+        /// If a SamplingKeyColumnName is provided, then it should be the same as this column.
         /// </summary>
         public string GroupIdColumnName { get; set; }
 

--- a/src/Microsoft.ML.AutoML/API/ColumnInference.cs
+++ b/src/Microsoft.ML.AutoML/API/ColumnInference.cs
@@ -59,7 +59,7 @@ namespace Microsoft.ML.AutoML
         public string UserIdColumnName { get; set; }
 
         /// <summary>
-        /// The dataset column to use as a group ID for computation.
+        /// The dataset column to use as a group ID for computation in a Ranking Task.
         /// If a SamplingKeyColumnName is provided, then it should be the same as this column.
         /// </summary>
         public string GroupIdColumnName { get; set; }

--- a/src/Microsoft.ML.AutoML/API/ColumnInference.cs
+++ b/src/Microsoft.ML.AutoML/API/ColumnInference.cs
@@ -118,7 +118,6 @@ namespace Microsoft.ML.AutoML
         public ColumnInformation()
         {
             LabelColumnName = DefaultColumnNames.Label;
-            GroupIdColumnName = DefaultColumnNames.GroupId;
             CategoricalColumnNames = new Collection<string>();
             NumericColumnNames = new Collection<string>();
             TextColumnNames = new Collection<string>();

--- a/src/Microsoft.ML.AutoML/API/ExperimentBase.cs
+++ b/src/Microsoft.ML.AutoML/API/ExperimentBase.cs
@@ -157,7 +157,10 @@ namespace Microsoft.ML.AutoML
         /// </remarks>
         public ExperimentResult<TMetrics> Execute(IDataView trainData, IDataView validationData, string labelColumnName = DefaultColumnNames.Label, IEstimator<ITransformer> preFeaturizer = null, IProgress<RunDetail<TMetrics>> progressHandler = null)
         {
-            var columnInformation = new ColumnInformation() { LabelColumnName = labelColumnName };
+            var columnInformation = (_task == TaskKind.Ranking) ?
+                new ColumnInformation() { LabelColumnName = labelColumnName, GroupIdColumnName = DefaultColumnNames.GroupId } :
+                new ColumnInformation() { LabelColumnName = labelColumnName};
+
             return Execute(trainData, validationData, columnInformation, preFeaturizer, progressHandler);
         }
 
@@ -245,7 +248,14 @@ namespace Microsoft.ML.AutoML
             string samplingKeyColumn = null, IEstimator<ITransformer> preFeaturizer = null,
             Progress<CrossValidationRunDetail<TMetrics>> progressHandler = null)
         {
-            var columnInformation = new ColumnInformation()
+            var columnInformation = (_task == TaskKind.Ranking) ?
+            new ColumnInformation()
+            {
+                LabelColumnName = labelColumnName,
+                GroupIdColumnName = samplingKeyColumn ??  DefaultColumnNames.GroupId
+            }
+            :
+            new ColumnInformation()
             {
                 LabelColumnName = labelColumnName,
                 SamplingKeyColumnName = samplingKeyColumn

--- a/src/Microsoft.ML.AutoML/API/ExperimentBase.cs
+++ b/src/Microsoft.ML.AutoML/API/ExperimentBase.cs
@@ -73,7 +73,8 @@ namespace Microsoft.ML.AutoML
                 columnInformation = new ColumnInformation()
                 {
                     LabelColumnName = labelColumnName,
-                    GroupIdColumnName = samplingKeyColumn ?? DefaultColumnNames.GroupId
+                    SamplingKeyColumnName = samplingKeyColumn ?? DefaultColumnNames.GroupId,
+                    GroupIdColumnName = samplingKeyColumn ?? DefaultColumnNames.GroupId // For ranking, we want to enforce having the same column as samplingKeyColum and GroupIdColumn
                 };
             }
             else
@@ -131,7 +132,7 @@ namespace Microsoft.ML.AutoML
         private string GetSamplingKey(string groupIdColumnName, string samplingKeyColumnName)
         {
             UserInputValidationUtil.ValidateSamplingKey(samplingKeyColumnName, groupIdColumnName, _task);
-            if ( _task == TaskKind.Ranking)
+            if (_task == TaskKind.Ranking)
                 return groupIdColumnName ?? DefaultColumnNames.GroupId;
             return samplingKeyColumnName;
         }
@@ -159,7 +160,7 @@ namespace Microsoft.ML.AutoML
         {
             var columnInformation = (_task == TaskKind.Ranking) ?
                 new ColumnInformation() { LabelColumnName = labelColumnName, GroupIdColumnName = DefaultColumnNames.GroupId } :
-                new ColumnInformation() { LabelColumnName = labelColumnName};
+                new ColumnInformation() { LabelColumnName = labelColumnName };
 
             return Execute(trainData, validationData, columnInformation, preFeaturizer, progressHandler);
         }
@@ -252,7 +253,8 @@ namespace Microsoft.ML.AutoML
             new ColumnInformation()
             {
                 LabelColumnName = labelColumnName,
-                GroupIdColumnName = samplingKeyColumn ??  DefaultColumnNames.GroupId
+                SamplingKeyColumnName = samplingKeyColumn ?? DefaultColumnNames.GroupId,
+                GroupIdColumnName = samplingKeyColumn ?? DefaultColumnNames.GroupId // For ranking, we want to enforce having the same column as samplingKeyColum and GroupIdColumn
             }
             :
             new ColumnInformation()

--- a/src/Microsoft.ML.AutoML/API/ExperimentBase.cs
+++ b/src/Microsoft.ML.AutoML/API/ExperimentBase.cs
@@ -194,7 +194,8 @@ namespace Microsoft.ML.AutoML
             IProgress<CrossValidationRunDetail<TMetrics>> progressHandler = null)
         {
             UserInputValidationUtil.ValidateNumberOfCVFoldsArg(numberOfCVFolds);
-            var splitResult = SplitUtil.CrossValSplit(Context, trainData, numberOfCVFolds, columnInformation?.SamplingKeyColumnName);
+            UserInputValidationUtil.ValidateSamplingKey(columnInformation?.SamplingKeyColumnName, columnInformation?.GroupIdColumnName, _task);
+            var splitResult = SplitUtil.CrossValSplit(Context, trainData, numberOfCVFolds, columnInformation?.GroupIdColumnName);
             return ExecuteCrossVal(splitResult.trainDatasets, columnInformation, splitResult.validationDatasets, preFeaturizer, progressHandler);
         }
 

--- a/src/Microsoft.ML.AutoML/API/ExperimentBase.cs
+++ b/src/Microsoft.ML.AutoML/API/ExperimentBase.cs
@@ -285,7 +285,7 @@ namespace Microsoft.ML.AutoML
                 validationData = preprocessorTransform.Transform(validationData);
             }
 
-            var runner = new TrainValidateRunner<TMetrics>(Context, trainData, validationData, columnInfo.LabelColumnName, MetricsAgent,
+            var runner = new TrainValidateRunner<TMetrics>(Context, trainData, validationData, columnInfo.GroupIdColumnName, columnInfo.LabelColumnName, MetricsAgent,
                 preFeaturizer, preprocessorTransform, _logger);
             var columns = DatasetColumnInfoUtil.GetDatasetColumnInfo(Context, trainData, columnInfo);
             return Execute(columnInfo, columns, preFeaturizer, progressHandler, runner);
@@ -305,7 +305,7 @@ namespace Microsoft.ML.AutoML
             (trainDatasets, validationDatasets, preprocessorTransforms) = ApplyPreFeaturizerCrossVal(trainDatasets, validationDatasets, preFeaturizer);
 
             var runner = new CrossValRunner<TMetrics>(Context, trainDatasets, validationDatasets, MetricsAgent, preFeaturizer,
-                preprocessorTransforms, columnInfo.LabelColumnName, _logger);
+                preprocessorTransforms, columnInfo.GroupIdColumnName, columnInfo.LabelColumnName, _logger);
             var columns = DatasetColumnInfoUtil.GetDatasetColumnInfo(Context, trainDatasets[0], columnInfo);
 
             // Execute experiment & get all pipelines run
@@ -332,7 +332,7 @@ namespace Microsoft.ML.AutoML
             (trainDatasets, validationDatasets, preprocessorTransforms) = ApplyPreFeaturizerCrossVal(trainDatasets, validationDatasets, preFeaturizer);
 
             var runner = new CrossValSummaryRunner<TMetrics>(Context, trainDatasets, validationDatasets, MetricsAgent, preFeaturizer,
-                preprocessorTransforms, columnInfo.LabelColumnName, OptimizingMetricInfo, _logger);
+                preprocessorTransforms, columnInfo.GroupIdColumnName, columnInfo.LabelColumnName, OptimizingMetricInfo, _logger);
             var columns = DatasetColumnInfoUtil.GetDatasetColumnInfo(Context, trainDatasets[0], columnInfo);
             return Execute(columnInfo, columns, preFeaturizer, progressHandler, runner);
         }

--- a/src/Microsoft.ML.AutoML/API/RankingExperiment.cs
+++ b/src/Microsoft.ML.AutoML/API/RankingExperiment.cs
@@ -34,7 +34,7 @@ namespace Microsoft.ML.AutoML
         public ICollection<RankingTrainer> Trainers { get; }
         public RankingExperimentSettings()
         {
-            GroupIdColumnName = "GroupId";
+            GroupIdColumnName = DefaultColumnNames.GroupId;
             OptimizingMetric = RankingMetric.Ndcg;
             Trainers = Enum.GetValues(typeof(RankingTrainer)).OfType<RankingTrainer>().ToList();
         }
@@ -77,7 +77,7 @@ namespace Microsoft.ML.AutoML
         /// <param name="metric">Metric to consider when selecting the best run.</param>
         /// <param name="groupIdColumnName">Name for the GroupId column.</param>
         /// <returns>The best experiment run.</returns>
-        public static RunDetail<RankingMetrics> Best(this IEnumerable<RunDetail<RankingMetrics>> results, RankingMetric metric = RankingMetric.Ndcg, string groupIdColumnName = "GroupId")
+        public static RunDetail<RankingMetrics> Best(this IEnumerable<RunDetail<RankingMetrics>> results, RankingMetric metric = RankingMetric.Ndcg, string groupIdColumnName = DefaultColumnNames.GroupId)
         {
             var metricsAgent = new RankingMetricsAgent(null, metric, groupIdColumnName);
             var isMetricMaximizing = new OptimizingMetricInfo(metric).IsMaximizing;
@@ -91,7 +91,7 @@ namespace Microsoft.ML.AutoML
         /// <param name="metric">Metric to consider when selecting the best run.</param>
         /// <param name="groupIdColumnName">Name for the GroupId column.</param>
         /// <returns>The best experiment run.</returns>
-        public static CrossValidationRunDetail<RankingMetrics> Best(this IEnumerable<CrossValidationRunDetail<RankingMetrics>> results, RankingMetric metric = RankingMetric.Ndcg, string groupIdColumnName = "GroupId")
+        public static CrossValidationRunDetail<RankingMetrics> Best(this IEnumerable<CrossValidationRunDetail<RankingMetrics>> results, RankingMetric metric = RankingMetric.Ndcg, string groupIdColumnName = DefaultColumnNames.GroupId)
         {
             var metricsAgent = new RankingMetricsAgent(null, metric, groupIdColumnName);
             var isMetricMaximizing = new OptimizingMetricInfo(metric).IsMaximizing;

--- a/src/Microsoft.ML.AutoML/API/RankingExperiment.cs
+++ b/src/Microsoft.ML.AutoML/API/RankingExperiment.cs
@@ -20,12 +20,6 @@ namespace Microsoft.ML.AutoML
         public RankingMetric OptimizingMetric { get; set; }
 
         /// <summary>
-        /// Name for the GroupId column.
-        /// </summary>
-        /// <value>The default value is GroupId.</value>
-        public string GroupIdColumnName { get; set; }
-
-        /// <summary>
         /// Collection of trainers the AutoML experiment can leverage.
         /// </summary>
         /// <value>
@@ -34,7 +28,6 @@ namespace Microsoft.ML.AutoML
         public ICollection<RankingTrainer> Trainers { get; }
         public RankingExperimentSettings()
         {
-            GroupIdColumnName = DefaultColumnNames.GroupId;
             OptimizingMetric = RankingMetric.Ndcg;
             Trainers = Enum.GetValues(typeof(RankingTrainer)).OfType<RankingTrainer>().ToList();
         }
@@ -75,11 +68,10 @@ namespace Microsoft.ML.AutoML
         /// </summary>
         /// <param name="results">Enumeration of AutoML experiment run results.</param>
         /// <param name="metric">Metric to consider when selecting the best run.</param>
-        /// <param name="groupIdColumnName">Name for the GroupId column.</param>
         /// <returns>The best experiment run.</returns>
-        public static RunDetail<RankingMetrics> Best(this IEnumerable<RunDetail<RankingMetrics>> results, RankingMetric metric = RankingMetric.Ndcg, string groupIdColumnName = DefaultColumnNames.GroupId)
+        public static RunDetail<RankingMetrics> Best(this IEnumerable<RunDetail<RankingMetrics>> results, RankingMetric metric = RankingMetric.Ndcg)
         {
-            var metricsAgent = new RankingMetricsAgent(null, metric, groupIdColumnName);
+            var metricsAgent = new RankingMetricsAgent(null, metric);
             var isMetricMaximizing = new OptimizingMetricInfo(metric).IsMaximizing;
             return BestResultUtil.GetBestRun(results, metricsAgent, isMetricMaximizing);
         }
@@ -89,11 +81,10 @@ namespace Microsoft.ML.AutoML
         /// </summary>
         /// <param name="results">Enumeration of AutoML experiment cross validation run results.</param>
         /// <param name="metric">Metric to consider when selecting the best run.</param>
-        /// <param name="groupIdColumnName">Name for the GroupId column.</param>
         /// <returns>The best experiment run.</returns>
-        public static CrossValidationRunDetail<RankingMetrics> Best(this IEnumerable<CrossValidationRunDetail<RankingMetrics>> results, RankingMetric metric = RankingMetric.Ndcg, string groupIdColumnName = DefaultColumnNames.GroupId)
+        public static CrossValidationRunDetail<RankingMetrics> Best(this IEnumerable<CrossValidationRunDetail<RankingMetrics>> results, RankingMetric metric = RankingMetric.Ndcg)
         {
-            var metricsAgent = new RankingMetricsAgent(null, metric, groupIdColumnName);
+            var metricsAgent = new RankingMetricsAgent(null, metric);
             var isMetricMaximizing = new OptimizingMetricInfo(metric).IsMaximizing;
             return BestResultUtil.GetBestRun(results, metricsAgent, isMetricMaximizing);
         }
@@ -112,7 +103,7 @@ namespace Microsoft.ML.AutoML
     {
         internal RankingExperiment(MLContext context, RankingExperimentSettings settings)
             : base(context,
-                  new RankingMetricsAgent(context, settings.OptimizingMetric, settings.GroupIdColumnName),
+                  new RankingMetricsAgent(context, settings.OptimizingMetric),
                   new OptimizingMetricInfo(settings.OptimizingMetric),
                   settings,
                   TaskKind.Ranking,

--- a/src/Microsoft.ML.AutoML/ColumnInference/ColumnInformationUtil.cs
+++ b/src/Microsoft.ML.AutoML/ColumnInference/ColumnInformationUtil.cs
@@ -21,6 +21,11 @@ namespace Microsoft.ML.AutoML
                 return ColumnPurpose.Weight;
             }
 
+            if (columnName == columnInfo.GroupIdColumnName)
+            {
+                return ColumnPurpose.GroupId;
+            }
+
             if (columnName == columnInfo.SamplingKeyColumnName)
             {
                 return ColumnPurpose.SamplingKey;
@@ -49,11 +54,6 @@ namespace Microsoft.ML.AutoML
             if (columnName == columnInfo.UserIdColumnName)
             {
                 return ColumnPurpose.UserId;
-            }
-
-            if (columnName == columnInfo.GroupIdColumnName)
-            {
-                return ColumnPurpose.GroupId;
             }
 
             if (columnName == columnInfo.ItemIdColumnName)

--- a/src/Microsoft.ML.AutoML/Experiment/MetricsAgents/BinaryMetricsAgent.cs
+++ b/src/Microsoft.ML.AutoML/Experiment/MetricsAgents/BinaryMetricsAgent.cs
@@ -78,7 +78,7 @@ namespace Microsoft.ML.AutoML
             }
         }
 
-        public BinaryClassificationMetrics EvaluateMetrics(IDataView data, string labelColumn)
+        public BinaryClassificationMetrics EvaluateMetrics(IDataView data, string labelColumn, string groupIdColumn)
         {
             return _mlContext.BinaryClassification.EvaluateNonCalibrated(data, labelColumn);
         }

--- a/src/Microsoft.ML.AutoML/Experiment/MetricsAgents/IMetricsAgent.cs
+++ b/src/Microsoft.ML.AutoML/Experiment/MetricsAgents/IMetricsAgent.cs
@@ -10,6 +10,6 @@ namespace Microsoft.ML.AutoML
 
         bool IsModelPerfect(double score);
 
-        T EvaluateMetrics(IDataView data, string labelColumn);
+        T EvaluateMetrics(IDataView data, string labelColumn, string groupId = null);
     }
 }

--- a/src/Microsoft.ML.AutoML/Experiment/MetricsAgents/IMetricsAgent.cs
+++ b/src/Microsoft.ML.AutoML/Experiment/MetricsAgents/IMetricsAgent.cs
@@ -10,6 +10,7 @@ namespace Microsoft.ML.AutoML
 
         bool IsModelPerfect(double score);
 
-        T EvaluateMetrics(IDataView data, string labelColumn, string groupId = null);
+        // GroupId is a parameter used only in RankingMetricsAgent
+        T EvaluateMetrics(IDataView data, string labelColumn, string groupId);
     }
 }

--- a/src/Microsoft.ML.AutoML/Experiment/MetricsAgents/MultiMetricsAgent.cs
+++ b/src/Microsoft.ML.AutoML/Experiment/MetricsAgents/MultiMetricsAgent.cs
@@ -66,7 +66,7 @@ namespace Microsoft.ML.AutoML
             }
         }
 
-        public MulticlassClassificationMetrics EvaluateMetrics(IDataView data, string labelColumn)
+        public MulticlassClassificationMetrics EvaluateMetrics(IDataView data, string labelColumn, string groupIdColumn)
         {
             return _mlContext.MulticlassClassification.Evaluate(data, labelColumn);
         }

--- a/src/Microsoft.ML.AutoML/Experiment/MetricsAgents/RankingMetricsAgent.cs
+++ b/src/Microsoft.ML.AutoML/Experiment/MetricsAgents/RankingMetricsAgent.cs
@@ -10,13 +10,11 @@ namespace Microsoft.ML.AutoML
     {
         private readonly MLContext _mlContext;
         private readonly RankingMetric _optimizingMetric;
-        private readonly string _groupIdColumnName;
 
-        public RankingMetricsAgent(MLContext mlContext, RankingMetric optimizingMetric, string groupIdColumnName)
+        public RankingMetricsAgent(MLContext mlContext, RankingMetric optimizingMetric)
         {
             _mlContext = mlContext;
             _optimizingMetric = optimizingMetric;
-            _groupIdColumnName = groupIdColumnName;
         }
 
         // Optimizing metric used: NDCG@10 and DCG@10
@@ -59,9 +57,9 @@ namespace Microsoft.ML.AutoML
             }
         }
 
-        public RankingMetrics EvaluateMetrics(IDataView data, string labelColumn)
+        public RankingMetrics EvaluateMetrics(IDataView data, string labelColumn, string groupIdColumn)
         {
-            return _mlContext.Ranking.Evaluate(data, labelColumn, _groupIdColumnName);
+            return _mlContext.Ranking.Evaluate(data, labelColumn, groupIdColumn);
         }
     }
 }

--- a/src/Microsoft.ML.AutoML/Experiment/MetricsAgents/RegressionMetricsAgent.cs
+++ b/src/Microsoft.ML.AutoML/Experiment/MetricsAgents/RegressionMetricsAgent.cs
@@ -61,7 +61,7 @@ namespace Microsoft.ML.AutoML
             }
         }
 
-        public RegressionMetrics EvaluateMetrics(IDataView data, string labelColumn)
+        public RegressionMetrics EvaluateMetrics(IDataView data, string labelColumn, string groupIdColumn)
         {
             return _mlContext.Regression.Evaluate(data, labelColumn);
         }

--- a/src/Microsoft.ML.AutoML/Experiment/Runners/CrossValRunner.cs
+++ b/src/Microsoft.ML.AutoML/Experiment/Runners/CrossValRunner.cs
@@ -19,6 +19,7 @@ namespace Microsoft.ML.AutoML
         private readonly IMetricsAgent<TMetrics> _metricsAgent;
         private readonly IEstimator<ITransformer> _preFeaturizer;
         private readonly ITransformer[] _preprocessorTransforms;
+        private readonly string _groupIdColumn;
         private readonly string _labelColumn;
         private readonly IChannel _logger;
         private readonly DataViewSchema _modelInputSchema;
@@ -29,6 +30,7 @@ namespace Microsoft.ML.AutoML
             IMetricsAgent<TMetrics> metricsAgent,
             IEstimator<ITransformer> preFeaturizer,
             ITransformer[] preprocessorTransforms,
+            string groupIdColumn,
             string labelColumn,
             IChannel logger)
         {
@@ -38,6 +40,7 @@ namespace Microsoft.ML.AutoML
             _metricsAgent = metricsAgent;
             _preFeaturizer = preFeaturizer;
             _preprocessorTransforms = preprocessorTransforms;
+            _groupIdColumn = groupIdColumn;
             _labelColumn = labelColumn;
             _logger = logger;
             _modelInputSchema = trainDatasets[0].Schema;
@@ -52,7 +55,7 @@ namespace Microsoft.ML.AutoML
             {
                 var modelFileInfo = RunnerUtil.GetModelFileInfo(modelDirectory, iterationNum, i + 1);
                 var trainResult = RunnerUtil.TrainAndScorePipeline(_context, pipeline, _trainDatasets[i], _validDatasets[i],
-                    _labelColumn, _metricsAgent, _preprocessorTransforms?[i], modelFileInfo, _modelInputSchema, _logger);
+                    _groupIdColumn, _labelColumn, _metricsAgent, _preprocessorTransforms?[i], modelFileInfo, _modelInputSchema, _logger);
                 trainResults.Add(new SuggestedPipelineTrainResult<TMetrics>(trainResult.model, trainResult.metrics, trainResult.exception, trainResult.score));
             }
 

--- a/src/Microsoft.ML.AutoML/Experiment/Runners/CrossValSummaryRunner.cs
+++ b/src/Microsoft.ML.AutoML/Experiment/Runners/CrossValSummaryRunner.cs
@@ -20,6 +20,7 @@ namespace Microsoft.ML.AutoML
         private readonly IMetricsAgent<TMetrics> _metricsAgent;
         private readonly IEstimator<ITransformer> _preFeaturizer;
         private readonly ITransformer[] _preprocessorTransforms;
+        private readonly string _groupIdColumn;
         private readonly string _labelColumn;
         private readonly OptimizingMetricInfo _optimizingMetricInfo;
         private readonly IChannel _logger;
@@ -31,6 +32,7 @@ namespace Microsoft.ML.AutoML
             IMetricsAgent<TMetrics> metricsAgent,
             IEstimator<ITransformer> preFeaturizer,
             ITransformer[] preprocessorTransforms,
+            string groupIdColumn,
             string labelColumn,
             OptimizingMetricInfo optimizingMetricInfo,
             IChannel logger)
@@ -41,6 +43,7 @@ namespace Microsoft.ML.AutoML
             _metricsAgent = metricsAgent;
             _preFeaturizer = preFeaturizer;
             _preprocessorTransforms = preprocessorTransforms;
+            _groupIdColumn = groupIdColumn;
             _labelColumn = labelColumn;
             _optimizingMetricInfo = optimizingMetricInfo;
             _logger = logger;
@@ -56,7 +59,7 @@ namespace Microsoft.ML.AutoML
             {
                 var modelFileInfo = RunnerUtil.GetModelFileInfo(modelDirectory, iterationNum, i + 1);
                 var trainResult = RunnerUtil.TrainAndScorePipeline(_context, pipeline, _trainDatasets[i], _validDatasets[i],
-                    _labelColumn, _metricsAgent, _preprocessorTransforms?.ElementAt(i), modelFileInfo, _modelInputSchema,
+                    _groupIdColumn, _labelColumn, _metricsAgent, _preprocessorTransforms?.ElementAt(i), modelFileInfo, _modelInputSchema,
                     _logger);
                 trainResults.Add(trainResult);
             }

--- a/src/Microsoft.ML.AutoML/Experiment/Runners/RunnerUtil.cs
+++ b/src/Microsoft.ML.AutoML/Experiment/Runners/RunnerUtil.cs
@@ -15,6 +15,7 @@ namespace Microsoft.ML.AutoML
             SuggestedPipeline pipeline,
             IDataView trainData,
             IDataView validData,
+            string groupId,
             string labelColumn,
             IMetricsAgent<TMetrics> metricsAgent,
             ITransformer preprocessorTransform,
@@ -28,7 +29,7 @@ namespace Microsoft.ML.AutoML
                 var model = estimator.Fit(trainData);
 
                 var scoredData = model.Transform(validData);
-                var metrics = metricsAgent.EvaluateMetrics(scoredData, labelColumn);
+                var metrics = metricsAgent.EvaluateMetrics(scoredData, labelColumn, groupId);
                 var score = metricsAgent.GetScore(metrics);
 
                 if (preprocessorTransform != null)

--- a/src/Microsoft.ML.AutoML/Experiment/Runners/TrainValidateRunner.cs
+++ b/src/Microsoft.ML.AutoML/Experiment/Runners/TrainValidateRunner.cs
@@ -13,6 +13,7 @@ namespace Microsoft.ML.AutoML
         private readonly MLContext _context;
         private readonly IDataView _trainData;
         private readonly IDataView _validData;
+        private readonly string _groupIdColumn;
         private readonly string _labelColumn;
         private readonly IMetricsAgent<TMetrics> _metricsAgent;
         private readonly IEstimator<ITransformer> _preFeaturizer;
@@ -23,6 +24,7 @@ namespace Microsoft.ML.AutoML
         public TrainValidateRunner(MLContext context,
             IDataView trainData,
             IDataView validData,
+            string groupIdColumn,
             string labelColumn,
             IMetricsAgent<TMetrics> metricsAgent,
             IEstimator<ITransformer> preFeaturizer,
@@ -33,6 +35,7 @@ namespace Microsoft.ML.AutoML
             _trainData = trainData;
             _validData = validData;
             _labelColumn = labelColumn;
+            _groupIdColumn = groupIdColumn;
             _metricsAgent = metricsAgent;
             _preFeaturizer = preFeaturizer;
             _preprocessorTransform = preprocessorTransform;
@@ -44,7 +47,7 @@ namespace Microsoft.ML.AutoML
             Run(SuggestedPipeline pipeline, DirectoryInfo modelDirectory, int iterationNum)
         {
             var modelFileInfo = GetModelFileInfo(modelDirectory, iterationNum);
-            var trainResult = RunnerUtil.TrainAndScorePipeline(_context, pipeline, _trainData, _validData,
+            var trainResult = RunnerUtil.TrainAndScorePipeline(_context, pipeline, _trainData, _validData, _groupIdColumn,
                 _labelColumn, _metricsAgent, _preprocessorTransform, modelFileInfo, _modelInputSchema, _logger);
             var suggestedPipelineRunDetail = new SuggestedPipelineRunDetail<TMetrics>(pipeline,
                 trainResult.score,

--- a/src/Microsoft.ML.AutoML/Utils/BestResultUtil.cs
+++ b/src/Microsoft.ML.AutoML/Utils/BestResultUtil.cs
@@ -35,9 +35,10 @@ namespace Microsoft.ML.AutoML
         }
 
         public static RunDetail<RankingMetrics> GetBestRun(IEnumerable<RunDetail<RankingMetrics>> results,
-            RankingMetric metric, string groupIdColumnName)
+            RankingMetric metric)
         {
-            var metricsAgent = new RankingMetricsAgent(null, metric, groupIdColumnName);
+            var metricsAgent = new RankingMetricsAgent(null, metric);
+
             var metricInfo = new OptimizingMetricInfo(metric);
             return GetBestRun(results, metricsAgent, metricInfo.IsMaximizing);
         }

--- a/src/Microsoft.ML.AutoML/Utils/UserInputValidationUtil.cs
+++ b/src/Microsoft.ML.AutoML/Utils/UserInputValidationUtil.cs
@@ -61,7 +61,7 @@ namespace Microsoft.ML.AutoML
         {
             if (task == TaskKind.Ranking && samplingKeyColumnName != null && samplingKeyColumnName != groupIdColumnName)
             {
-                throw new ArgumentException($"{nameof(samplingKeyColumnName)} must be the same as {nameof(groupIdColumnName)}", samplingKeyColumnName);
+                throw new ArgumentException($"{nameof(samplingKeyColumnName)} must be the same as {nameof(groupIdColumnName)} for Ranking Experiments", samplingKeyColumnName);
             }
         }
 

--- a/src/Microsoft.ML.AutoML/Utils/UserInputValidationUtil.cs
+++ b/src/Microsoft.ML.AutoML/Utils/UserInputValidationUtil.cs
@@ -57,6 +57,14 @@ namespace Microsoft.ML.AutoML
             }
         }
 
+        public static void ValidateSamplingKey(string samplingKeyColumnName, string groupIdColumnName, TaskKind task)
+        {
+            if (task == TaskKind.Ranking && samplingKeyColumnName != null && samplingKeyColumnName != groupIdColumnName)
+            {
+                throw new ArgumentException($"{nameof(samplingKeyColumnName)} must be the same as {nameof(groupIdColumnName)}", samplingKeyColumnName);
+            }
+        }
+
         private static void ValidateTrainData(IDataView trainData, ColumnInformation columnInformation)
         {
             if (trainData == null)

--- a/src/Microsoft.ML.AutoML/Utils/UserInputValidationUtil.cs
+++ b/src/Microsoft.ML.AutoML/Utils/UserInputValidationUtil.cs
@@ -61,7 +61,7 @@ namespace Microsoft.ML.AutoML
         {
             if (task == TaskKind.Ranking && samplingKeyColumnName != null && samplingKeyColumnName != groupIdColumnName)
             {
-                throw new ArgumentException($"{nameof(samplingKeyColumnName)} must be the same as {nameof(groupIdColumnName)} for Ranking Experiments", samplingKeyColumnName);
+                throw new ArgumentException($"If provided, {nameof(samplingKeyColumnName)} must be the same as {nameof(groupIdColumnName)} for Ranking Experiments", samplingKeyColumnName);
             }
         }
 

--- a/src/Microsoft.ML.CodeGenerator/Templates/Console/ModelBuilder.cs
+++ b/src/Microsoft.ML.CodeGenerator/Templates/Console/ModelBuilder.cs
@@ -417,7 +417,7 @@ if("Regression".Equals(TaskType) || "Recommendation".Equals(TaskType)){
 
         public static void PrintRankingFoldsAverageMetrics(IEnumerable<TrainCatalogBase.CrossValidationResult<RankingMetrics>> crossValidationResults)
         {
-            var max = (crossValidationResults.First().Metrics.NormalizedDiscountedCumulativeGains.Count < 10) ? metrics.NormalizedDiscountedCumulativeGains.Count-1 : 9;
+            var max = (crossValidationResults.First().Metrics.NormalizedDiscountedCumulativeGains.Count < 10) ? crossValidationResults.First().Metrics.NormalizedDiscountedCumulativeGains.Count-1 : 9;
             var NDCG = crossValidationResults.Select(r => r.Metrics.NormalizedDiscountedCumulativeGains[max]);
             var DCG = crossValidationResults.Select(r => r.Metrics.DiscountedCumulativeGains[max]);
             Console.WriteLine($""*************************************************************************************************************"");

--- a/src/Microsoft.ML.CodeGenerator/Templates/Console/ModelBuilder.tt
+++ b/src/Microsoft.ML.CodeGenerator/Templates/Console/ModelBuilder.tt
@@ -336,7 +336,7 @@ else{#>
 
         public static void PrintRankingFoldsAverageMetrics(IEnumerable<TrainCatalogBase.CrossValidationResult<RankingMetrics>> crossValidationResults)
         {
-            var max = (crossValidationResults.First().Metrics.NormalizedDiscountedCumulativeGains.Count < 10) ? metrics.NormalizedDiscountedCumulativeGains.Count-1 : 9;
+            var max = (crossValidationResults.First().Metrics.NormalizedDiscountedCumulativeGains.Count < 10) ? crossValidationResults.First().Metrics.NormalizedDiscountedCumulativeGains.Count-1 : 9;
             var NDCG = crossValidationResults.Select(r => r.Metrics.NormalizedDiscountedCumulativeGains[max]);
             var DCG = crossValidationResults.Select(r => r.Metrics.DiscountedCumulativeGains[max]);
             Console.WriteLine($"*************************************************************************************************************");

--- a/src/Microsoft.ML.Data/DataLoadSave/DataOperationsCatalog.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/DataOperationsCatalog.cs
@@ -398,6 +398,7 @@ namespace Microsoft.ML
         /// <param name="testFraction">The fraction of data to go into the test set.</param>
         /// <param name="samplingKeyColumnName">Name of a column to use for grouping rows. If two examples share the same value of the <paramref name="samplingKeyColumnName"/>,
         /// they are guaranteed to appear in the same subset (train or test). This can be used to ensure no label leakage from the train to the test set.
+        /// Note that when performing a Ranking Experiment, the <paramref name="samplingKeyColumnName"/> must be the GroupId column.
         /// If <see langword="null"/> no row grouping will be performed.</param>
         /// <param name="seed">Seed for the random number generator used to select rows for the train-test split.</param>
         /// <example>
@@ -444,6 +445,7 @@ namespace Microsoft.ML
         /// <param name="numberOfFolds">Number of cross-validation folds.</param>
         /// <param name="samplingKeyColumnName">Name of a column to use for grouping rows. If two examples share the same value of the <paramref name="samplingKeyColumnName"/>,
         /// they are guaranteed to appear in the same subset (train or test). This can be used to ensure no label leakage from the train to the test set.
+        /// Note that when performing a Ranking Experiment, the <paramref name="samplingKeyColumnName"/> must be the GroupId column.
         /// If <see langword="null"/> no row grouping will be performed.</param>
         /// <param name="seed">Seed for the random number generator used to select rows for cross-validation folds.</param>
         /// <example>

--- a/src/Microsoft.ML.Data/Evaluators/RankingEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/RankingEvaluator.cs
@@ -63,7 +63,7 @@ namespace Microsoft.ML.Data
         /// </value>
         public const string GroupSummary = "GroupSummary";
 
-        private const string GroupId = "GroupId";
+        private const string GroupId = DefaultColumnNames.GroupId;
 
         private readonly int _truncationLevel;
         private readonly bool _groupSummary;

--- a/src/Microsoft.ML.Data/TrainCatalog.cs
+++ b/src/Microsoft.ML.Data/TrainCatalog.cs
@@ -685,7 +685,7 @@ namespace Microsoft.ML
         /// <param name="numberOfFolds">Number of cross-validation folds.</param>
         /// <param name="labelColumnName">The label column (for evaluation).</param>
         /// <param name="rowGroupColumnName">The name of the groupId column in <paramref name="data"/>, which is used to group rows.
-        /// This column will automatically be used as SamplingKeyColumn when splitting the data for Cross Validation, 
+        /// This column will automatically be used as SamplingKeyColumn when splitting the data for Cross Validation,
         /// as this is required by the ranking algorithms
         /// If <see langword="null"/> no row grouping will be performed. </param>
         /// <param name="seed">  Seed for the random number generator used to select rows for cross-validation folds.</param>

--- a/src/Microsoft.ML.Data/TrainCatalog.cs
+++ b/src/Microsoft.ML.Data/TrainCatalog.cs
@@ -685,8 +685,8 @@ namespace Microsoft.ML
         /// <param name="numberOfFolds">Number of cross-validation folds.</param>
         /// <param name="labelColumnName">The label column (for evaluation).</param>
         /// <param name="rowGroupColumnName">The name of the groupId column in <paramref name="data"/>, which is used to group rows.
-        /// While for other crossvalidation methods this column is called samplingKeyColumnName, ranking requires
-        /// this column to be <paramref name="rowGroupColumnName"/>.
+        /// This column will automatically be used as SamplingKeyColumn when splitting the data for Cross Validation, 
+        /// as this is required by the ranking algorithms
         /// If <see langword="null"/> no row grouping will be performed. </param>
         /// <param name="seed">  Seed for the random number generator used to select rows for cross-validation folds.</param>
         /// <returns>Per-fold results: metrics, models, scored datasets.</returns>

--- a/src/Microsoft.ML.Data/TrainCatalog.cs
+++ b/src/Microsoft.ML.Data/TrainCatalog.cs
@@ -677,25 +677,25 @@ namespace Microsoft.ML
 
         /// <summary>
         /// Run cross-validation over <paramref name="numberOfFolds"/> folds of <paramref name="data"/>, by fitting <paramref name="estimator"/>,
-        /// and respecting <paramref name="samplingKeyColumnName"/> if provided.
+        /// and respecting <paramref name="rowGroupColumnName"/>if provided.
         /// Then evaluate each sub-model against <paramref name="labelColumnName"/> and return metrics.
         /// </summary>
         /// <param name="data">The data to run cross-validation on.</param>
         /// <param name="estimator">The estimator to fit.</param>
         /// <param name="numberOfFolds">Number of cross-validation folds.</param>
         /// <param name="labelColumnName">The label column (for evaluation).</param>
-        /// <param name="samplingKeyColumnName">Name of a column to use for grouping rows. If two examples share the same value of the <paramref name="samplingKeyColumnName"/>,
-        /// they are guaranteed to appear in the same subset (train or test). This can be used to ensure no label leakage from the train to the test set.
-        /// If <see langword="null"/> no row grouping will be performed.</param>
-        /// <param name="rowGroupColumnName">The name of the groupId column in <paramref name="data"/>.</param>
-        /// <param name="seed">Seed for the random number generator used to select rows for cross-validation folds.</param>
+        /// <param name="rowGroupColumnName">The name of the groupId column in <paramref name="data"/>, which is used to group rows.
+        /// While for other crossvalidation methods this column is called samplingKeyColumnName, ranking requires
+        /// this column to be <paramref name="rowGroupColumnName"/>.
+        /// If <see langword="null"/> no row grouping will be performed. </param>
+        /// <param name="seed">  Seed for the random number generator used to select rows for cross-validation folds.</param>
         /// <returns>Per-fold results: metrics, models, scored datasets.</returns>
         public IReadOnlyList<CrossValidationResult<RankingMetrics>> CrossValidate(
             IDataView data, IEstimator<ITransformer> estimator, int numberOfFolds = 5, string labelColumnName = DefaultColumnNames.Label,
-            string samplingKeyColumnName = DefaultColumnNames.GroupId, string rowGroupColumnName = DefaultColumnNames.GroupId, int ? seed = null)
+            string rowGroupColumnName = DefaultColumnNames.GroupId, int ? seed = null)
         {
             Environment.CheckNonEmpty(labelColumnName, nameof(labelColumnName));
-            var result = CrossValidateTrain(data, estimator, numberOfFolds, samplingKeyColumnName, seed);
+            var result = CrossValidateTrain(data, estimator, numberOfFolds, rowGroupColumnName, seed);
             return result.Select(x => new CrossValidationResult<RankingMetrics>(x.Model,
                 Evaluate(x.Scores, labelColumnName, rowGroupColumnName), x.Scores, x.Fold)).ToArray();
         }

--- a/src/Microsoft.ML.LightGbm/LightGbmRankingTrainer.cs
+++ b/src/Microsoft.ML.LightGbm/LightGbmRankingTrainer.cs
@@ -179,7 +179,7 @@ namespace Microsoft.ML.Trainers.LightGbm
         /// <param name="env">The private instance of <see cref="IHostEnvironment"/>.</param>
         /// <param name="labelColumnName">The name of the label column.</param>
         /// <param name="featureColumnName">The name of the feature column.</param>
-        /// <param name="rowGroupdColumnName">The name of the column containing the group ID. </param>
+        /// <param name="rowGroupIdColumnName">The name of the column containing the group ID. </param>
         /// <param name="weightsColumnName">The name of the optional column containing the initial weights.</param>
         /// <param name="numberOfLeaves">The number of leaves to use.</param>
         /// <param name="learningRate">The learning rate.</param>
@@ -188,7 +188,7 @@ namespace Microsoft.ML.Trainers.LightGbm
         internal LightGbmRankingTrainer(IHostEnvironment env,
             string labelColumnName = DefaultColumnNames.Label,
             string featureColumnName = DefaultColumnNames.Features,
-            string rowGroupdColumnName = DefaultColumnNames.GroupId,
+            string rowGroupIdColumnName = DefaultColumnNames.GroupId,
             string weightsColumnName = null,
             int? numberOfLeaves = null,
             int? minimumExampleCountPerLeaf = null,
@@ -200,14 +200,14 @@ namespace Microsoft.ML.Trainers.LightGbm
                       LabelColumnName = labelColumnName,
                       FeatureColumnName = featureColumnName,
                       ExampleWeightColumnName = weightsColumnName,
-                      RowGroupColumnName = rowGroupdColumnName,
+                      RowGroupColumnName = rowGroupIdColumnName,
                       NumberOfLeaves = numberOfLeaves,
                       MinimumExampleCountPerLeaf = minimumExampleCountPerLeaf,
                       LearningRate = learningRate,
                       NumberOfIterations = numberOfIterations
                   })
         {
-            Host.CheckNonEmpty(rowGroupdColumnName, nameof(rowGroupdColumnName));
+            Host.CheckNonEmpty(rowGroupIdColumnName, nameof(rowGroupIdColumnName));
         }
 
         private protected override void CheckDataValid(IChannel ch, RoleMappedData data)

--- a/test/Microsoft.ML.AutoML.Tests/AutoFitTests.cs
+++ b/test/Microsoft.ML.AutoML.Tests/AutoFitTests.cs
@@ -125,7 +125,7 @@ namespace Microsoft.ML.AutoML.Test
         {
             string labelColumnName = "Label";
             string scoreColumnName = "Score";
-            string groupIdColumnName = "CustomGroupId";
+            string groupIdColumnName = "GroupId";
             string featuresColumnVectorNameA = "FeatureVectorA";
             string featuresColumnVectorNameB = "FeatureVectorB";
             var mlContext = new MLContext(1);
@@ -138,18 +138,18 @@ namespace Microsoft.ML.AutoML.Test
 
             // STEP 2: Run AutoML experiment
             var experiment = mlContext.Auto()
-                .CreateRankingExperiment(new RankingExperimentSettings() { GroupIdColumnName = groupIdColumnName, MaxExperimentTimeInSeconds = 5 });
+                .CreateRankingExperiment(5);
 
             ExperimentResult<RankingMetrics>[] experimentResults =
             {
                 experiment.Execute(trainDataView, labelColumnName, groupIdColumnName),
-                //experiment.Execute(trainDataView, testDataView),
+                experiment.Execute(trainDataView, testDataView),
                 experiment.Execute(trainDataView, testDataView,
-                    new ColumnInformation()
-                    {
-                        LabelColumnName = labelColumnName,
-                        GroupIdColumnName = groupIdColumnName,
-                    })
+                new ColumnInformation()
+                {
+                    LabelColumnName = labelColumnName,
+                    GroupIdColumnName = groupIdColumnName,
+                })
             };
 
             for (int i = 0; i < experimentResults.Length; i++)
@@ -179,10 +179,10 @@ namespace Microsoft.ML.AutoML.Test
             var mlContext = new MLContext(1);
             var reader = new TextLoader(mlContext, GetLoaderArgsRank(labelColumnName, groupIdColumnName,
                 featuresColumnVectorNameA, featuresColumnVectorNameB));
-            var trainDataView = reader.Load(new MultiFileSource(DatasetUtil.GetMLSRDataset()));
+            var trainDataView = reader.Load(DatasetUtil.GetMLSRDataset());
 
             var experiment = mlContext.Auto()
-                .CreateRankingExperiment(new RankingExperimentSettings() { GroupIdColumnName = groupIdColumnName, MaxExperimentTimeInSeconds = 5 });
+                .CreateRankingExperiment(5);
             CrossValidationExperimentResult<RankingMetrics>[] experimentResults =
             {
                 experiment.Execute(trainDataView, numFolds,

--- a/test/Microsoft.ML.AutoML.Tests/AutoFitTests.cs
+++ b/test/Microsoft.ML.AutoML.Tests/AutoFitTests.cs
@@ -76,7 +76,7 @@ namespace Microsoft.ML.AutoML.Test
             Assert.Equal(TextDataViewType.Instance, scoredData.Schema[DefaultColumnNames.PredictedLabel].Type);
         }
 
-        [Fact(Skip ="Takes too much time, ~10 minutes.")]
+        [Fact(Skip = "Takes too much time, ~10 minutes.")]
         public void AutoFitImageClassification()
         {
             // This test executes the code path that model builder code will take to get a model using image 
@@ -149,6 +149,13 @@ namespace Microsoft.ML.AutoML.Test
                 {
                     LabelColumnName = labelColumnName,
                     GroupIdColumnName = groupIdColumnName,
+                }),
+                experiment.Execute(trainDataView, testDataView,
+                new ColumnInformation()
+                {
+                    LabelColumnName = labelColumnName,
+                    GroupIdColumnName = groupIdColumnName,
+                    SamplingKeyColumnName = groupIdColumnName
                 })
             };
 
@@ -291,7 +298,7 @@ namespace Microsoft.ML.AutoML.Test
 
             var models = new[] { modelFull, modelTrainTest, modelCV };
 
-            foreach(var model in models)
+            foreach (var model in models)
             {
                 var resFull = model.Transform(dataFull);
                 var resTrainTest = model.Transform(dataTrainTest.TrainSet);

--- a/test/Microsoft.ML.AutoML.Tests/AutoFitTests.cs
+++ b/test/Microsoft.ML.AutoML.Tests/AutoFitTests.cs
@@ -186,7 +186,7 @@ namespace Microsoft.ML.AutoML.Test
         public void AutoFitRankingCV2Test()
         {
             string labelColumnName = "Label";
-            string groupIdColumnName = "GroupId";
+            string groupIdColumnName = "GroupIdCustom";
             string featuresColumnVectorNameA = "FeatureVectorA";
             string featuresColumnVectorNameB = "FeatureVectorB";
             uint numFolds = 3;

--- a/test/Microsoft.ML.AutoML.Tests/MetricsAgentsTests.cs
+++ b/test/Microsoft.ML.AutoML.Tests/MetricsAgentsTests.cs
@@ -127,14 +127,14 @@ namespace Microsoft.ML.AutoML.Test
             double[] ndcg = { 0.2, 0.3, 0.4 };
             double[] dcg = { 0.2, 0.3, 0.4 };
             var metrics = MetricsUtil.CreateRankingMetrics(dcg, ndcg);
-            Assert.Equal(0.4, GetScore(metrics, RankingMetric.Dcg, "GroupId"));
-            Assert.Equal(0.4, GetScore(metrics, RankingMetric.Ndcg, "GroupId"));
+            Assert.Equal(0.4, GetScore(metrics, RankingMetric.Dcg));
+            Assert.Equal(0.4, GetScore(metrics, RankingMetric.Ndcg));
 
             double[] largeNdcg = { 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.85, 0.9, 0.95 };
             double[] largeDcg = { 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.85, 0.9, 0.95 };
             metrics = MetricsUtil.CreateRankingMetrics(largeDcg, largeNdcg);
-            Assert.Equal(0.9, GetScore(metrics, RankingMetric.Dcg, "GroupId"));
-            Assert.Equal(0.9, GetScore(metrics, RankingMetric.Ndcg, "GroupId"));
+            Assert.Equal(0.9, GetScore(metrics, RankingMetric.Dcg));
+            Assert.Equal(0.9, GetScore(metrics, RankingMetric.Ndcg));
         }
 
         [Fact]
@@ -143,8 +143,8 @@ namespace Microsoft.ML.AutoML.Test
             double[] ndcg = { 0.2, 0.3, 0.4 };
             double[] dcg = { 0.2, 0.3, 0.4 };
             var metrics = MetricsUtil.CreateRankingMetrics(dcg, ndcg);
-            Assert.False(IsPerfectModel(metrics, RankingMetric.Dcg, "GroupId"));
-            Assert.False(IsPerfectModel(metrics, RankingMetric.Ndcg, "GroupId"));
+            Assert.False(IsPerfectModel(metrics, RankingMetric.Dcg));
+            Assert.False(IsPerfectModel(metrics, RankingMetric.Ndcg));
         }
 
         [Fact]
@@ -153,8 +153,8 @@ namespace Microsoft.ML.AutoML.Test
             double[] ndcg = { 0.2, 0.3, 1 };
             double[] dcg = { 0.2, 0.3, 1 };
             var metrics = MetricsUtil.CreateRankingMetrics(dcg, ndcg);
-            Assert.False(IsPerfectModel(metrics, RankingMetric.Dcg, "GroupId")); //REVIEW: No true Perfect model
-            Assert.True(IsPerfectModel(metrics, RankingMetric.Ndcg, "GroupId"));
+            Assert.False(IsPerfectModel(metrics, RankingMetric.Dcg)); //REVIEW: No true Perfect model
+            Assert.True(IsPerfectModel(metrics, RankingMetric.Ndcg));
         }
 
         [Fact]
@@ -179,9 +179,9 @@ namespace Microsoft.ML.AutoML.Test
             return new RegressionMetricsAgent(null, metric).GetScore(metrics);
         }
 
-        private static double GetScore(RankingMetrics metrics, RankingMetric metric, string groupIdColumnName)
+        private static double GetScore(RankingMetrics metrics, RankingMetric metric)
         {
-            return new RankingMetricsAgent(null, metric, groupIdColumnName).GetScore(metrics);
+            return new RankingMetricsAgent(null, metric).GetScore(metrics);
         }
 
         private static bool IsPerfectModel(BinaryClassificationMetrics metrics, BinaryClassificationMetric metric)
@@ -202,9 +202,9 @@ namespace Microsoft.ML.AutoML.Test
             return IsPerfectModel(metricsAgent, metrics);
         }
 
-        private static bool IsPerfectModel(RankingMetrics metrics, RankingMetric metric, string groupIdColumnName)
+        private static bool IsPerfectModel(RankingMetrics metrics, RankingMetric metric)
         {
-            var metricsAgent = new RankingMetricsAgent(null, metric, groupIdColumnName);
+            var metricsAgent = new RankingMetricsAgent(null, metric);
             return IsPerfectModel(metricsAgent, metrics);
         }
 

--- a/test/Microsoft.ML.CodeGenerator.Tests/ApprovalTests/ConsoleCodeGeneratorTests.ConsoleAppModelBuilderCSFileContentRankingTest.approved.txt
+++ b/test/Microsoft.ML.CodeGenerator.Tests/ApprovalTests/ConsoleCodeGeneratorTests.ConsoleAppModelBuilderCSFileContentRankingTest.approved.txt
@@ -11,7 +11,6 @@ using System.Linq;
 using Microsoft.ML;
 using Microsoft.ML.Data;
 using TestNamespace.Model;
-using Microsoft.ML.Trainers.LightGbm;
 
 namespace TestNamespace.ConsoleApp
 {
@@ -58,7 +57,7 @@ namespace TestNamespace.ConsoleApp
             // Data process configuration with pipeline data transformations 
             var dataProcessPipeline = mlContext.Transforms.Conversion.Hash("GroupId", "GroupId");
             // Set the training algorithm 
-            var trainer = mlContext.Ranking.Trainers.LightGbm(new LightGbmRankingTrainer.Options() { rowGroupColumnName = "GroupId", LabelColumnName = "Label", FeatureColumnName = "Features" });
+            var trainer = mlContext.Ranking.Trainers.LightGbm(rowGroupColumnName: "GroupId", labelColumnName: "Label", featureColumnName: "Features");
 
             var trainingPipeline = dataProcessPipeline.Append(trainer);
 
@@ -115,7 +114,7 @@ namespace TestNamespace.ConsoleApp
 
         public static void PrintRankingFoldsAverageMetrics(IEnumerable<TrainCatalogBase.CrossValidationResult<RankingMetrics>> crossValidationResults)
         {
-            var max = (crossValidationResults.First().Metrics.NormalizedDiscountedCumulativeGains.Count < 10) ? metrics.NormalizedDiscountedCumulativeGains.Count - 1 : 9;
+            var max = (crossValidationResults.First().Metrics.NormalizedDiscountedCumulativeGains.Count < 10) ? crossValidationResults.First().Metrics.NormalizedDiscountedCumulativeGains.Count - 1 : 9;
             var NDCG = crossValidationResults.Select(r => r.Metrics.NormalizedDiscountedCumulativeGains[max]);
             var DCG = crossValidationResults.Select(r => r.Metrics.DiscountedCumulativeGains[max]);
             Console.WriteLine($"*************************************************************************************************************");

--- a/test/Microsoft.ML.CodeGenerator.Tests/ApprovalTests/ConsoleCodeGeneratorTests.cs
+++ b/test/Microsoft.ML.CodeGenerator.Tests/ApprovalTests/ConsoleCodeGeneratorTests.cs
@@ -623,10 +623,9 @@ namespace mlnet.Tests
         {
             if (_mockedPipeline == null)
             {
-                MLContext context = new MLContext();
                 var hyperParam = new Dictionary<string, object>()
                 {
-                    {"rowGroupColumnName","GroupId" },
+                    {"RowGroupColumnName","GroupId" },
                     {"LabelColumnName","Label" },
                 };
                 var hashPipelineNode = new PipelineNode(nameof(EstimatorName.Hashing), PipelineNodeType.Transform, "GroupId", "GroupId");

--- a/test/Microsoft.ML.Functional.Tests/Validation.cs
+++ b/test/Microsoft.ML.Functional.Tests/Validation.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Linq;
 using Microsoft.ML.Data;
 using Microsoft.ML.Functional.Tests.Datasets;
@@ -54,13 +55,17 @@ namespace Microsoft.ML.Functional.Tests
         }
 
         [Fact]
-        public void AutoFitRankingCVTest()
+        public void RankingCVTest()
         {
             string labelColumnName = "Label";
             string groupIdColumnName = "GroupId";
             string featuresColumnVectorNameA = "FeatureVectorA";
             string featuresColumnVectorNameB = "FeatureVectorB";
             int numFolds = 3;
+
+            // LightGBM is not supported on x86 machines
+            if (!Environment.Is64BitProcess)
+                return;
 
             var mlContext = new MLContext(1);
             var dataProcessPipeline = mlContext.Transforms.Concatenate("Features", new[] { "FeatureVectorA", "FeatureVectorB" }).Append(

--- a/test/Microsoft.ML.Functional.Tests/Validation.cs
+++ b/test/Microsoft.ML.Functional.Tests/Validation.cs
@@ -2,11 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Linq;
 using Microsoft.ML.Data;
 using Microsoft.ML.Functional.Tests.Datasets;
 using Microsoft.ML.TestFrameworkCommon;
 using Microsoft.ML.Trainers;
 using Microsoft.ML.Trainers.FastTree;
+using Microsoft.ML.Trainers.LightGbm;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -49,6 +51,42 @@ namespace Microsoft.ML.Functional.Tests
             // And validate the metrics.
             foreach (var result in cvResult)
                 Common.AssertMetrics(result.Metrics);
+        }
+
+        [Fact]
+        public void AutoFitRankingCVTest()
+        {
+            string labelColumnName = "Label";
+            string groupIdColumnName = "GroupId";
+            string featuresColumnVectorNameA = "FeatureVectorA";
+            string featuresColumnVectorNameB = "FeatureVectorB";
+            int numFolds = 3;
+
+            var mlContext = new MLContext(1);
+            var dataProcessPipeline = mlContext.Transforms.Concatenate("Features", new[] { "FeatureVectorA", "FeatureVectorB" }).Append(
+                mlContext.Transforms.Conversion.Hash("GroupId", "GroupId"));
+
+            var trainer = mlContext.Ranking.Trainers.LightGbm(new LightGbmRankingTrainer.Options() { RowGroupColumnName = "GroupId", LabelColumnName = "Label", FeatureColumnName = "Features" });
+            var reader = mlContext.Data.CreateTextLoader(new TextLoader.Options()
+            {
+                Separators = new[] { '\t' },
+                HasHeader = true,
+                Columns = new[]
+                {
+                    new TextLoader.Column(labelColumnName, DataKind.Single, 0),
+                    new TextLoader.Column(groupIdColumnName, DataKind.Int32, 1),
+                    new TextLoader.Column(featuresColumnVectorNameA, DataKind.Single, 2, 9),
+                    new TextLoader.Column(featuresColumnVectorNameB, DataKind.Single, 10, 137)
+                }
+            });
+            var trainDataView = reader.Load(TestCommon.GetDataPath(DataDir, "MSLRWeb1K-tiny.tsv"));
+            var trainingPipeline = dataProcessPipeline.Append(trainer);
+            var result = mlContext.Ranking.CrossValidate(trainDataView, trainingPipeline, numberOfFolds: numFolds);
+            for (int i = 0; i < numFolds; i++)
+            {
+                Assert.True(result[i].Metrics.NormalizedDiscountedCumulativeGains.Max() > .4);
+                Assert.True(result[i].Metrics.DiscountedCumulativeGains.Max() > 16);
+            }
         }
 
         /// <summary>

--- a/test/Microsoft.ML.Functional.Tests/Validation.cs
+++ b/test/Microsoft.ML.Functional.Tests/Validation.cs
@@ -63,15 +63,12 @@ namespace Microsoft.ML.Functional.Tests
             string featuresColumnVectorNameB = "FeatureVectorB";
             int numFolds = 3;
 
-            // LightGBM is not supported on x86 machines
-            if (!Environment.Is64BitProcess)
-                return;
-
             var mlContext = new MLContext(1);
             var dataProcessPipeline = mlContext.Transforms.Concatenate("Features", new[] { "FeatureVectorA", "FeatureVectorB" }).Append(
                 mlContext.Transforms.Conversion.Hash("GroupId", "GroupId"));
 
-            var trainer = mlContext.Ranking.Trainers.LightGbm(new LightGbmRankingTrainer.Options() { RowGroupColumnName = "GroupId", LabelColumnName = "Label", FeatureColumnName = "Features" });
+            var trainer = mlContext.Ranking.Trainers.FastTree(new FastTreeRankingTrainer.Options()
+            { RowGroupColumnName = "GroupId", LabelColumnName = "Label", FeatureColumnName = "Features" });
             var reader = mlContext.Data.CreateTextLoader(new TextLoader.Options()
             {
                 Separators = new[] { '\t' },


### PR DESCRIPTION
- Enabled Ranking Cross Validation 
- Fixed some syntax errors in the ranking CodeGen generated code

**Issue**:  Cross Validation is needed in order to integrate the AutoML Ranking Experiment with ModelBuilder. 
**Resolves:** #2685 

User Scenarios: 
- If the user doesn't provide a `GroupIdColumnName`, the default becomes "GroupId". This is used as the `SamplingKeyColumn` used to split the data. 

- If the user provides both a `GroupIdColumnName` and a `SamplingKeyColumnName`, both most be the same or an exception is thrown. 

**Review**: If the user only provides a `SamplingKeyColumnName`, should we throw an error. Since we use the groupId to split the CV data, the user should not be populating the `SamplingKeyColumnName`. As of right now, an error is only thrown when the `GroupIdColumnName` and a `SamplingKeyColumnName` differ. 
