### PR TITLE
Added IDisposable to OnnxTransformer and fixed memory leaks

### DIFF
--- a/src/Microsoft.ML.OnnxTransformer/OnnxTransform.cs
+++ b/src/Microsoft.ML.OnnxTransformer/OnnxTransform.cs
@@ -744,6 +744,9 @@ namespace Microsoft.ML.Transforms.Onnx
     ///
     /// The inputs and outputs of the ONNX models must be Tensor type. Sequence and Maps are not yet supported.
     ///
+    /// Internally, OnnxTransformer (the return value of OnnxScoringEstimator.Fit()) holds a reference to an inference session which points to unmanaged memory owned by OnnxRuntime.dll.
+    /// Whenever there is a call to [ApplyOnnxModel](xref:Microsoft.ML.OnnxCatalog.ApplyOnnxModel*) in a pipeline, it is advised to cast the return value of the Fit() call to IDisposable and call Dispose() to ensure that there are no memory leaks.
+    ///
     /// OnnxRuntime works on Windows, MacOS and Ubuntu 16.04 Linux 64-bit platforms.
     /// Visit [ONNX Models](https://github.com/onnx/models) to see a list of readily available models to get started with.
     /// Refer to [ONNX](http://onnx.ai) for more information.

--- a/src/Microsoft.ML.OnnxTransformer/OnnxTransform.cs
+++ b/src/Microsoft.ML.OnnxTransformer/OnnxTransform.cs
@@ -39,7 +39,7 @@ namespace Microsoft.ML.Transforms.Onnx
     /// Please refer to <see cref="OnnxScoringEstimator"/> to learn more about the necessary dependencies,
     /// and how to run it on a GPU.
     /// </summary>
-    public sealed class OnnxTransformer : RowToRowTransformerBase
+    public sealed class OnnxTransformer : RowToRowTransformerBase, IDisposable
     {
         /// <summary>
         /// A class used for capturing shape information from command line.
@@ -351,6 +351,15 @@ namespace Microsoft.ML.Transforms.Onnx
         internal int MapDataViewColumnToOnnxOutputTensor(int iinfo)
         {
             return Model.ModelInfo.OutputNames.IndexOf(Outputs[iinfo]);
+        }
+
+        private bool _isDisposed;
+        public void Dispose()
+        {
+            if (_isDisposed)
+                return;
+            Model?.Dispose();
+            _isDisposed = true;
         }
 
         private sealed class Mapper : MapperBase

--- a/src/Microsoft.ML.OnnxTransformer/OnnxUtils.cs
+++ b/src/Microsoft.ML.OnnxTransformer/OnnxUtils.cs
@@ -339,10 +339,7 @@ namespace Microsoft.ML.Transforms.Onnx
         public static OnnxModel CreateFromBytes(byte[] modelBytes, int? gpuDeviceId = null, bool fallbackToCpu = false,
             IDictionary<string, int[]> shapeDictionary = null)
         {
-            var tempModelDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-            Directory.CreateDirectory(tempModelDir);
-
-            var tempModelFile = Path.Combine(tempModelDir, "model.onnx");
+            var tempModelFile = $"{Path.GetTempFileName()}.onnx";
             File.WriteAllBytes(tempModelFile, modelBytes);
             return new OnnxModel(tempModelFile, gpuDeviceId, fallbackToCpu,
                 ownModelFile: true, shapeDictionary: shapeDictionary);

--- a/src/Microsoft.ML.OnnxTransformer/OnnxUtils.cs
+++ b/src/Microsoft.ML.OnnxTransformer/OnnxUtils.cs
@@ -339,7 +339,7 @@ namespace Microsoft.ML.Transforms.Onnx
         public static OnnxModel CreateFromBytes(byte[] modelBytes, int? gpuDeviceId = null, bool fallbackToCpu = false,
             IDictionary<string, int[]> shapeDictionary = null)
         {
-            var tempModelFile = $"{Path.GetTempFileName()}.onnx";
+            var tempModelFile = Path.GetTempFileName();
             File.WriteAllBytes(tempModelFile, modelBytes);
             return new OnnxModel(tempModelFile, gpuDeviceId, fallbackToCpu,
                 ownModelFile: true, shapeDictionary: shapeDictionary);

--- a/test/Microsoft.ML.OnnxTransformerTest/OnnxTransformTests.cs
+++ b/test/Microsoft.ML.OnnxTransformerTest/OnnxTransformTests.cs
@@ -145,7 +145,9 @@ namespace Microsoft.ML.Tests
             pipe.GetOutputSchema(SchemaShape.Create(invalidDataWrongVectorSize.Schema));
             try
             {
-                pipe.Fit(invalidDataWrongVectorSize);
+                var onnxTransformer = pipe.Fit(invalidDataWrongVectorSize);
+                (onnxTransformer as IDisposable)?.Dispose();
+
                 Assert.False(true);
             }
             catch (ArgumentOutOfRangeException) { }
@@ -206,6 +208,7 @@ namespace Microsoft.ML.Tests
                     }
                     Assert.InRange(sum, 0.99999, 1.00001);
                 }
+                (transformer as IDisposable)?.Dispose();
             }
         }
 
