### PR TITLE
Fixed MacOS daily & nightly builds due to Homebrew bug

### DIFF
--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -58,7 +58,7 @@ jobs:
           brew untap local/python2
         displayName: MacOS Homebrew bug Workaround
     - ${{ if eq(parameters.pool.name, 'Hosted macOS') }}:
-      - script: brew update && brew install mono-libgdiplus && brew install $(Build.SourcesDirectory)/build/libomp.rb && brew link libomp --force
+      - script: brew update && brew unlink python@3.8 && brew install mono-libgdiplus && brew install $(Build.SourcesDirectory)/build/libomp.rb && brew link libomp --force
         displayName: Install build dependencies
     - ${{ if and( eq(parameters.nightlyBuild, 'true'), eq(parameters.pool.name, 'Hosted Ubuntu 1604')) }}:
       - bash: echo "##vso[task.setvariable variable=LD_LIBRARY_PATH]$(nightlyBuildRunPath):$LD_LIBRARY_PATH"

--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -58,7 +58,7 @@ jobs:
           brew untap local/python2
         displayName: MacOS Homebrew bug Workaround
     - ${{ if eq(parameters.pool.name, 'Hosted macOS') }}:
-      - script: brew update && brew install $(Build.SourcesDirectory)/build/libomp.rb && brew link libomp --force
+      - script: brew update && brew install mono-libgdiplus && brew install $(Build.SourcesDirectory)/build/libomp.rb && brew link libomp --force
         displayName: Install build dependencies
     - ${{ if and( eq(parameters.nightlyBuild, 'true'), eq(parameters.pool.name, 'Hosted Ubuntu 1604')) }}:
       - bash: echo "##vso[task.setvariable variable=LD_LIBRARY_PATH]$(nightlyBuildRunPath):$LD_LIBRARY_PATH"

--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -53,10 +53,12 @@ jobs:
     - ${{ if eq(parameters.pool.name, 'Hosted macOS') }}:
       - script: |
           brew uninstall openssl@1.0.2t |
-          brew untap local/openssl
+          brew uninstall python@2.7.17 |
+          brew untap local/openssl |
+          brew untap local/python2
         displayName: MacOS Homebrew bug Workaround
     - ${{ if eq(parameters.pool.name, 'Hosted macOS') }}:
-      - script: brew update && brew install $(Build.SourcesDirectory)/build/libomp.rb && brew install mono-libgdiplus && brew link libomp --force
+      - script: brew update && brew install $(Build.SourcesDirectory)/build/libomp.rb && brew link libomp --force
         displayName: Install build dependencies
     - ${{ if and( eq(parameters.nightlyBuild, 'true'), eq(parameters.pool.name, 'Hosted Ubuntu 1604')) }}:
       - bash: echo "##vso[task.setvariable variable=LD_LIBRARY_PATH]$(nightlyBuildRunPath):$LD_LIBRARY_PATH"

--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -58,7 +58,7 @@ jobs:
           brew untap local/python2
         displayName: MacOS Homebrew bug Workaround
     - ${{ if eq(parameters.pool.name, 'Hosted macOS') }}:
-      - script: brew update && brew install cmake $(Build.SourcesDirectory)/build/libomp.rb && brew install mono-libgdiplus gettext && brew link gettext --force && brew link libomp --force
+      - script: brew update && brew install $(Build.SourcesDirectory)/build/libomp.rb && brew install mono-libgdiplus && brew link libomp --force
         displayName: Install build dependencies
     - ${{ if and( eq(parameters.nightlyBuild, 'true'), eq(parameters.pool.name, 'Hosted Ubuntu 1604')) }}:
       - bash: echo "##vso[task.setvariable variable=LD_LIBRARY_PATH]$(nightlyBuildRunPath):$LD_LIBRARY_PATH"

--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -53,9 +53,7 @@ jobs:
     - ${{ if eq(parameters.pool.name, 'Hosted macOS') }}:
       - script: |
           brew uninstall openssl@1.0.2t |
-          brew uninstall python@2.7.17 |
           brew untap local/openssl |
-          brew untap local/python2
         displayName: MacOS Homebrew bug Workaround
     - ${{ if eq(parameters.pool.name, 'Hosted macOS') }}:
       - script: brew update && brew install $(Build.SourcesDirectory)/build/libomp.rb && brew install mono-libgdiplus && brew link libomp --force

--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -53,7 +53,7 @@ jobs:
     - ${{ if eq(parameters.pool.name, 'Hosted macOS') }}:
       - script: |
           brew uninstall openssl@1.0.2t |
