### PR TITLE
Properly normalize column names in Utils.GetSampleData() for duplicate cases

### DIFF
--- a/src/Microsoft.ML.CodeGenerator/Microsoft.ML.CodeGenerator.csproj
+++ b/src/Microsoft.ML.CodeGenerator/Microsoft.ML.CodeGenerator.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <PackageReference Include="System.CodeDom" Version="$(SystemCodeDomPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisCSharpVersion)" />
+    <PackageReference Include="System.Collections.Specialized" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.ML.CodeGenerator.Tests/UtilTest.cs
+++ b/test/Microsoft.ML.CodeGenerator.Tests/UtilTest.cs
@@ -56,6 +56,57 @@ namespace Microsoft.ML.CodeGenerator.Tests
         public bool T { get; set; }
     }
 
+    class TestClassContainsDuplicates
+    {
+        [LoadColumn(0)]
+        public string Label_col_0 { get; set; }
+
+        [LoadColumn(1)]
+        public string STR_col_1 { get; set; }
+
+        [LoadColumn(2)]
+        public string STR_col_2 { get; set; }
+
+        [LoadColumn(3)]
+        public string PATH_col_3 { get; set; }
+
+        [LoadColumn(4)]
+        public int INT_col_4 { get; set; }
+
+        [LoadColumn(5)]
+        public Double DOUBLE_col_5 { get; set; }
+
+        [LoadColumn(6)]
+        public float FLOAT_col_6 { get; set; }
+
+        [LoadColumn(7)]
+        public float FLOAT_col_7 { get; set; }
+
+        [LoadColumn(8)]
+        public string TrickySTR_col_8 { get; set; }
+
+        [LoadColumn(9)]
+        public float SingleNan_col_9 { get; set; }
+
+        [LoadColumn(10)]
+        public float SinglePositiveInfinity_col_10 { get; set; }
+
+        [LoadColumn(11)]
+        public float SingleNegativeInfinity_col_11 { get; set; }
+
+        [LoadColumn(12)]
+        public float SingleNegativeInfinity_col_12 { get; set; }
+
+        [LoadColumn(13)]
+        public string EmptyString_col_13 { get; set; }
+
+        [LoadColumn(14)]
+        public bool One_col_14 { get; set; }
+
+        [LoadColumn(15)]
+        public bool T_col_15 { get; set; }
+    }
+
     public class UtilTest : BaseTestClass
     {
         public UtilTest(ITestOutputHelper output) : base(output)
@@ -94,6 +145,44 @@ namespace Microsoft.ML.CodeGenerator.Tests
                 Assert.Equal("@\"\"", sampleData["EmptyString"]);
                 Assert.Equal($"true", sampleData["One"]);
                 Assert.Equal($"true", sampleData["T"]);
+            }
+        }
+
+        [Fact]
+        public async Task TestGenerateSampleDataAsyncDuplicateColumnNames()
+        {
+            var filePath = "sample2.txt";
+            using (var file = new StreamWriter(filePath))
+            {
+                await file.WriteLineAsync("Label,STR,STR,PATH,INT,DOUBLE,FLOAT,FLOAT,TrickySTR,SingleNan,SinglePositiveInfinity,SingleNegativeInfinity,SingleNegativeInfinity,EmptyString,One,T");
+                await file.WriteLineAsync("label1,feature1,feature2,/path/to/file,2,1.2,1.223E+10,1.223E+11,ab\"\';@#$%^&-++==,NaN,Infinity,-Infinity,-Infinity,,1,T");
+                await file.FlushAsync();
+                file.Close();
+                var context = new MLContext();
+                var dataView = context.Data.LoadFromTextFile<TestClassContainsDuplicates>(filePath, separatorChar: ',', hasHeader: true);
+                var columnInference = new ColumnInferenceResults()
+                {
+                    ColumnInformation = new ColumnInformation()
+                    {
+                        LabelColumnName = "Label_col_0"
+                    }
+                };
+                var sampleData = Utils.GenerateSampleData(dataView, columnInference);
+                Assert.Equal("@\"feature1\"", sampleData["STR_col_1"]);
+                Assert.Equal("@\"feature2\"", sampleData["STR_col_2"]);
+                Assert.Equal("@\"/path/to/file\"", sampleData["PATH_col_3"]);
+                Assert.Equal("2", sampleData["INT_col_4"]);
+                Assert.Equal("1.2", sampleData["DOUBLE_col_5"]);
+                Assert.Equal("1.223E+10F", sampleData["FLOAT_col_6"]);
+                Assert.Equal("1.223E+11F", sampleData["FLOAT_col_7"]);
+                Assert.Equal("@\"ab\\\"\';@#$%^&-++==\"", sampleData["TrickySTR_col_8"]);
+                Assert.Equal($"Single.NaN", sampleData["SingleNan_col_9"]);
+                Assert.Equal($"Single.PositiveInfinity", sampleData["SinglePositiveInfinity_col_10"]);
+                Assert.Equal($"Single.NegativeInfinity", sampleData["SingleNegativeInfinity_col_11"]);
+                Assert.Equal($"Single.NegativeInfinity", sampleData["SingleNegativeInfinity_col_12"]);
+                Assert.Equal("@\"\"", sampleData["EmptyString_col_13"]);
+                Assert.Equal($"true", sampleData["One_col_14"]);
+                Assert.Equal($"true", sampleData["T_col_15"]);
             }
         }
 


### PR DESCRIPTION
Fix #5267 

This PR fixes the bug where columns generated from inline data were normalized directly through `Utils.Normalize()`, which only fixes the naming of a given column name, but **does not** take into account duplicate column names that may exist in a dataset.

PR #5177 introduced a way to fix these duplicate column names by adding the differentiator suffix '_col_x' where 'x' represents the the dataset load order for a given column. In this PR I have separated this generation of distinct and unique column names from `Utils.GenerateClassLabels()` and made it into its own function to `Utils.GenerateColumnNames()`. This is so that this generation of distinct and unique column names can also be used in `Utils.GenerateSampleData`, which before this PR resulted in exceptions. Now, column names from inline data are properly normalized, and duplicate column names are handled.

This PR also adds a unit test to test the case of duplicate column names with `Utils.GenerateSampleData`.