### PR TITLE
[Issue4484] Support specifying command timeout while using the database loader

### DIFF
--- a/src/Microsoft.ML.Data/DataLoadSave/Database/DatabaseLoaderCursor.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Database/DatabaseLoaderCursor.cs
@@ -75,9 +75,9 @@ namespace Microsoft.ML.Data
                     {
                         _command = Connection.CreateCommand();
                         _command.CommandText = _source.CommandText;
-                        if (_source.CommandTimeOut.HasValue)
+                        if (_source.CommandTimeOutInSeconds.HasValue)
                         {
-                            _command.CommandTimeout = _source.CommandTimeOut.Value;
+                            _command.CommandTimeout = _source.CommandTimeOutInSeconds.Value;
                         }
                     }
                     return _command;

--- a/src/Microsoft.ML.Data/DataLoadSave/Database/DatabaseLoaderCursor.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Database/DatabaseLoaderCursor.cs
@@ -75,6 +75,10 @@ namespace Microsoft.ML.Data
                     {
                         _command = Connection.CreateCommand();
                         _command.CommandText = _source.CommandText;
+                        if (_source.CommandTimeOut is {})
+                        {
+                            _command.CommandTimeout = _source.CommandTimeOut;
+                        }
                     }
                     return _command;
                 }

--- a/src/Microsoft.ML.Data/DataLoadSave/Database/DatabaseLoaderCursor.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Database/DatabaseLoaderCursor.cs
@@ -75,10 +75,7 @@ namespace Microsoft.ML.Data
                     {
                         _command = Connection.CreateCommand();
                         _command.CommandText = _source.CommandText;
-                        if (_source.CommandTimeOutInSeconds.HasValue)
-                        {
-                            _command.CommandTimeout = _source.CommandTimeOutInSeconds.Value;
-                        }
+                        _command.CommandTimeout = _source.CommandTimeoutInSeconds;
                     }
                     return _command;
                 }

--- a/src/Microsoft.ML.Data/DataLoadSave/Database/DatabaseLoaderCursor.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Database/DatabaseLoaderCursor.cs
@@ -75,9 +75,9 @@ namespace Microsoft.ML.Data
                     {
                         _command = Connection.CreateCommand();
                         _command.CommandText = _source.CommandText;
-                        if (_source.CommandTimeOut is {})
+                        if (_source.CommandTimeOut.HasValue)
                         {
-                            _command.CommandTimeout = _source.CommandTimeOut;
+                            _command.CommandTimeout = _source.CommandTimeOut.Value;
                         }
                     }
                     return _command;

--- a/src/Microsoft.ML.Data/DataLoadSave/Database/DatabaseSource.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Database/DatabaseSource.cs
@@ -10,7 +10,8 @@ namespace Microsoft.ML.Data
     /// <summary>Exposes the data required for opening a database for reading.</summary>
     public sealed class DatabaseSource
     {
-        public static readonly int DefaultCommandTimeoutInSeconds = 30;
+        private const int DefaultCommandTimeoutInSeconds = 30;
+
         /// <summary>Creates a new instance of the <see cref="DatabaseSource" /> class.</summary>
         /// <param name="providerFactory">The factory used to create the <see cref="DbConnection"/>..</param>
         /// <param name="connectionString">The string used to open the connection.</param>

--- a/src/Microsoft.ML.Data/DataLoadSave/Database/DatabaseSource.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Database/DatabaseSource.cs
@@ -25,6 +25,26 @@ namespace Microsoft.ML.Data
             CommandText = commandText;
         }
 
+        /// <summary>Creates a new instance of the <see cref="DatabaseSource" /> class.</summary>
+        /// <param name="providerFactory">The factory used to create the <see cref="DbConnection"/>..</param>
+        /// <param name="connectionString">The string used to open the connection.</param>
+        /// <param name="commandText">The text command to run against the data source.</param>
+        /// <param name="commandTimeOut">The text command to run against the data source.</param>
+        public DatabaseSource(DbProviderFactory providerFactory, string connectionString, string commandText, int commandTimeOut)
+        {
+            Contracts.CheckValue(providerFactory, nameof(providerFactory));
+            Contracts.CheckValue(connectionString, nameof(connectionString));
+            Contracts.CheckValue(commandText, nameof(commandText));
+
+            ProviderFactory = providerFactory;
+            ConnectionString = connectionString;
+            CommandText = commandText;
+            CommandTimeOut = commandTimeOut;
+        }
+
+        /// <summary>Gets the timeout for database command.</summary>
+        public int CommandTimeOut { get; }
+
         /// <summary>Gets the text command to run against the data source.</summary>
         public string CommandText { get; }
 

