### PR TITLE
MaxModels exit criteria for AutoML unit test

### DIFF
--- a/test/Microsoft.ML.AutoML.Tests/AutoFitTests.cs
+++ b/test/Microsoft.ML.AutoML.Tests/AutoFitTests.cs
@@ -120,11 +120,11 @@ namespace Microsoft.ML.AutoML.Test
                 // the sweeper encounters problems when parsing some strings.
                 // So testing in another culture is necessary.
                 // Furthermore, these issues might only occur after ~70
-                // iterations, so more experiment time is needed for this to
-                // occur.
-                uint experimentTime = (uint) (culture == "en-US" ? 0 : 180);
+                // iterations, so setting the internal maxModels parameter.
+                int maxModels = culture == "en-US" ? 1 : 75;
 
-                var experimentSettings = new RegressionExperimentSettings { MaxExperimentTimeInSeconds = experimentTime};
+                var experimentSettings = new RegressionExperimentSettings { MaxModels = maxModels };
+
                 if (!Environment.Is64BitProcess)
                 {
                     // LightGBM isn't available on x86 machines
@@ -143,11 +143,10 @@ namespace Microsoft.ML.AutoML.Test
                     .Execute(trainData, validationData,
                         new ColumnInformation() { LabelColumnName = DatasetUtil.MlNetGeneratedRegressionLabel });
 
-                Assert.True(result.RunDetails.Max(i => i.ValidationMetrics.RSquared > 0.9));
+                Assert.True(result.RunDetails.Max(i => i.ValidationMetrics.RSquared) > 0.99);
 
-                // Ensure experimentTime allows enough iterations to fully test the internationalization code
-                // If the below assertion fails, increase the experiment time so the number of iterations is met
-                Assert.True(culture == "en-US" || result.RunDetails.Count() >= 75, $"RunDetails.Count() = {result.RunDetails.Count()}, below 75");
+                // Test the internal maxModels parameter
+                Assert.True(culture == "en-US" || result.RunDetails.Count() == 75, $"RunDetails.Count() = {result.RunDetails.Count()}, is not 75");
 
             }
             finally


### PR DESCRIPTION
Update to https://github.com/dotnet/machinelearning/pull/5163.

Uses the internal [`maxModels`](https://github.com/dotnet/machinelearning/blob/e50c4d20012e0d62852f404ae443afca7dad043e/src/Microsoft.ML.AutoML/API/ExperimentSettings.cs#L60) parameter instead of `MaxExperimentTimeInSeconds` for the exit criteria of AutoML. 

This is to increase the test stability in case the test is run on a slower machine.