### PR TITLE
Fixed MacOS CI Pipeline builds

### DIFF
--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -50,8 +50,8 @@ jobs:
 
     steps:
     # Work around MacOS Homebrew image/environment bug: https://github.com/actions/virtual-environments/issues/1811
-    - ${{ if eq(parameters.pool.name, 'Hosted macOS') }}:	    - ${{ if eq(parameters.pool.name, 'Hosted macOS') }}:
-      - script: brew update && brew install $(Build.SourcesDirectory)/build/libomp.rb && brew unlink python@2 && brew install mono-libgdiplus gettext && brew link gettext --force && brew link libomp --force	      - script: |
+    - ${{ if eq(parameters.pool.name, 'Hosted macOS') }}:
+      - script: |
           brew uninstall openssl@1.0.2t |
           brew uninstall python@2.7.17 |
           brew untap local/openssl |

--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -49,8 +49,16 @@ jobs:
       container: ${{ parameters.container }}
 
     steps:
+    # Work around MacOS Homebrew image/environment bug: https://github.com/actions/virtual-environments/issues/1811
+    - ${{ if eq(parameters.pool.name, 'Hosted macOS') }}:	    - ${{ if eq(parameters.pool.name, 'Hosted macOS') }}:
+      - script: brew update && brew install $(Build.SourcesDirectory)/build/libomp.rb && brew unlink python@2 && brew install mono-libgdiplus gettext && brew link gettext --force && brew link libomp --force	      - script: |
+          brew uninstall openssl@1.0.2t |
+          brew uninstall python@2.7.17 |
+          brew untap local/openssl |
+          brew untap local/python2
+        displayName: MacOS Homebrew bug Workaround
     - ${{ if eq(parameters.pool.name, 'Hosted macOS') }}:
-      - script: brew update && brew install $(Build.SourcesDirectory)/build/libomp.rb && brew unlink python@2 && brew install mono-libgdiplus gettext && brew link gettext --force && brew link libomp --force
+      - script: brew update && brew install cmake $(Build.SourcesDirectory)/build/libomp.rb && brew install mono-libgdiplus gettext && brew link gettext --force && brew link libomp --force
         displayName: Install build dependencies
     - ${{ if and( eq(parameters.nightlyBuild, 'true'), eq(parameters.pool.name, 'Hosted Ubuntu 1604')) }}:
       - bash: echo "##vso[task.setvariable variable=LD_LIBRARY_PATH]$(nightlyBuildRunPath):$LD_LIBRARY_PATH"


### PR DESCRIPTION
This PR adds build workarounds for the recently-failing MacOS builds. As discussed in the main MacOS-Homebrew GitHub [issue](https://github.com/actions/virtual-environments/issues/1811), the `openssl` package that is due to be removed from the MacOS images and an outdated standard Homebrew installation on CI's MacOS images were causing the builds to fail.