@@ -232,7 +235,15 @@ namespace Microsoft.ML.Tests
 
             TestEstimatorCore(pipe, data);
 
-            var result = pipe.Fit(data).Transform(data);
+            var model = pipe.Fit(data);
+            var result = model.Transform(data);
+
+            // save and reload the model
+            var tempPath = Path.GetTempFileName();
+            ML.Model.Save(model, data.Schema, tempPath);
+            var loadedModel = ML.Model.Load(tempPath, out DataViewSchema modelSchema);
+            (loadedModel as IDisposable)?.Dispose();
+
             var softmaxOutCol = result.Schema["softmaxout_1"];
 
             using (var cursor = result.GetRowCursor(softmaxOutCol))
@@ -279,7 +290,9 @@ namespace Microsoft.ML.Tests
                     }
                 });
 
-            var onnx = ML.Transforms.ApplyOnnxModel("softmaxout_1", "data_0", modelFile).Fit(dataView).Transform(dataView);
+            var pipeline = ML.Transforms.ApplyOnnxModel("softmaxout_1", "data_0", modelFile);
+            var onnxTransformer = pipeline.Fit(dataView);
+            var onnx = onnxTransformer.Transform(dataView);
             var scoreCol = onnx.Schema["softmaxout_1"];
 
             using (var curs = onnx.GetRowCursor(scoreCol))
@@ -292,6 +305,7 @@ namespace Microsoft.ML.Tests
                     Assert.Equal(1000, buffer.Length);
                 }
             }
+            (onnxTransformer as IDisposable)?.Dispose();
         }
 
         [OnnxFact]
@@ -309,7 +323,9 @@ namespace Microsoft.ML.Tests
                         inb = new float[] {1,2,3,4,5}
                     }
                 });
-            var onnx = ML.Transforms.ApplyOnnxModel(new[] { "outa", "outb" }, new[] { "ina", "inb" }, modelFile).Fit(dataView).Transform(dataView);
+            var pipeline = ML.Transforms.ApplyOnnxModel(new[] { "outa", "outb" }, new[] { "ina", "inb" }, modelFile);
+            var onnxTransformer = pipeline.Fit(dataView);
+            var onnx = onnxTransformer.Transform(dataView);
 
             var outaCol = onnx.Schema["outa"];
             var outbCol = onnx.Schema["outb"];
@@ -330,6 +346,7 @@ namespace Microsoft.ML.Tests
                     Assert.Equal(30, bufferb.GetValues().ToArray().Sum());
                 }
             }
+            (onnxTransformer as IDisposable)?.Dispose();
         }
 
         [OnnxFact]
@@ -346,7 +363,9 @@ namespace Microsoft.ML.Tests
                     }
                 });
             // The model returns the output columns in the order outa, outb. We are doing the opposite here, making sure the name mapping is correct.
-            var onnx = ML.Transforms.ApplyOnnxModel(new[] { "outb", "outa" }, new[] { "ina", "inb" }, modelFile).Fit(dataView).Transform(dataView);
+            var pipeline = ML.Transforms.ApplyOnnxModel(new[] { "outb", "outa" }, new[] { "ina", "inb" }, modelFile);
+            var onnxTransformer = pipeline.Fit(dataView);
+            var onnx = onnxTransformer.Transform(dataView);
 
             var outaCol = onnx.Schema["outa"];
             var outbCol = onnx.Schema["outb"];
@@ -367,9 +386,12 @@ namespace Microsoft.ML.Tests
                     Assert.Equal(30, bufferb.GetValues().ToArray().Sum());
                 }
             }
+            (onnxTransformer as IDisposable)?.Dispose();
 
             // The model returns the output columns in the order outa, outb. We are doing only a subset, outb, to make sure the mapping works.
