### PR TITLE
ProduceWordBags Onnx Export Fix 

### DIFF
--- a/src/Microsoft.ML.Transforms/Text/TextCatalog.cs
+++ b/src/Microsoft.ML.Transforms/Text/TextCatalog.cs
@@ -334,7 +334,7 @@ namespace Microsoft.ML
             => new CustomStopWordsRemovingEstimator(Contracts.CheckRef(catalog, nameof(catalog)).GetEnvironment(), outputColumnName, inputColumnName, stopwords);
 
         /// <summary>
-        /// Create a <see cref="WordHashBagEstimator"/>, which maps the column specified in <paramref name="inputColumnName"/>
+        /// Create a <see cref="WordBagEstimator"/>, which maps the column specified in <paramref name="inputColumnName"/>
         /// to a vector of n-gram counts in a new column named <paramref name="outputColumnName"/>.
         /// </summary>
         /// <remarks>
@@ -363,7 +363,7 @@ namespace Microsoft.ML
                 outputColumnName, inputColumnName, ngramLength, skipLength, useAllLengths, maximumNgramsCount, weighting);
 
         /// <summary>
-        /// Create a <see cref="WordHashBagEstimator"/>, which maps the multiple columns specified in <paramref name="inputColumnNames"/>
+        /// Create a <see cref="WordBagEstimator"/>, which maps the multiple columns specified in <paramref name="inputColumnNames"/>
         /// to a vector of n-gram counts in a new column named <paramref name="outputColumnName"/>.
         /// </summary>
         /// <remarks>

--- a/src/Microsoft.ML.Transforms/Text/WordTokenizing.cs
+++ b/src/Microsoft.ML.Transforms/Text/WordTokenizing.cs
@@ -404,7 +404,6 @@ namespace Microsoft.ML.Transforms.Text
                 string opType;
                 while (columns.MoveNext())
                 {
-
                     opType = "Tokenizer";
                     var column = columns.Current;
                     var intermediateVar = ctx.AddIntermediateVariable(_type, "TokenizerOutput", true);

--- a/src/Microsoft.ML.Transforms/Text/WordTokenizing.cs
+++ b/src/Microsoft.ML.Transforms/Text/WordTokenizing.cs
@@ -404,6 +404,7 @@ namespace Microsoft.ML.Transforms.Text
                 string opType;
                 while (columns.MoveNext())
                 {
+
                     opType = "Tokenizer";
                     var column = columns.Current;
                     var intermediateVar = ctx.AddIntermediateVariable(_type, "TokenizerOutput", true);
@@ -415,10 +416,10 @@ namespace Microsoft.ML.Transforms.Text
                     string[] separators = column.SeparatorsArray.Select(c => c.ToString()).ToArray();
                     tokenizerNode.AddAttribute("separators", separators);
 
-                    opType = "Squeeze";
-                    var squeezeOutput = ctx.AddIntermediateVariable(_type, column.Name);
-                    var squeezeNode = ctx.CreateNode(opType, intermediateVar, squeezeOutput, ctx.GetNodeName(opType), "");
-                    squeezeNode.AddAttribute("axes", new long[] { 1 });
+                    opType = "Reshape";
+                    var shape = ctx.AddInitializer(new long[] { 1, -1 }, new long[] { 2 }, "Shape");
+                    var reshapeOutput = ctx.AddIntermediateVariable(new VectorDataViewType(TextDataViewType.Instance, 1), column.Name);
+                    var reshapeNode = ctx.CreateNode(opType, new[] { intermediateVar, shape }, new[] { reshapeOutput }, ctx.GetNodeName(opType), "");
                 }
             }
         }

--- a/test/Microsoft.ML.Tests/OnnxConversionTest.cs
+++ b/test/Microsoft.ML.Tests/OnnxConversionTest.cs
@@ -1321,6 +1321,7 @@ namespace Microsoft.ML.Tests
                             ngramLength: ngramLength,
                             useAllLengths: useAllLength,
                             weighting: weighting)),
