### PR TITLE
Throw when PCA generates invalid eigenvectors

### DIFF
--- a/src/Microsoft.ML.PCA/PcaTrainer.cs
+++ b/src/Microsoft.ML.PCA/PcaTrainer.cs
@@ -461,6 +461,9 @@ namespace Microsoft.ML.Trainers
             {
                 _eigenVectors[i] = new VBuffer<float>(eigenVectors[i].Length, eigenVectors[i]);
                 _meanProjected[i] = VectorUtils.DotProduct(in _eigenVectors[i], in mean);
+                Host.CheckParam(_eigenVectors[i].GetValues().All(FloatUtils.IsFinite),
+                    nameof(eigenVectors),
+                    "The learnt eigenvectors contained NaN values, consider modifying the dataset or lower the rank or oversampling parameters");
             }
 
             _mean = mean;


### PR DESCRIPTION
Fixes https://github.com/microsoft/NimbusML/issues/497

As discussed there, the problem is that when PCA generates eigenvectors with NaN values, a cryptic exception is thrown on NimbusML during prediction and not during training. It's thrown during prediction because to do prediction NimbusML saves the model to disk and loads it back, and during deserialization there's a check that prevents loading eigenvectors that contain NaNs.

In this PR I'm adding an exception to the constructor of PcaModelParameters so that a more readable exception is thrown during training of either NimbusML or ML.NET, so there's no need to wait until prediction for NimbusML to throw it.