### PR TITLE
Aded catch in R^2 calculation for case with few samples

### DIFF
--- a/src/Microsoft.ML.Data/Evaluators/RegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/RegressionEvaluator.cs
@@ -110,8 +110,7 @@ namespace Microsoft.ML.Data
                                 return double.NaN;
                             return 1 - TotalL2Loss / (TotalLabelSquaredW - TotalLabelW * TotalLabelW / SumWeights);
                         }
-                        else
-                            return 0;
+                        return 0;
                     }
                 }
 

--- a/src/Microsoft.ML.Data/Evaluators/RegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/RegressionEvaluator.cs
@@ -104,9 +104,14 @@ namespace Microsoft.ML.Data
                     {
                         // RSquared value cannot be well-defined with less than two samples.
                         // Return NaN instead of -Infinity.
-                        if ((TotalLabelSquaredW - TotalLabelW * TotalLabelW / SumWeights) == 0)
-                            return double.NaN;
-                        return SumWeights > 0 ? 1 - TotalL2Loss / (TotalLabelSquaredW - TotalLabelW * TotalLabelW / SumWeights) : 0;
+                        if (SumWeights > 0)
+                        {
+                            if ((TotalLabelSquaredW - TotalLabelW * TotalLabelW / SumWeights) == 0)
+                                return double.NaN;
+                            return 1 - TotalL2Loss / (TotalLabelSquaredW - TotalLabelW * TotalLabelW / SumWeights);
+                        }
+                        else
+                            return 0;
                     }
                 }
 

--- a/src/Microsoft.ML.Data/Evaluators/RegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/RegressionEvaluator.cs
@@ -102,6 +102,10 @@ namespace Microsoft.ML.Data
                 {
                     get
                     {
+                        // RSquared value cannot be well-defined with less than two samples.
+                        // Return NaN instead of -Infinity.
+                        if ((TotalLabelSquaredW - TotalLabelW * TotalLabelW / SumWeights) == 0)
+                            return double.NaN;
                         return SumWeights > 0 ? 1 - TotalL2Loss / (TotalLabelSquaredW - TotalLabelW * TotalLabelW / SumWeights) : 0;
                     }
                 }


### PR DESCRIPTION
This PR fixes #5306 by adding a catch for the calculation of `R^2` during metric calculation. When there is less than two rows of data used for the calculation of `R^2`, the returned value becomes `-Infinity`, whereas it should be returning `NaN`.

An example of this behavior in another ML framework is in scikit-learn, in the following lines:

https://github.com/scikit-learn/scikit-learn/blob/fd237278e895b42abe8d8d09105cbb82dc2cbba7/sklearn/metrics/_regression.py#L587-L590