### PR TITLE
AutoML.Net filter infinity value when calculate average score

### DIFF
--- a/src/Microsoft.ML.AutoML/Experiment/Runners/CrossValSummaryRunner.cs
+++ b/src/Microsoft.ML.AutoML/Experiment/Runners/CrossValSummaryRunner.cs
@@ -158,7 +158,7 @@ namespace Microsoft.ML.AutoML
         }
 
         /// <summary>
-        /// return the index of value from <paramref name="values"/> that closest to <paramref name="average"/>. If <paramref name="average"/> is non, +/- inf, the first, max/min value's index will be return.
+        /// return the index of value from <paramref name="values"/> that closest to <paramref name="average"/>. If <paramref name="average"/> is NaN, +/- inf, the first, max/min value's index will be return.
         /// </summary>
         private static int GetIndexClosestToAverage(IEnumerable<double> values, double average)
         {
@@ -171,7 +171,7 @@ namespace Microsoft.ML.AutoML
             if (double.IsPositiveInfinity(average))
                 return values.ToList().IndexOf(values.Max());
 
-            // Return the max value's index if average is positive inf.
+            // Return the min value's index if average is negative inf.
             if (double.IsNegativeInfinity(average))
                 return values.ToList().IndexOf(values.Min());
 

--- a/src/Microsoft.ML.AutoML/Experiment/Runners/CrossValSummaryRunner.cs
+++ b/src/Microsoft.ML.AutoML/Experiment/Runners/CrossValSummaryRunner.cs
@@ -157,12 +157,23 @@ namespace Microsoft.ML.AutoML
             return newResults.Average(r => r);
         }
 
+        /// <summary>
+        /// return the index of value from <paramref name="values"/> that closest to <paramref name="average"/>. If <paramref name="average"/> is non, +/- inf, the first, max/min value's index will be return.
+        /// </summary>
         private static int GetIndexClosestToAverage(IEnumerable<double> values, double average)
         {
             // Average will be NaN iff all values are NaN.
             // Return the first index in this case.
             if (double.IsNaN(average))
                 return 0;
+
+            // Return the max value's index if average is positive inf.
+            if (double.IsPositiveInfinity(average))
+                return values.ToList().IndexOf(values.Max());
+
+            // Return the max value's index if average is positive inf.
+            if (double.IsNegativeInfinity(average))
+                return values.ToList().IndexOf(values.Min());
 
             int avgFoldIndex = -1;
             var smallestDistFromAvg = double.PositiveInfinity;


### PR DESCRIPTION
### Fix issue:
- #5339 

This pr fixes #5339 by filtering out the infinity value when [calculating average scores](https://github.com/dotnet/machinelearning/blob/9d3e5452096ac61baf9d2a7ead5a963865fca7d5/src/Microsoft.ML.AutoML/Experiment/Runners/CrossValSummaryRunner.cs#L155) from the results of cross validation runner, so that the average score won't be infinity value in any situation, so that the return value of [GetIndexCloestToAverage](https://github.com/dotnet/machinelearning/blob/37af3f9db86414f4ec5b16a8734c90b498946caa/src/Microsoft.ML.AutoML/Experiment/Runners/CrossValSummaryRunner.cs#L84) will not be -1.

In rare case, when all the scores from cross-validation run are infinitive, the average score will be designated to nan. and the return value of [GetIndexCloestToAverage](https://github.com/dotnet/machinelearning/blob/37af3f9db86414f4ec5b16a8734c90b498946caa/src/Microsoft.ML.AutoML/Experiment/Runners/CrossValSummaryRunner.cs#L84) will be 0

Noted: the +/- infinite value is filtered before calculating average score because of the same reason nan value is filtered. By doing that the evaluation for cross-validation runner might be better than the real situation.