### PR TITLE
Added support for RankingMetrics with CrossValSummaryRunner

### DIFF
--- a/src/Microsoft.ML.AutoML/Experiment/Runners/CrossValSummaryRunner.cs
+++ b/src/Microsoft.ML.AutoML/Experiment/Runners/CrossValSummaryRunner.cs
@@ -158,11 +158,14 @@ namespace Microsoft.ML.AutoML
             throw new NotImplementedException($"Metric {typeof(TMetrics)} not implemented");
         }
 
-        private static double[] GetAverageOfNonNaNScoresInNestedEnumerable(IEnumerable<IEnumerable <double>> results)
+        private static double[] GetAverageOfNonNaNScoresInNestedEnumerable(IEnumerable<IEnumerable<double>> results)
         {
             double[] arr = new double[results.ElementAt(0).Count()];
             for (int i = 0; i < arr.Length; i++)
+            {
+                Contracts.Assert(arr.Length == results.ElementAt(i).Count());
                 arr[i] = GetAverageOfNonNaNScores(results.Select(x => x.ElementAt(i)));
+            }
             return arr;
         }
 

--- a/src/Microsoft.ML.AutoML/Experiment/Runners/CrossValSummaryRunner.cs
+++ b/src/Microsoft.ML.AutoML/Experiment/Runners/CrossValSummaryRunner.cs
@@ -144,7 +144,26 @@ namespace Microsoft.ML.AutoML
                 return result as TMetrics;
             }
 
+            if (typeof(TMetrics) == typeof(RankingMetrics))
+            {
+                var newMetrics = metrics.Select(x => x as RankingMetrics);
+                Contracts.Assert(newMetrics != null);
+
+                var result = new RankingMetrics(
+                    dcg: GetAverageOfNonNaNScoresInNestedEnumerable(newMetrics.Select(x => x.DiscountedCumulativeGains)),
+                    ndcg: GetAverageOfNonNaNScoresInNestedEnumerable(newMetrics.Select(x => x.NormalizedDiscountedCumulativeGains)));
+                return result as TMetrics;
+            }
+
             throw new NotImplementedException($"Metric {typeof(TMetrics)} not implemented");
+        }
+
+        private static double[] GetAverageOfNonNaNScoresInNestedEnumerable(IEnumerable<IEnumerable <double>> results)
+        {
+            double[] arr = new double[results.ElementAt(0).Count()];
+            for (int i = 0; i < arr.Length; i++)
+                arr[i] = GetAverageOfNonNaNScores(results.Select(x => x.ElementAt(i)));
+            return arr;
         }
 
         private static double GetAverageOfNonNaNScores(IEnumerable<double> results)

--- a/src/Microsoft.ML.Data/DataLoadSave/DataOperationsCatalog.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/DataOperationsCatalog.cs
@@ -63,7 +63,7 @@ namespace Microsoft.ML
         /// results.
         /// </summary>
         /// <typeparam name="TRow">The user-defined item type.</typeparam>
-        /// <param name="data">The enumerable data containing type <typeparamref name="TRow"/> to convert to an<see cref="IDataView"/>.</param>
+        /// <param name="data">The enumerable data containing type <typeparamref name="TRow"/> to convert to a <see cref="IDataView"/>.</param>
         /// <param name="schemaDefinition">The optional schema definition of the data view to create. If <c>null</c>,
         /// the schema definition is inferred from <typeparamref name="TRow"/>.</param>
         /// <returns>The constructed <see cref="IDataView"/>.</returns>

--- a/test/Microsoft.ML.AutoML.Tests/AutoFitTests.cs
+++ b/test/Microsoft.ML.AutoML.Tests/AutoFitTests.cs
@@ -157,6 +157,7 @@ namespace Microsoft.ML.AutoML.Test
 
             ExperimentResult<RankingMetrics>[] experimentResults =
             {
+                experiment.Execute(trainDataView, labelColumnName, groupIdColumnName),
                 experiment.Execute(trainDataView, testDataView),
                 experiment.Execute(trainDataView, testDataView,
                 new ColumnInformation()
@@ -172,10 +173,11 @@ namespace Microsoft.ML.AutoML.Test
                     SamplingKeyColumnName = groupIdColumnName
                 })
             };
-            if (isUsingTrainValidateRunner)
-                experimentResults.Append(experiment.Execute(trainDataView, labelColumnName, groupIdColumnName));
 
-            for (int i = 0; i < experimentResults.Length; i++)
+            // Skip first experiment during cross validation testing as no test
+            // dataset is provided
+            int startIndex = isUsingTrainValidateRunner ? 0 : 1;
+            for (int i = startIndex; i < experimentResults.Length; i++)
             {
                 RunDetail<RankingMetrics> bestRun = experimentResults[i].BestRun;
                 Assert.True(experimentResults[i].RunDetails.Count() > 0);


### PR DESCRIPTION
Fix #5381 

Previously, `AutoFitRankingTest` was never testing `RankingMetrics` with `CrossValSummaryRunner` due to the row limit for cross validation testing, and as the MLSR dataset that `trainDataView` is pulling from is large:

https://github.com/dotnet/machinelearning/blob/f87a3bbd8adb12934dae0a0060813ce9b7500664/test/Microsoft.ML.AutoML.Tests/AutoFitTests.cs#L123-L141

https://github.com/dotnet/machinelearning/blob/6bae29fc342bf192a36a69484d62db8d6266f8df/src/Microsoft.ML.AutoML/API/ExperimentBase.cs#L109-L130

As a result, this lacking of support for `RankingMetrics` with `CrossValSummaryRunner` was not noticed until Issue #5381. This PR adds support for this case, and edits the `RankingMetrics` AutoML unit tests to include testing of `RankingMetrics` with `CrossValSummaryRunner` as well.