### PR TITLE
make timeout larger as we are seeing timeouts in CI

### DIFF
--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -16,9 +16,9 @@ jobs:
     ${{ if eq(parameters.nightlyBuild, 'true') }}:
       timeoutInMinutes: 30
     ${{ if and(eq(parameters.nightlyBuild, 'false'), eq(parameters.codeCoverage, 'false')) }}:
-      timeoutInMinutes: 75
+      timeoutInMinutes: 90
     ${{ if eq(parameters.codeCoverage, 'true') }}:
-      timeoutInMinutes: 100
+      timeoutInMinutes: 120
     cancelTimeoutInMinutes: 10
     variables:
       dotnetPath: $(Build.SourcesDirectory)/Tools/dotnetcli/dotnet


### PR DESCRIPTION
we start to seeing timeouts in CI build so make the timeout larger, this is caused by sometimes download tensorflow meta files are slow(takes more than 10 minutes but normally this takes less than 1 minute), also CI tests runs slow than before:

https://dev.azure.com/dnceng/public/_build/results?buildId=689649&view=logs&j=dd8eddb6-ecc6-5f65-73e6-df90e5693b94
https://dev.azure.com/dnceng/public/_build/results?buildId=706453&view=logs&j=87172896-2df6-55a2-04c3-60b48f00f19f
