### PR TITLE
Improve VectorTypeAttribute(dims) docs

### DIFF
--- a/src/Microsoft.ML.Data/Data/SchemaDefinition.cs
+++ b/src/Microsoft.ML.Data/Data/SchemaDefinition.cs
@@ -80,7 +80,9 @@ namespace Microsoft.ML.Data
         }
 
         /// <summary>
-        /// Mark member with expected dimensions of array.
+        /// Mark member with expected dimensions of array. Notice that this attribute is expected to be added to one dimensional arrays,
+        /// and it shouldn't be added to multidimensional arrays. Internally, ML.NET will use the shape information provided as the
+        /// "dimensions" param of this constructor, to use it as a multidimensional array.
         /// </summary>
         /// <param name="dimensions">Dimensions of array. All values should be non-negative.
         /// A zero value indicates that the vector type is considered to have unknown length along that dimension.</param>


### PR DESCRIPTION
Addresses #5273 : On the confusion of users about how to use the VectorTypeAttribute.

As confirmed offline by @yaeldekel , users currently can't provide a multidimensional array with a `VectorTypeAttribute(dims)` . They should flatten their arrays into 1-D arrays and then use the `VectorTypeAttribute(dims)` to describe the shape ML.NET will use internally.

**Note:** Originally I was planning on throwing a readable exception if the user added the `VectorTypeAttribute` to a multidimensional array, but some discussion would be needed to decide where to do this (either in `InternalSchemaDefinition.Create`, or somewhere else on `InternalSchemaDefinition` or `SchemaDefinition` itself). Furthermore, I'm thinking that maybe there's a bug on these classes, where if a user adds a custom `DataViewType` (see #3263 ) and adds the attribute of this type to an array, then some unexpected behavior will happen as [`InternalSchemaDefinition.GetMappedType()` ](https://github.com/antoniovs1029/machinelearning/blob/bb13d629000c218136e741b643767cf45ae12fc4/src/Microsoft.ML.Data/DataView/InternalSchemaDefinition.cs#L163) assumes that any array (multidimensional or otherwise) is `isVector = true`, and then elsewhere in the code we assume that if a type `isVector == true` then it _should_ be a `VectorDataViewType`. More discussion and inspection would be needed on this regard and it might, or not, affect the decision of where to throw an exception for multidimensionals array with `VectorTypeAttribute`. And these may be addressed on a separate PR.

So, for the time being, and the fact that this might not be a common problem anyway, I think that simply changing slightly the docs is the best option for the next release.