### PR TITLE
Added getter for InputObjectDataView's Data value in documentation

### DIFF
--- a/docs/samples/Microsoft.ML.Samples/Dynamic/SimpleDataViewImplementation.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/SimpleDataViewImplementation.cs
@@ -146,6 +146,13 @@ namespace Samples.Dynamic
         private sealed class InputObjectDataView : IDataView
         {
             private readonly IEnumerable<InputObject> _data;
+            public IEnumerable<InputObject> Data
+            {
+                get
+                {
+                    return _data;
+                }
+            }
             public DataViewSchema Schema { get; }
             public bool CanShuffle => false;
 
@@ -249,7 +256,7 @@ namespace Samples.Dynamic
                 {
                     Schema = parent.Schema;
                     _position = -1;
-                    _enumerator = parent._data.GetEnumerator();
+                    _enumerator = parent.Data.GetEnumerator();
                     _getters = new Delegate[]
                     {
                         wantsLabel ?


### PR DESCRIPTION
#Fixed #5371 

Added getter function to the `private readonly IEnumerable<InputObject> _data` to prevent call to `InputObjectDataView`'s private value.