### PR TITLE
issue 5336

### DIFF
--- a/src/Microsoft.ML.TensorFlow/TensorflowUtils.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorflowUtils.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Security.AccessControl;
 using System.Security.Principal;
+using System.Text;
 using Microsoft.ML.Data;
 using Microsoft.ML.Internal.Utilities;
 using Microsoft.ML.Runtime;
@@ -440,13 +441,13 @@ namespace Microsoft.ML.TensorFlow
                 return new Tensor((double[])(object)data, dims, TF_DataType.TF_DOUBLE);
             else if (typeof(T) == typeof(ReadOnlyMemory<char>))
             {
-                string[] strings = new string[data.Length];
-                for (int i = 0; i < strings.Length; i++)
+                byte[][] bytes = new byte[data.Length][];
+                for (int i = 0; i < bytes.Length; i++)
                 {
-                    strings[i] = data[i].ToString();
+                    bytes[i] = Encoding.Unicode.GetBytes(((ReadOnlyMemory<char>)(object)data[i]).ToArray());
                 }
 
-                return new Tensor(strings);
+                return new Tensor(bytes, TF_DataType.TF_STRING);
             }
 
             return new Tensor(new NDArray(data, tfShape));


### PR DESCRIPTION
fix issue #5336 
1. use byte array to create tensor instead of string
2. use Unicode encode instead of UTF8

This issue is little bit complicated so please read through below:

User want to load a pb model in ML.NET, the input tensor looks like below which is a serialized Example object (a binary buffer, not a text string):
`
      inputs['inputs'] tensor_info:
      dtype: DT_STRING
      shape: (-1)
      name: input_example_tensor:0
`

I find a workable solution is first convert Example object to protobuf encoded byte array using:
`
example.ToByteArray()
`
then convert byte array to string (char array) using some sort of reliable encoding (ideally Unicode or Base64 encoding):
`
Encoding.Unicode.GetString(example.ToByteArray())
`
Then ML.NET will convert the string back to byte array with same encoding and pass to tf.net:
`
Encoding.Unicode.GetBytes(((ReadOnlyMemory<char>)(object)data[i]).ToArray());
`

The method ML.NET uses to create Tensor is [CastDataAndReturnAsTensor](https://github.com/dotnet/machinelearning/blob/release/1.5.2/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs#L808), previously we are using [UTF8](https://github.com/dotnet/machinelearning/blob/release/1.5.2/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs#L832-L838) to decode the string and convert to byte array, UTF8 is not reliable encoding as I described in this [comment](https://github.com/dotnet/machinelearning/issues/5336#issuecomment-714278364) so I would like to change the encoding to Unicode.
Also, recently Xiaoyun upgrade our TF version in this [PR](https://github.com/dotnet/machinelearning/pull/5404) and changed to use string[] instead of byte[][] to create Tensor, in this case we need to use byte[][] as the input string itself is converted from binary buffer(protobuf encoded). 