-            onnx = ML.Transforms.ApplyOnnxModel(new[] { "outb" }, new[] { "ina", "inb" }, modelFile).Fit(dataView).Transform(dataView);
+            pipeline = ML.Transforms.ApplyOnnxModel(new[] { "outb" }, new[] { "ina", "inb" }, modelFile);
+            onnxTransformer = pipeline.Fit(dataView);
+            onnx = onnxTransformer.Transform(dataView);
 
             outbCol = onnx.Schema["outb"];
             using (var curs = onnx.GetRowCursor(outbCol))
@@ -384,6 +406,7 @@ namespace Microsoft.ML.Tests
                     Assert.Equal(30, bufferb.GetValues().ToArray().Sum());
                 }
             }
+            (onnxTransformer as IDisposable)?.Dispose();
         }
 
         [OnnxFact]
@@ -401,12 +424,15 @@ namespace Microsoft.ML.Tests
                 };
             var idv = mlContext.Data.LoadFromEnumerable(data);
             var pipeline = ML.Transforms.ApplyOnnxModel(modelFile);
-            var transformedValues = pipeline.Fit(idv).Transform(idv);
+            var onnxTransformer = pipeline.Fit(idv);
+            var transformedValues = onnxTransformer.Transform(idv);
             var predictions = mlContext.Data.CreateEnumerable<PredictionUnknownDimensions>(transformedValues, reuseRowObject: false).ToArray();
 
             Assert.Equal(1, predictions[0].argmax[0]);
             Assert.Equal(0, predictions[1].argmax[0]);
             Assert.Equal(2, predictions[2].argmax[0]);
+
+            (onnxTransformer as IDisposable)?.Dispose();
         }
 
         [OnnxFact]
@@ -424,7 +450,8 @@ namespace Microsoft.ML.Tests
             };
             var idv = mlContext.Data.LoadFromEnumerable(data);
             var pipeline = ML.Transforms.ApplyOnnxModel(modelFile);
-            var transformedValues = pipeline.Fit(idv).Transform(idv);
+            var onnxTransformer = pipeline.Fit(idv);
+            var transformedValues = onnxTransformer.Transform(idv);
             var predictions = mlContext.Data.CreateEnumerable<PredictionNoneDimension>(transformedValues, reuseRowObject: false).ToArray();
 
             Assert.Equal(-0.080, Math.Round(predictions[0].variable[0], 3));
@@ -510,6 +537,8 @@ namespace Microsoft.ML.Tests
             foreach (var dataPoint in transformedDataPoints)
                 foreach (var score in dataPoint.Scores)
                     Assert.True(score > 0);
+
+            (model as IDisposable)?.Dispose();
         }
 
         private class ZipMapInput
@@ -545,7 +574,9 @@ namespace Microsoft.ML.Tests
             };
 
             var dataView = ML.Data.LoadFromEnumerable(dataPoints);
-            var transformedDataView = ML.Transforms.ApplyOnnxModel(new[] { "output" }, new[] { "input" }, modelFile).Fit(dataView).Transform(dataView);
+            var pipeline = ML.Transforms.ApplyOnnxModel(new[] { "output" }, new[] { "input" }, modelFile);
+            var onnxTransformer = pipeline.Fit(dataView);
+            var transformedDataView = onnxTransformer.Transform(dataView);
 
             // Verify output column carried by an IDataView.
             var outputColumn = transformedDataView.Schema["output"];
@@ -579,6 +610,7 @@ namespace Microsoft.ML.Tests
                 Assert.Equal(dataPoints[i].Input[1], dictionary[17]);
                 Assert.Equal(dataPoints[i].Input[2], dictionary[36]);
             }
+            (onnxTransformer as IDisposable)?.Dispose();
         }
 
         /// <summary>
@@ -595,7 +627,9 @@ namespace Microsoft.ML.Tests
             };
 
             var dataView = ML.Data.LoadFromEnumerable(dataPoints);
-            var transformedDataView = ML.Transforms.ApplyOnnxModel(new[] { "output" }, new[] { "input" }, modelFile).Fit(dataView).Transform(dataView);
+            var pipeline = ML.Transforms.ApplyOnnxModel(new[] { "output" }, new[] { "input" }, modelFile);
+            var onnxTransformer = pipeline.Fit(dataView);
+            var transformedDataView = onnxTransformer.Transform(dataView);
 
             // Verify output column carried by an IDataView.
             var outputColumn = transformedDataView.Schema["output"];