--- a/src/Microsoft.ML.Data/DataLoadSave/Database/DatabaseSource.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Database/DatabaseSource.cs
@@ -10,35 +10,36 @@ namespace Microsoft.ML.Data
     /// <summary>Exposes the data required for opening a database for reading.</summary>
     public sealed class DatabaseSource
     {
+        public static readonly int DefaultCommandTimeoutInSeconds = 30;
         /// <summary>Creates a new instance of the <see cref="DatabaseSource" /> class.</summary>
         /// <param name="providerFactory">The factory used to create the <see cref="DbConnection"/>..</param>
         /// <param name="connectionString">The string used to open the connection.</param>
         /// <param name="commandText">The text command to run against the data source.</param>
-        public DatabaseSource(DbProviderFactory providerFactory, string connectionString, string commandText)
+        public DatabaseSource(DbProviderFactory providerFactory, string connectionString, string commandText) :
+            this(providerFactory, connectionString, commandText, DefaultCommandTimeoutInSeconds)
+        {
+        }
+
+        /// <summary>Creates a new instance of the <see cref="DatabaseSource" /> class.</summary>
+        /// <param name="providerFactory">The factory used to create the <see cref="DbConnection"/>..</param>
+        /// <param name="connectionString">The string used to open the connection.</param>
+        /// <param name="commandText">The text command to run against the data source.</param>
+        /// <param name="commandTimeoutInSeconds">The timeout(in seconds) for database command.</param>
+        public DatabaseSource(DbProviderFactory providerFactory, string connectionString, string commandText, int commandTimeoutInSeconds)
         {
             Contracts.CheckValue(providerFactory, nameof(providerFactory));
             Contracts.CheckValue(connectionString, nameof(connectionString));
             Contracts.CheckValue(commandText, nameof(commandText));
+            Contracts.CheckUserArg(commandTimeoutInSeconds >= 0, nameof(commandTimeoutInSeconds));
 
             ProviderFactory = providerFactory;
             ConnectionString = connectionString;
             CommandText = commandText;
-        }
-
-        /// <summary>Creates a new instance of the <see cref="DatabaseSource" /> class.</summary>
-        /// <param name="providerFactory">The factory used to create the <see cref="DbConnection"/>..</param>
-        /// <param name="connectionString">The string used to open the connection.</param>
-        /// <param name="commandText">The text command to run against the data source.</param>
-        /// <param name="commandTimeOutInSeconds">The timeout(in seconds) for database command.</param>
-        public DatabaseSource(DbProviderFactory providerFactory, string connectionString, string commandText, int commandTimeOutInSeconds) :
-            this(providerFactory, connectionString, commandText)
-        {
-            Contracts.CheckUserArg(commandTimeOutInSeconds >= 0, nameof(commandTimeOutInSeconds));
-            CommandTimeOutInSeconds = commandTimeOutInSeconds;
+            CommandTimeoutInSeconds = commandTimeoutInSeconds;
         }
 
         /// <summary>Gets the timeout for database command.</summary>
-        public int? CommandTimeOutInSeconds { get; }
+        public int CommandTimeoutInSeconds { get; }
 
         /// <summary>Gets the text command to run against the data source.</summary>
         public string CommandText { get; }

--- a/src/Microsoft.ML.Data/DataLoadSave/Database/DatabaseSource.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Database/DatabaseSource.cs
@@ -43,7 +43,7 @@ namespace Microsoft.ML.Data
         }
 
         /// <summary>Gets the timeout for database command.</summary>
-        public int CommandTimeOut { get; }
+        public int? CommandTimeOut { get; }
 
         /// <summary>Gets the text command to run against the data source.</summary>
         public string CommandText { get; }

