### PR TITLE
Fix for conditional error in root cause analysis additions

### DIFF
--- a/src/Microsoft.ML.TimeSeries/RootCauseAnalyzer.cs
+++ b/src/Microsoft.ML.TimeSeries/RootCauseAnalyzer.cs
@@ -481,7 +481,8 @@ namespace Microsoft.ML.TimeSeries
             List<BestDimension> ordered = new List<BestDimension>();
 
             BestDimension best;
-            do {
+            do
+            {
                 best = null;
 
                 foreach (KeyValuePair<BestDimension, double> dimension in valueMapAsList)
@@ -492,7 +493,7 @@ namespace Microsoft.ML.TimeSeries
                         {
                             best = dimension.Key;
                         }
-                        else if (dimension.Key.AnomalyDis.Count == 1)
+                        else
                         {
                             bool isRatioNan = Double.IsNaN(valueRatioMap[best]);
                             if (dimension.Key.AnomalyDis.Count > 1)
@@ -507,7 +508,7 @@ namespace Microsoft.ML.TimeSeries
 
                                 if (best.AnomalyDis.Count > 1)
                                 {
-                                    best = GetBestDimension(best, dimension, valueRatioMap);
+                                    best = dimension.Key;
                                 }
                                 else if (best.AnomalyDis.Count == 1)
                                 {


### PR DESCRIPTION
Fix for error in refactoring RCA code. This establishes the same logic in the `OrderDimensions` code as in the previous version, cf. https://github.com/dotnet/machinelearning/blob/1c2469fb8c99afa45531fa9ecca67598291a2288/src/Microsoft.ML.TimeSeries/RootCauseAnalyzer.cs#L460