@@ -629,6 +663,7 @@ namespace Microsoft.ML.Tests
                 Assert.Equal(dataPoints[i].Input[1], dictionary["B"]);
                 Assert.Equal(dataPoints[i].Input[2], dictionary["C"]);
             }
+            (onnxTransformer as IDisposable)?.Dispose();
         }
 
         [OnnxFact]
@@ -748,23 +783,30 @@ namespace Microsoft.ML.Tests
 
             var dataView = ML.Data.LoadFromEnumerable(dataPoints);
 
+            var pipeline = new OnnxScoringEstimator[3];
+            var onnxTransformer = new OnnxTransformer[3];
             var transformedDataViews = new IDataView[3];
 
             // Test three public ONNX APIs with the custom shape.
 
             // Test 1.
-            transformedDataViews[0] = ML.Transforms.ApplyOnnxModel(
+            pipeline[0] = ML.Transforms.ApplyOnnxModel(
                 new[] { nameof(PredictionWithCustomShape.argmax) }, new[] { nameof(InputWithCustomShape.input) },
-                modelFile, shapeDictionary).Fit(dataView).Transform(dataView);
+                modelFile, shapeDictionary);
+            onnxTransformer[0] = pipeline[0].Fit(dataView);
+            transformedDataViews[0] = onnxTransformer[0].Transform(dataView);
 
             // Test 2.
-            transformedDataViews[1] = ML.Transforms.ApplyOnnxModel(
+            pipeline[1] = ML.Transforms.ApplyOnnxModel(
                 nameof(PredictionWithCustomShape.argmax), nameof(InputWithCustomShape.input),
-                modelFile, shapeDictionary).Fit(dataView).Transform(dataView);
+                modelFile, shapeDictionary);
+            onnxTransformer[1] = pipeline[1].Fit(dataView);
+            transformedDataViews[1] = onnxTransformer[1].Transform(dataView);
 
             // Test 3.
-            transformedDataViews[2] = ML.Transforms.ApplyOnnxModel(
-                modelFile, shapeDictionary).Fit(dataView).Transform(dataView);
+            pipeline[2] = ML.Transforms.ApplyOnnxModel(modelFile, shapeDictionary);
+            onnxTransformer[2] = pipeline[2].Fit(dataView);
+            transformedDataViews[2] = onnxTransformer[2].Transform(dataView);
 
             // Conduct the same check for all the 3 called public APIs.
             foreach(var transformedDataView in transformedDataViews)
@@ -787,6 +829,8 @@ namespace Microsoft.ML.Tests
                 for (int i = 0; i < transformedDataPoints.Count; ++i)
                     Assert.Equal(transformedDataPoints[i].argmax, expectedResults[i]);
             }
+            for (int i = 0; i < 3; i++)
+                (onnxTransformer[i] as IDisposable)?.Dispose();
         }
 
         /// <summary>
@@ -948,6 +992,9 @@ namespace Microsoft.ML.Tests
 
             for (int i = 0; i < transformedDataPoints.Count; ++i)
                 Assert.Equal(transformedDataPoints[i].argmax, expectedResults[i]);
+
+            (model as IDisposable)?.Dispose();
+            (loadedModel as IDisposable)?.Dispose();
         }
     }
 }

--- a/test/Microsoft.ML.OnnxTransformerTest/OnnxTransformTests.cs
+++ b/test/Microsoft.ML.OnnxTransformerTest/OnnxTransformTests.cs
@@ -259,6 +259,8 @@ namespace Microsoft.ML.Tests
                 }
                 Assert.Equal(4, numRows);
             }
+            (model as IDisposable)?.Dispose();
+            File.Delete(tempPath);
         }
 
         [OnnxFact]

--- a/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
+++ b/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
@@ -147,6 +147,7 @@ namespace Microsoft.ML.RunTests
             // Schema verification between estimator and transformer.
             var scoredTrainSchemaShape = SchemaShape.Create(transformer.GetOutputSchema(validFitInput.Schema));
             CheckSameSchemaShape(outSchemaShape, scoredTrainSchemaShape);
+            (loadedTransformer as IDisposable)?.Dispose();
         }
 
         private void CheckSameSchemaShape(SchemaShape promised, SchemaShape delivered)

