### PR TITLE
Fix perf regression in ShuffleRows

### DIFF
--- a/test/Microsoft.ML.Benchmarks/ShuffleRowsBench.cs
+++ b/test/Microsoft.ML.Benchmarks/ShuffleRowsBench.cs
@@ -1,0 +1,53 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Attributes;
+using Microsoft.ML.Benchmarks.Harness;
+using Microsoft.ML.Data;
+
+namespace Microsoft.ML.Benchmarks
+{
+    [CIBenchmark]
+    public class ShuffleRowsBench : BenchmarkBase
+    {
+        private TrainRow[] _rows;
+        private MLContext _context;
+        
+        [GlobalSetup]
+        public void Setup()
+        {
+            _rows = new TrainRow[10_000];
+            for (var i = 0; i < _rows.Length; i++)
+            {
+                _rows[i] = new TrainRow() { Sample = i.ToString(), Week = i, Label = i / 2 };
+            }
+
+            _context = new MLContext();
+        }
+
+        [Benchmark]
+        public void ShuffleRows()
+        {
+            IDataView data = _context.Data.LoadFromEnumerable(_rows);
+
+            IDataView shuffledData = _context.Data.ShuffleRows(data, seed: 0);
+
+            foreach (string sample in shuffledData.GetColumn<string>("Sample"))
+            {
+            }
+        }
+
+        private class TrainRow
+        {
+            [ColumnName("Sample")]
+            public string Sample;
+
+            [ColumnName("Week")]
+            public float Week;
+
+            [ColumnName("Label")]
+            public float Label;
+        }
+    }
+}


### PR DESCRIPTION
RowShufflingTransformer is using ChannelReader incorrectly. It needs to block waiting for items to read and was Thread.Sleeping in order to wait, but not spin the current core. This caused a major perf regression.

The fix is to block synchronously correctly - by calling AsTask() on the ValueTask that is returned from the ChannelReader and block on the Task.

Fix #5416

Results of the added benchmark:

||      Method |    Mean |    Error |   StdDev | Extra Metric |
|------------|------------:|--------:|---------:|---------:|-------------:|
|master | ShuffleRows | 2.911 s | 0.0379 s | 0.0354 s |            - |
|PR | ShuffleRows | 2.736 ms | 0.0530 ms | 0.0470 ms |            - |


cc @jwood803 @ogo-adp @stephentoub 