+
                 mlContext.Transforms.Text.ProduceWordBags("Tokens", "Text",
                             ngramLength: ngramLength,
                             useAllLengths: useAllLength,

--- a/test/Microsoft.ML.Tests/OnnxConversionTest.cs
+++ b/test/Microsoft.ML.Tests/OnnxConversionTest.cs
@@ -1310,11 +1310,11 @@ namespace Microsoft.ML.Tests
             IEstimator<ITransformer>[] pipelines =
             {
                 mlContext.Transforms.Text.TokenizeIntoWords("Tokens", "Text", new[] { ' ' })
-                .Append(mlContext.Transforms.Conversion.MapValueToKey("Tokens"))
-                .Append(mlContext.Transforms.Text.ProduceNgrams("NGrams", "Tokens",
-                            ngramLength: ngramLength,
-                            useAllLengths: useAllLength,
-                            weighting: weighting)),
+                                .Append(mlContext.Transforms.Conversion.MapValueToKey("Tokens"))
+                                .Append(mlContext.Transforms.Text.ProduceNgrams("NGrams", "Tokens",
+                                            ngramLength: ngramLength,
+                                            useAllLengths: useAllLength,
+                                            weighting: weighting)),
 
                 mlContext.Transforms.Text.TokenizeIntoCharactersAsKeys("Tokens", "Text")
                 .Append(mlContext.Transforms.Text.ProduceNgrams("NGrams", "Tokens",

--- a/test/Microsoft.ML.Tests/OnnxConversionTest.cs
+++ b/test/Microsoft.ML.Tests/OnnxConversionTest.cs
@@ -1312,20 +1312,19 @@ namespace Microsoft.ML.Tests
                 mlContext.Transforms.Text.TokenizeIntoWords("Tokens", "Text", new[] { ' ' })
                 .Append(mlContext.Transforms.Conversion.MapValueToKey("Tokens"))
                 .Append(mlContext.Transforms.Text.ProduceNgrams("NGrams", "Tokens",
-                ngramLength: ngramLength,
-                useAllLengths: useAllLength,
-                weighting: weighting)),
+                            ngramLength: ngramLength,
+                            useAllLengths: useAllLength,
+                            weighting: weighting)),
 
                 mlContext.Transforms.Text.TokenizeIntoCharactersAsKeys("Tokens", "Text")
                 .Append(mlContext.Transforms.Text.ProduceNgrams("NGrams", "Tokens",
-                ngramLength: ngramLength,
-                useAllLengths: useAllLength,
-                weighting: weighting)),
-
+                            ngramLength: ngramLength,
+                            useAllLengths: useAllLength,
+                            weighting: weighting)),
                 mlContext.Transforms.Text.ProduceWordBags("Tokens", "Text",
-                ngramLength: ngramLength,
-                useAllLengths: useAllLength,
-                weighting: weighting),
+                            ngramLength: ngramLength,
+                            useAllLengths: useAllLength,
+                            weighting: weighting),
 
                 mlContext.Transforms.Text.TokenizeIntoWords("Tokens0", "Text")
                 .Append(mlContext.Transforms.Text.ProduceWordBags("Tokens", "Tokens0"))

--- a/test/Microsoft.ML.Tests/OnnxConversionTest.cs
+++ b/test/Microsoft.ML.Tests/OnnxConversionTest.cs
@@ -1310,22 +1310,25 @@ namespace Microsoft.ML.Tests
             IEstimator<ITransformer>[] pipelines =
             {
                 mlContext.Transforms.Text.TokenizeIntoWords("Tokens", "Text", new[] { ' ' })
-                                .Append(mlContext.Transforms.Conversion.MapValueToKey("Tokens"))
-                                .Append(mlContext.Transforms.Text.ProduceNgrams("NGrams", "Tokens",
-                                            ngramLength: ngramLength,
-                                            useAllLengths: useAllLength,
-                                            weighting: weighting)),
+                .Append(mlContext.Transforms.Conversion.MapValueToKey("Tokens"))
+                .Append(mlContext.Transforms.Text.ProduceNgrams("NGrams", "Tokens",
+                ngramLength: ngramLength,
+                useAllLengths: useAllLength,
+                weighting: weighting)),
 
                 mlContext.Transforms.Text.TokenizeIntoCharactersAsKeys("Tokens", "Text")
                 .Append(mlContext.Transforms.Text.ProduceNgrams("NGrams", "Tokens",
-                            ngramLength: ngramLength,
-                            useAllLengths: useAllLength,
-                            weighting: weighting)),
+                ngramLength: ngramLength,
+                useAllLengths: useAllLength,
+                weighting: weighting)),
 
                 mlContext.Transforms.Text.ProduceWordBags("Tokens", "Text",
-                                        ngramLength: ngramLength,
-                                        useAllLengths: useAllLength,
-                                        weighting: weighting)
+                ngramLength: ngramLength,
+                useAllLengths: useAllLength,
+                weighting: weighting),
+
+                mlContext.Transforms.Text.TokenizeIntoWords("Tokens0", "Text")
+                .Append(mlContext.Transforms.Text.ProduceWordBags("Tokens", "Tokens0"))
             };
 
             for (int i = 0; i < pipelines.Length; i++)
@@ -1346,7 +1349,7 @@ namespace Microsoft.ML.Tests
                     var onnxEstimator = mlContext.Transforms.ApplyOnnxModel(onnxFilePath, gpuDeviceId: _gpuDeviceId, fallbackToCpu: _fallbackToCpu);
                     var onnxTransformer = onnxEstimator.Fit(dataView);
                     var onnxResult = onnxTransformer.Transform(dataView);
-                    var columnName = i == pipelines.Length - 1 ? "Tokens" : "NGrams";
+                    var columnName = i >= pipelines.Length - 2 ? "Tokens" : "NGrams";
                     CompareResults(columnName, columnName, transformedData, onnxResult, 3);
 
                     VBuffer<ReadOnlyMemory<char>> mlNetSlots = default;


### PR DESCRIPTION
`ProduceWordBags` Onnx export assumes that the input will be a string of untokenized text. However, in ML.NET the user can choose to tokenize the text before passing it. Even though this is an unnecessary step, since a `WordTokenizer` is added before the `NgramExtraction` transformer, there is no error in ML.NET but there is an error in OnnxRuntime because a double tokenization resulted in more dimensions in Onnx. I have changed the Squeeze transformer to Reshape, so the dimension can remain consistent in this edge case. 