--- a/src/Microsoft.ML.Data/DataLoadSave/Database/DatabaseSource.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Database/DatabaseSource.cs
@@ -29,7 +29,7 @@ namespace Microsoft.ML.Data
         /// <param name="providerFactory">The factory used to create the <see cref="DbConnection"/>..</param>
         /// <param name="connectionString">The string used to open the connection.</param>
         /// <param name="commandText">The text command to run against the data source.</param>
-        /// <param name="commandTimeOut">The text command to run against the data source.</param>
+        /// <param name="commandTimeOut">The timeout(in seconds) for database command.</param>
         public DatabaseSource(DbProviderFactory providerFactory, string connectionString, string commandText, int commandTimeOut)
         {
             Contracts.CheckValue(providerFactory, nameof(providerFactory));

--- a/src/Microsoft.ML.Data/DataLoadSave/Database/DatabaseSource.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Database/DatabaseSource.cs
@@ -29,21 +29,16 @@ namespace Microsoft.ML.Data
         /// <param name="providerFactory">The factory used to create the <see cref="DbConnection"/>..</param>
         /// <param name="connectionString">The string used to open the connection.</param>
         /// <param name="commandText">The text command to run against the data source.</param>
-        /// <param name="commandTimeOut">The timeout(in seconds) for database command.</param>
-        public DatabaseSource(DbProviderFactory providerFactory, string connectionString, string commandText, int commandTimeOut)
+        /// <param name="commandTimeOutInSeconds">The timeout(in seconds) for database command.</param>
+        public DatabaseSource(DbProviderFactory providerFactory, string connectionString, string commandText, int commandTimeOutInSeconds) :
+            this(providerFactory, connectionString, commandText)
         {
-            Contracts.CheckValue(providerFactory, nameof(providerFactory));
-            Contracts.CheckValue(connectionString, nameof(connectionString));
-            Contracts.CheckValue(commandText, nameof(commandText));
-
-            ProviderFactory = providerFactory;
-            ConnectionString = connectionString;
-            CommandText = commandText;
-            CommandTimeOut = commandTimeOut;
+            Contracts.CheckUserArg(commandTimeOutInSeconds >= 0, nameof(commandTimeOutInSeconds));
+            CommandTimeOutInSeconds = commandTimeOutInSeconds;
         }
 
         /// <summary>Gets the timeout for database command.</summary>
-        public int? CommandTimeOut { get; }
+        public int? CommandTimeOutInSeconds { get; }
 
         /// <summary>Gets the text command to run against the data source.</summary>
         public string CommandText { get; }

--- a/test/Microsoft.ML.Tests/DatabaseLoaderTests.cs
+++ b/test/Microsoft.ML.Tests/DatabaseLoaderTests.cs
@@ -35,9 +35,11 @@ namespace Microsoft.ML.Tests
         [LightGBMFact]
         public void IrisLightGbmWithTimeOut()
         {
-            DatabaseSource dbs = GetIrisDatabaseSourceWithTimeOut("WAITFOR DELAY '00:00:01'; SELECT * FROM {0}", 1);
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) //sqlite does not have built-in command for sleep
+                return;
+            DatabaseSource dbs = GetIrisDatabaseSource("WAITFOR DELAY '00:00:01'; SELECT * FROM {0}", 1);
             var ex = Assert.Throws<System.Reflection.TargetInvocationException>(() => IrisLightGbmImpl(dbs));
-            Assert.Contains("Timeout expired", ex.InnerException.Message);
+            Assert.Contains("Timeout", ex.InnerException.Message);
         }
 
         private void IrisLightGbmImpl(DatabaseSource dbs)
@@ -225,34 +227,20 @@ namespace Microsoft.ML.Tests
         /// SQLite database is used on Linux and MacOS builds.
         /// </summary>
         /// <returns>Return the appropiate Iris DatabaseSource according to build OS.</returns>
