### PR TITLE
Change the _maxCalibrationExamples default on CalibratorUtils

### DIFF
--- a/src/Microsoft.ML.Data/Prediction/Calibrator.cs
+++ b/src/Microsoft.ML.Data/Prediction/Calibrator.cs
@@ -838,7 +838,9 @@ namespace Microsoft.ML.Calibrators
     internal static class CalibratorUtils
     {
         // maximum number of rows passed to the calibrator.
-        private const int _maxCalibrationExamples = 1000000;
+        // if 0, we'll actually look through the whole dataset to
+        // when training the calibrator
+        private const int _maxCalibrationExamples = 0;
 
         private static bool NeedCalibration(IHostEnvironment env, IChannel ch, ICalibratorTrainer calibrator,
             ITrainer trainer, IPredictor predictor, RoleMappedSchema schema)
@@ -988,6 +990,10 @@ namespace Microsoft.ML.Calibrators
                     caliTrainer.ProcessTrainingExample(score, label > 0, weight);
 
                     if (maxRows > 0 && ++num >= maxRows)
+                        // If maxRows was 0, we'll process all of the rows in the dataset
+                        // Notice that depending of the calibrator, "processing" means
+                        // only using N random rows of the ones that where processed
+                        // to actually train the calibrator.
                         break;
                 }
             }

--- a/src/Microsoft.ML.Data/Prediction/Calibrator.cs
+++ b/src/Microsoft.ML.Data/Prediction/Calibrator.cs
@@ -837,9 +837,8 @@ namespace Microsoft.ML.Calibrators
     [BestFriend]
     internal static class CalibratorUtils
     {
-        // maximum number of rows passed to the calibrator.
-        // if 0, we'll actually look through the whole dataset to
-        // when training the calibrator
+        // Maximum number of rows to process when training the Calibrator.
+        // If 0, we'll actually process the whole dataset.
         private const int _maxCalibrationExamples = 0;
 
         private static bool NeedCalibration(IHostEnvironment env, IChannel ch, ICalibratorTrainer calibrator,
@@ -991,8 +990,8 @@ namespace Microsoft.ML.Calibrators
 
                     if (maxRows > 0 && ++num >= maxRows)
                         // If maxRows was 0, we'll process all of the rows in the dataset
-                        // Notice that depending of the calibrator, "processing" means
-                        // only using N random rows of the ones that where processed
+                        // Notice that depending on the calibrator, "processing" might mean
+                        // randomly choosing some of the "processed" rows
                         // to actually train the calibrator.
                         break;
                 }


### PR DESCRIPTION
As reported offline, ML.NET yielded different results than TLC when training a PlattCalibrator with the same dataset.

Upon further investigation, it turns out that it only happened on datasets over 1 million rows, and the reason was that when porting the CalibratorUtils class from TLC, a "_maxCalibrationExamples = 1000000" default parameter was added.

Upon reading through the code (in particular [CalibratorTrainingBase's ProcessingTrainingExample](https://github.com/dotnet/machinelearning/blob/4960f9de83351b25874e58d1ca504c9a32aa1112/src/Microsoft.ML.Data/Prediction/Calibrator.cs#L1437-L1443)) it turns out that on TLC `TrainCalibrator` was called with `maxRows = 0`, and this made that when training the PlattCalibrator, all the dataset was seen, but only 1M rows where selected randomly to be [added to the DataStore](https://github.com/dotnet/machinelearning/blob/4960f9de83351b25874e58d1ca504c9a32aa1112/src/Microsoft.ML.Data/Prediction/Calibrator.cs#L1402-L1417). In contrast, on ML.NET that same method was called with `maxRows = 1M`, and this made that only the first 1M rows were added to the DataStore (instead of randomly selecting them from the complete dataset). This caused bias and undesired results.