--- a/test/Microsoft.ML.Tests/OnnxConversionTest.cs
+++ b/test/Microsoft.ML.Tests/OnnxConversionTest.cs
@@ -817,6 +817,7 @@ namespace Microsoft.ML.Tests
                     CompareResults("Score", "Score", transformedData, onnxResult, isRightColumnOnnxScalar: true);
                     CompareResults("Probability", "Probability", transformedData, onnxResult, isRightColumnOnnxScalar: true);
                     CompareResults("PredictedLabel", "PredictedLabel", transformedData, onnxResult, isRightColumnOnnxScalar: true);
+                    (onnxTransformer as IDisposable)?.Dispose();
                 }
                 CheckEquality(subDir, onnxTextName, digitsOfPrecision: 3);
             }
@@ -976,6 +977,7 @@ namespace Microsoft.ML.Tests
                     var onnxTransformer = onnxEstimator.Fit(dataView);
                     var onnxResult = onnxTransformer.Transform(dataView);
                     CompareResults("pca", "pca", transformedData, onnxResult);
+                    (onnxTransformer as IDisposable)?.Dispose();
                 }
             }
             Done();
@@ -1351,6 +1353,7 @@ namespace Microsoft.ML.Tests
                     var onnxSlotNames = onnxSlots.DenseValues().ToList();
                     for (int j = 0; j < mlNetSlots.Length; j++)
                         Assert.Equal(mlNetSlotNames[j].ToString(), onnxSlotNames[j].ToString());
+                    (onnxTransformer as IDisposable)?.Dispose();
                 }
             }
             Done();
@@ -1456,6 +1459,7 @@ namespace Microsoft.ML.Tests
                 var onnxTransformer = onnxEstimator.Fit(dataView);
                 var onnxResult = onnxTransformer.Transform(dataView);
                 CompareResults("Label", "Label", outputData, onnxResult, isRightColumnOnnxScalar: true);
+                (onnxTransformer as IDisposable)?.Dispose();
             }
             Done();
         }
@@ -1586,7 +1590,8 @@ namespace Microsoft.ML.Tests
             {
                 // Step 5: Apply Onnx Model
                 var onnxEstimator = mlContext.Transforms.ApplyOnnxModel(outputNames, inputNames, onnxModelPath);
-                var onnxResult = onnxEstimator.Fit(reloadedData).Transform(reloadedData);
+                var onnxTransformer = onnxEstimator.Fit(reloadedData);
+                var onnxResult = onnxTransformer.Transform(reloadedData);
 
                 // Step 6: Compare results to an onnx model created using the mappedData IDataView
                 // Notice that this ONNX model would actually include the steps to do the ValueToKeyTransformer mapping,
@@ -1598,7 +1603,8 @@ namespace Microsoft.ML.Tests
                 using (FileStream stream = new FileStream(onnxModelPath2, FileMode.Create))
                     mlContext.Model.ConvertToOnnx(model, mappedData, stream);
                 var onnxEstimator2 = mlContext.Transforms.ApplyOnnxModel(outputNames, inputNames, onnxModelPath2);
-                var onnxResult2 = onnxEstimator2.Fit(originalData).Transform(originalData);
+                var onnxTransformer2 = onnxEstimator2.Fit(originalData);
+                var onnxResult2 = onnxTransformer2.Transform(originalData);
 
                 var stdSuffix = ".output";
                 foreach (var name in outputNames)
@@ -1607,6 +1613,8 @@ namespace Microsoft.ML.Tests
                     var colName = name.Replace(stdSuffix, "");
                     CompareResults(colName, colName, onnxResult, onnxResult2);
                 }
+                (onnxTransformer as IDisposable)?.Dispose();
+                (onnxTransformer2 as IDisposable)?.Dispose();
             }
 
             Done();
@@ -2035,6 +2043,7 @@ namespace Microsoft.ML.Tests
                 {
                     CompareResults(column.Name, column.Name, transformedData, onnxResult, column.Precision, true);
                 }
+                (onnxTransformer as IDisposable)?.Dispose();
             }
         }
 


### PR DESCRIPTION
Fixes #5342 
A temp file was being created when the Onnx model was being loaded from within an ML.NET model. This file wasn't being deleted when the session exited because OnnxTransformer didn't support IDisposable. (Also added Dispose calls to OnnxTransformer objects in the tests)

Thanks to the reported bug, this also fixes memory leaks that we would see from OnnxRuntime.dll because the native memory associated with InferenceSession wasn't freed.