-        private DatabaseSource GetIrisDatabaseSource(string command)
-        {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                return new DatabaseSource(
-                    SqlClientFactory.Instance,
-                    GetMSSQLConnectionString(TestDatasets.irisDb.name),
-                    String.Format(command, $@"""{TestDatasets.irisDb.trainFilename}"""));
-            else
-                return new DatabaseSource(
-                    SQLiteFactory.Instance,
-                    GetSQLiteConnectionString(TestDatasets.irisDbSQLite.name),
-                    String.Format(command, TestDatasets.irisDbSQLite.trainFilename));
-        }
-
-        private DatabaseSource GetIrisDatabaseSourceWithTimeOut(string command, int commandTimeOut)
+        private DatabaseSource GetIrisDatabaseSource(string command, int commandTimeOutInSeconds = 30)
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 return new DatabaseSource(
                     SqlClientFactory.Instance,
                     GetMSSQLConnectionString(TestDatasets.irisDb.name),
                     String.Format(command, $@"""{TestDatasets.irisDb.trainFilename}"""),
-                    commandTimeOut);
+                    commandTimeOutInSeconds);
             else
                 return new DatabaseSource(
                     SQLiteFactory.Instance,
                     GetSQLiteConnectionString(TestDatasets.irisDbSQLite.name),
                     String.Format(command, TestDatasets.irisDbSQLite.trainFilename),
-                    commandTimeOut);
+                    commandTimeOutInSeconds);
         }
 
         private string GetMSSQLConnectionString(string databaseName)

--- a/test/Microsoft.ML.Tests/DatabaseLoaderTests.cs
+++ b/test/Microsoft.ML.Tests/DatabaseLoaderTests.cs
@@ -38,7 +38,6 @@ namespace Microsoft.ML.Tests
             DatabaseSource dbs = GetIrisDatabaseSourceWithTimeOut("WAITFOR DELAY '00:00:05'; SELECT * FROM {0}", 1);
             var ex = Assert.Throws<System.Reflection.TargetInvocationException>(() => IrisLightGbmImpl(dbs));
             Assert.Contains("Timeout expired", ex.InnerException.Message);
-
         }
 
         private void IrisLightGbmImpl(DatabaseSource dbs)

--- a/test/Microsoft.ML.Tests/DatabaseLoaderTests.cs
+++ b/test/Microsoft.ML.Tests/DatabaseLoaderTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.ML.Tests
         [LightGBMFact]
         public void IrisLightGbmWithTimeOut()
         {
-            DatabaseSource dbs = GetIrisDatabaseSourceWithTimeOut("WAITFOR DELAY '00:00:05'; SELECT * FROM {0}", 1);
+            DatabaseSource dbs = GetIrisDatabaseSourceWithTimeOut("WAITFOR DELAY '00:00:01'; SELECT * FROM {0}", 1);
             var ex = Assert.Throws<System.Reflection.TargetInvocationException>(() => IrisLightGbmImpl(dbs));
             Assert.Contains("Timeout expired", ex.InnerException.Message);
         }

--- a/test/Microsoft.ML.Tests/DatabaseLoaderTests.cs
+++ b/test/Microsoft.ML.Tests/DatabaseLoaderTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.ML.Tests
         }
 
         [LightGBMFact]
-        public void IrisLightGbmWithTimeOut()
+        public void IrisLightGbmWithTimeout()
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) //sqlite does not have built-in command for sleep
                 return;
@@ -227,20 +227,20 @@ namespace Microsoft.ML.Tests
         /// SQLite database is used on Linux and MacOS builds.
         /// </summary>
         /// <returns>Return the appropiate Iris DatabaseSource according to build OS.</returns>
-        private DatabaseSource GetIrisDatabaseSource(string command, int commandTimeOutInSeconds = 30)
+        private DatabaseSource GetIrisDatabaseSource(string command, int commandTimeoutInSeconds = 30)
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 return new DatabaseSource(
                     SqlClientFactory.Instance,
                     GetMSSQLConnectionString(TestDatasets.irisDb.name),
                     String.Format(command, $@"""{TestDatasets.irisDb.trainFilename}"""),
-                    commandTimeOutInSeconds);
+                    commandTimeoutInSeconds);
             else
                 return new DatabaseSource(
                     SQLiteFactory.Instance,
                     GetSQLiteConnectionString(TestDatasets.irisDbSQLite.name),
                     String.Format(command, TestDatasets.irisDbSQLite.trainFilename),
-                    commandTimeOutInSeconds);
+                    commandTimeoutInSeconds);
         }
 
         private string GetMSSQLConnectionString(string databaseName)


### PR DESCRIPTION
fix issue [4484](https://github.com/dotnet/machinelearning/issues/4484)

-add option to set db command timeout in db loader
-add corresponding test
this pr partially refers to a hanging [PR](https://github.com/dotnet/machinelearning/pull/4494).