-          brew untap local/openssl |
+          brew untap local/openssl
         displayName: MacOS Homebrew bug Workaround
     - ${{ if eq(parameters.pool.name, 'Hosted macOS') }}:
       - script: brew update && brew install $(Build.SourcesDirectory)/build/libomp.rb && brew install mono-libgdiplus && brew link libomp --force

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -46,7 +46,14 @@ phases:
   queue:
     name: Hosted macOS
   steps:
-  - script: brew update && brew install $(Build.SourcesDirectory)/build/libomp.rb && brew link libomp --force
+  # Work around MacOS Homebrew image/environment bug: https://github.com/actions/virtual-environments/issues/1811
+  - script: |
+      brew uninstall openssl@1.0.2t |
+      brew uninstall python@2.7.17 |
+      brew untap local/openssl |
+      brew untap local/python2
+    displayName: MacOS Homebrew bug Workaround
+  - script: brew update && brew install cmake $(Build.SourcesDirectory)/build/libomp.rb && brew install mono-libgdiplus gettext && brew link gettext --force && brew link libomp --force
     displayName: Install build dependencies
   # Only build native assets to avoid conflicts.
   - script: ./build.sh -buildNative -$(BuildConfig) -skipRIDAgnosticAssets

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -49,9 +49,11 @@ phases:
   # Work around MacOS Homebrew image/environment bug: https://github.com/actions/virtual-environments/issues/1811
   - script: |
       brew uninstall openssl@1.0.2t |
-      brew untap local/openssl
+      brew uninstall python@2.7.17 |
+      brew untap local/openssl |
+      brew untap local/python2
     displayName: MacOS Homebrew bug Workaround
-  - script: brew update && brew install $(Build.SourcesDirectory)/build/libomp.rb && brew install mono-libgdiplus && brew link libomp --force
+  - script: brew update && brew install $(Build.SourcesDirectory)/build/libomp.rb && brew link libomp --force
     displayName: Install build dependencies
   # Only build native assets to avoid conflicts.
   - script: ./build.sh -buildNative -$(BuildConfig) -skipRIDAgnosticAssets

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -49,9 +49,7 @@ phases:
   # Work around MacOS Homebrew image/environment bug: https://github.com/actions/virtual-environments/issues/1811
   - script: |
       brew uninstall openssl@1.0.2t |
-      brew uninstall python@2.7.17 |
       brew untap local/openssl |
-      brew untap local/python2
     displayName: MacOS Homebrew bug Workaround
   - script: brew update && brew install $(Build.SourcesDirectory)/build/libomp.rb && brew install mono-libgdiplus && brew link libomp --force
     displayName: Install build dependencies

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -49,7 +49,7 @@ phases:
   # Work around MacOS Homebrew image/environment bug: https://github.com/actions/virtual-environments/issues/1811
   - script: |
       brew uninstall openssl@1.0.2t |
-      brew untap local/openssl |
+      brew untap local/openssl
     displayName: MacOS Homebrew bug Workaround
   - script: brew update && brew install $(Build.SourcesDirectory)/build/libomp.rb && brew install mono-libgdiplus && brew link libomp --force
     displayName: Install build dependencies

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -53,7 +53,7 @@ phases:
       brew untap local/openssl |
       brew untap local/python2
     displayName: MacOS Homebrew bug Workaround
-  - script: brew update && brew install cmake $(Build.SourcesDirectory)/build/libomp.rb && brew install mono-libgdiplus gettext && brew link gettext --force && brew link libomp --force
+  - script: brew update && brew install $(Build.SourcesDirectory)/build/libomp.rb && brew install mono-libgdiplus && brew link libomp --force
     displayName: Install build dependencies
   # Only build native assets to avoid conflicts.
   - script: ./build.sh -buildNative -$(BuildConfig) -skipRIDAgnosticAssets


### PR DESCRIPTION
Similar to Issue #5457, the nightly ML.NET MacOS builds are failing due to the `openssl` package that is due to be removed from the MacOS images and an outdated standard Homebrew installation on CI's MacOS images, as discussed in the original MacOS-Homebrew GitHub [issue](https://github.com/actions/virtual-environments/issues/1811). This PR adds the fix for this issue.

It is said [in this comment](https://github.com/actions/virtual-environments/issues/1811#issuecomment-717348403) that the fix for this issue will be deployed in a few days, until which the changes in this PR will remain on main.