### PR TITLE
handle exception during GetNextPipeline for AutoML

### DIFF
--- a/src/Microsoft.ML.AutoML/Experiment/Experiment.cs
+++ b/src/Microsoft.ML.AutoML/Experiment/Experiment.cs
@@ -63,7 +63,7 @@ namespace Microsoft.ML.AutoML
                 // get next pipeline
                 var getPipelineStopwatch = Stopwatch.StartNew();
                 var pipeline = PipelineSuggester.GetNextInferredPipeline(_context, _history, _datasetColumnInfo, _task,
-                    _optimizingMetricInfo.IsMaximizing, _experimentSettings.CacheBeforeTrainer, _trainerAllowList);
+                    _optimizingMetricInfo.IsMaximizing, _experimentSettings.CacheBeforeTrainer, _logger, _trainerAllowList);
 
                 var pipelineInferenceTimeInSeconds = getPipelineStopwatch.Elapsed.TotalSeconds;
 

--- a/test/Microsoft.ML.AutoML.Tests/GetNextPipelineTests.cs
+++ b/test/Microsoft.ML.AutoML.Tests/GetNextPipelineTests.cs
@@ -9,6 +9,7 @@ using Xunit;
 using Newtonsoft.Json;
 using Microsoft.ML.TestFramework;
 using Xunit.Abstractions;
+using Microsoft.ML.Runtime;
 
 namespace Microsoft.ML.AutoML.Test
 {
@@ -27,7 +28,8 @@ namespace Microsoft.ML.AutoML.Test
             var columns = DatasetColumnInfoUtil.GetDatasetColumnInfo(context, uciAdult, new ColumnInformation() { LabelColumnName = DatasetUtil.UciAdultLabel });
 
             // get next pipeline
-            var pipeline = PipelineSuggester.GetNextPipeline(context, new List<PipelineScore>(), columns, TaskKind.BinaryClassification);
+            var pipeline = PipelineSuggester.GetNextPipeline(context, new List<PipelineScore>(), columns,
+                TaskKind.BinaryClassification, ((IChannelProvider)context).Start("AutoMLTest"));
 
             // serialize & deserialize pipeline
             var serialized = JsonConvert.SerializeObject(pipeline);
@@ -57,7 +59,7 @@ namespace Microsoft.ML.AutoML.Test
             for (var i = 0; i < maxIterations; i++)
             {
                 // Get next pipeline
-                var pipeline = PipelineSuggester.GetNextPipeline(context, history, columns, task);
+                var pipeline = PipelineSuggester.GetNextPipeline(context, history, columns, task, ((IChannelProvider)context).Start("AutoMLTest"));
                 if (pipeline == null)
                 {
                     break;


### PR DESCRIPTION
fix part of issue found from #5428 

handle exception during GetNextPipeline for AutoML experiment to avoid exception crash the whole AutoML pipeline.

