### PR TITLE
ImageResizer bitmap ownership 

### DIFF
--- a/src/Microsoft.ML.ImageAnalytics/ImageResizer.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ImageResizer.cs
@@ -393,7 +393,10 @@ namespace Microsoft.ML.Transforms.Image
                             }
                         }
                         else
+                        {
                             dst = new Bitmap(info.ImageWidth, info.ImageHeight, src.PixelFormat);
+                        }
+
                         var srcRectangle = new Rectangle(sourceX, sourceY, sourceWidth, sourceHeight);
                         var destRectangle = new Rectangle(destX, destY, destWidth, destHeight);
                         using (var g = Graphics.FromImage(dst))

--- a/src/Microsoft.ML.ImageAnalytics/ImageResizer.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ImageResizer.cs
@@ -310,73 +310,72 @@ namespace Microsoft.ML.Transforms.Image
                         float aspect = 0;
                         float widthAspect = 0;
                         float heightAspect = 0;
-                        if (src.Height != info.ImageHeight || src.Width != info.ImageWidth)
+
+                        widthAspect = (float)info.ImageWidth / sourceWidth;
+                        heightAspect = (float)info.ImageHeight / sourceHeight;
+
+                        if (info.Resizing == ImageResizingEstimator.ResizingKind.IsoPad)
                         {
                             widthAspect = (float)info.ImageWidth / sourceWidth;
                             heightAspect = (float)info.ImageHeight / sourceHeight;
-
-                            if (info.Resizing == ImageResizingEstimator.ResizingKind.IsoPad)
+                            if (heightAspect < widthAspect)
                             {
-                                widthAspect = (float)info.ImageWidth / sourceWidth;
-                                heightAspect = (float)info.ImageHeight / sourceHeight;
-                                if (heightAspect < widthAspect)
-                                {
-                                    aspect = heightAspect;
-                                    destX = (int)((info.ImageWidth - (sourceWidth * aspect)) / 2);
-                                }
-                                else
-                                {
-                                    aspect = widthAspect;
-                                    destY = (int)((info.ImageHeight - (sourceHeight * aspect)) / 2);
-                                }
-
-                                destWidth = (int)(sourceWidth * aspect);
-                                destHeight = (int)(sourceHeight * aspect);
+                                aspect = heightAspect;
+                                destX = (int)((info.ImageWidth - (sourceWidth * aspect)) / 2);
                             }
-                            else if (info.Resizing == ImageResizingEstimator.ResizingKind.IsoCrop)
+                            else
                             {
-                                if (heightAspect < widthAspect)
-                                {
-                                    aspect = widthAspect;
-                                    switch (info.Anchor)
-                                    {
-                                        case ImageResizingEstimator.Anchor.Top:
-                                            destY = 0;
-                                            break;
-                                        case ImageResizingEstimator.Anchor.Bottom:
-                                            destY = (int)(info.ImageHeight - (sourceHeight * aspect));
-                                            break;
-                                        default:
-                                            destY = (int)((info.ImageHeight - (sourceHeight * aspect)) / 2);
-                                            break;
-                                    }
-                                }
-                                else
-                                {
-                                    aspect = heightAspect;
-                                    switch (info.Anchor)
-                                    {
-                                        case ImageResizingEstimator.Anchor.Left:
-                                            destX = 0;
-                                            break;
-                                        case ImageResizingEstimator.Anchor.Right:
-                                            destX = (int)(info.ImageWidth - (sourceWidth * aspect));
-                                            break;
-                                        default:
-                                            destX = (int)((info.ImageWidth - (sourceWidth * aspect)) / 2);
-                                            break;
-                                    }
-                                }
+                                aspect = widthAspect;
+                                destY = (int)((info.ImageHeight - (sourceHeight * aspect)) / 2);
+                            }
 
-                                destWidth = (int)(sourceWidth * aspect);
-                                destHeight = (int)(sourceHeight * aspect);
-                            }
-                            else if (info.Resizing == ImageResizingEstimator.ResizingKind.Fill)
-                            {
-                                destWidth = info.ImageWidth;
-                                destHeight = info.ImageHeight;
-                            }
+                            destWidth = (int)(sourceWidth * aspect);
+                            destHeight = (int)(sourceHeight * aspect);
                         }
+                        else if (info.Resizing == ImageResizingEstimator.ResizingKind.IsoCrop)
+                        {
+                            if (heightAspect < widthAspect)
+                            {
+                                aspect = widthAspect;
+                                switch (info.Anchor)
+                                {
+                                    case ImageResizingEstimator.Anchor.Top:
+                                        destY = 0;
+                                        break;
+                                    case ImageResizingEstimator.Anchor.Bottom:
+                                        destY = (int)(info.ImageHeight - (sourceHeight * aspect));
+                                        break;
+                                    default:
+                                        destY = (int)((info.ImageHeight - (sourceHeight * aspect)) / 2);
+                                        break;
+                                }
+                            }
+                            else
+                            {
+                                aspect = heightAspect;
+                                switch (info.Anchor)
+                                {
+                                    case ImageResizingEstimator.Anchor.Left:
+                                        destX = 0;
+                                        break;
+                                    case ImageResizingEstimator.Anchor.Right:
+                                        destX = (int)(info.ImageWidth - (sourceWidth * aspect));
+                                        break;
+                                    default:
+                                        destX = (int)((info.ImageWidth - (sourceWidth * aspect)) / 2);
+                                        break;
+                                }
+                            }
+
+                            destWidth = (int)(sourceWidth * aspect);
+                            destHeight = (int)(sourceHeight * aspect);
+                        }
+                        else if (info.Resizing == ImageResizingEstimator.ResizingKind.Fill)
+                        {
+                            destWidth = info.ImageWidth;
+                            destHeight = info.ImageHeight;
+                        }
+
                         // Graphics.DrawImage() does not support PixelFormat.Indexed. Hence convert the
                         // pixel format to Format32bppArgb as described here https://stackoverflow.com/questions/17313285/graphics-on-indexed-image
                         // For images with invalid pixel format also use Format32bppArgb to draw the resized image.

--- a/src/Microsoft.ML.ImageAnalytics/ImageResizer.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ImageResizer.cs
@@ -292,12 +292,17 @@ namespace Microsoft.ML.Transforms.Image
                 ValueGetter<Bitmap> del =
                     (ref Bitmap dst) =>
                     {
-                        if (dst != null)
-                            dst.Dispose();
-
                         getSrc(ref src);
                         if (src == null || src.Height <= 0 || src.Width <= 0)
                             return;
+
+                        if (src.Height == info.ImageHeight && src.Width == info.ImageWidth)
+                        {
+                            dst = src;
+                            return;
+                        }
+                        else if(dst != null)
+                            dst.Dispose();
 
                         int sourceWidth = src.Width;
                         int sourceHeight = src.Height;

--- a/src/Microsoft.ML.ImageAnalytics/ImageResizer.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ImageResizer.cs
@@ -298,11 +298,6 @@ namespace Microsoft.ML.Transforms.Image
                         getSrc(ref src);
                         if (src == null || src.Height <= 0 || src.Width <= 0)
                             return;
-                        if (src.Height == info.ImageHeight && src.Width == info.ImageWidth)
-                        {
-                            dst = src;
-                            return;
-                        }
 
                         int sourceWidth = src.Width;
                         int sourceHeight = src.Height;
@@ -315,72 +310,73 @@ namespace Microsoft.ML.Transforms.Image
                         float aspect = 0;
                         float widthAspect = 0;
                         float heightAspect = 0;
-
-                        widthAspect = (float)info.ImageWidth / sourceWidth;
-                        heightAspect = (float)info.ImageHeight / sourceHeight;
-
-                        if (info.Resizing == ImageResizingEstimator.ResizingKind.IsoPad)
+                        if (src.Height != info.ImageHeight || src.Width != info.ImageWidth)
                         {
                             widthAspect = (float)info.ImageWidth / sourceWidth;
                             heightAspect = (float)info.ImageHeight / sourceHeight;
-                            if (heightAspect < widthAspect)
-                            {
-                                aspect = heightAspect;
-                                destX = (int)((info.ImageWidth - (sourceWidth * aspect)) / 2);
-                            }
-                            else
-                            {
-                                aspect = widthAspect;
-                                destY = (int)((info.ImageHeight - (sourceHeight * aspect)) / 2);
-                            }
 
-                            destWidth = (int)(sourceWidth * aspect);
-                            destHeight = (int)(sourceHeight * aspect);
-                        }
-                        else if (info.Resizing == ImageResizingEstimator.ResizingKind.IsoCrop)
-                        {
-                            if (heightAspect < widthAspect)
+                            if (info.Resizing == ImageResizingEstimator.ResizingKind.IsoPad)
                             {
-                                aspect = widthAspect;
-                                switch (info.Anchor)
+                                widthAspect = (float)info.ImageWidth / sourceWidth;
+                                heightAspect = (float)info.ImageHeight / sourceHeight;
+                                if (heightAspect < widthAspect)
                                 {
-                                    case ImageResizingEstimator.Anchor.Top:
-                                        destY = 0;
-                                        break;
-                                    case ImageResizingEstimator.Anchor.Bottom:
-                                        destY = (int)(info.ImageHeight - (sourceHeight * aspect));
-                                        break;
-                                    default:
-                                        destY = (int)((info.ImageHeight - (sourceHeight * aspect)) / 2);
-                                        break;
+                                    aspect = heightAspect;
+                                    destX = (int)((info.ImageWidth - (sourceWidth * aspect)) / 2);
                                 }
-                            }
-                            else
-                            {
-                                aspect = heightAspect;
-                                switch (info.Anchor)
+                                else
                                 {
-                                    case ImageResizingEstimator.Anchor.Left:
-                                        destX = 0;
-                                        break;
-                                    case ImageResizingEstimator.Anchor.Right:
-                                        destX = (int)(info.ImageWidth - (sourceWidth * aspect));
-                                        break;
-                                    default:
-                                        destX = (int)((info.ImageWidth - (sourceWidth * aspect)) / 2);
-                                        break;
+                                    aspect = widthAspect;
+                                    destY = (int)((info.ImageHeight - (sourceHeight * aspect)) / 2);
                                 }
+
+                                destWidth = (int)(sourceWidth * aspect);
+                                destHeight = (int)(sourceHeight * aspect);
                             }
+                            else if (info.Resizing == ImageResizingEstimator.ResizingKind.IsoCrop)
+                            {
+                                if (heightAspect < widthAspect)
+                                {
+                                    aspect = widthAspect;
+                                    switch (info.Anchor)
+                                    {
+                                        case ImageResizingEstimator.Anchor.Top:
+                                            destY = 0;
+                                            break;
+                                        case ImageResizingEstimator.Anchor.Bottom:
+                                            destY = (int)(info.ImageHeight - (sourceHeight * aspect));
+                                            break;
+                                        default:
+                                            destY = (int)((info.ImageHeight - (sourceHeight * aspect)) / 2);
+                                            break;
+                                    }
+                                }
+                                else
+                                {
+                                    aspect = heightAspect;
+                                    switch (info.Anchor)
+                                    {
+                                        case ImageResizingEstimator.Anchor.Left:
+                                            destX = 0;
+                                            break;
+                                        case ImageResizingEstimator.Anchor.Right:
+                                            destX = (int)(info.ImageWidth - (sourceWidth * aspect));
+                                            break;
+                                        default:
+                                            destX = (int)((info.ImageWidth - (sourceWidth * aspect)) / 2);
+                                            break;
+                                    }
+                                }
 
-                            destWidth = (int)(sourceWidth * aspect);
-                            destHeight = (int)(sourceHeight * aspect);
+                                destWidth = (int)(sourceWidth * aspect);
+                                destHeight = (int)(sourceHeight * aspect);
+                            }
+                            else if (info.Resizing == ImageResizingEstimator.ResizingKind.Fill)
+                            {
+                                destWidth = info.ImageWidth;
+                                destHeight = info.ImageHeight;
+                            }
                         }
-                        else if (info.Resizing == ImageResizingEstimator.ResizingKind.Fill)
-                        {
-                            destWidth = info.ImageWidth;
-                            destHeight = info.ImageHeight;
-                        }
-
                         // Graphics.DrawImage() does not support PixelFormat.Indexed. Hence convert the
                         // pixel format to Format32bppArgb as described here https://stackoverflow.com/questions/17313285/graphics-on-indexed-image
                         // For images with invalid pixel format also use Format32bppArgb to draw the resized image.
@@ -399,7 +395,6 @@ namespace Microsoft.ML.Transforms.Image
                         }
                         else
                             dst = new Bitmap(info.ImageWidth, info.ImageHeight, src.PixelFormat);
-
                         var srcRectangle = new Rectangle(sourceX, sourceY, sourceWidth, sourceHeight);
                         var destRectangle = new Rectangle(destX, destY, destWidth, destHeight);
                         using (var g = Graphics.FromImage(dst))

--- a/src/Microsoft.ML.ImageAnalytics/ImageResizer.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ImageResizer.cs
@@ -292,17 +292,12 @@ namespace Microsoft.ML.Transforms.Image
                 ValueGetter<Bitmap> del =
                     (ref Bitmap dst) =>
                     {
+                        if (dst != null)
+                            dst.Dispose();
+
                         getSrc(ref src);
                         if (src == null || src.Height <= 0 || src.Width <= 0)
                             return;
-
-                        if (src.Height == info.ImageHeight && src.Width == info.ImageWidth)
-                        {
-                            dst = src;
-                            return;
-                        }
-                        else if(dst != null)
-                            dst.Dispose();
 
                         int sourceWidth = src.Width;
                         int sourceHeight = src.Height;
@@ -398,9 +393,7 @@ namespace Microsoft.ML.Transforms.Image
                             }
                         }
                         else
-                        {
                             dst = new Bitmap(info.ImageWidth, info.ImageHeight, src.PixelFormat);
-                        }
 
                         var srcRectangle = new Rectangle(sourceX, sourceY, sourceWidth, sourceHeight);
                         var destRectangle = new Rectangle(destX, destY, destWidth, destHeight);

--- a/test/Microsoft.ML.Tests/ImagesTests.cs
+++ b/test/Microsoft.ML.Tests/ImagesTests.cs
@@ -815,8 +815,10 @@ namespace Microsoft.ML.Tests
             }
         }
 
-        [Fact]
-        public void ImageResizerTransformResizingModeFill()
+        [Theory]
+        [CombinatorialData]
+        public void ImageResizerTransformResizingModeFillSameSIze([CombinatorialValues(200, 50)] int imageWidth,
+            [CombinatorialValues(100, 50)] int imageHeight)
         {
             var env = new MLContext(1);
             var dataFile = GetDataPath("images/fillmode.tsv");
@@ -829,9 +831,8 @@ namespace Microsoft.ML.Tests
                 }
             }, new MultiFileSource(dataFile));
 
-            const int targetDimension = 50;
             var pipe = new ImageLoadingEstimator(env, imageFolder, ("ImageReal", "ImagePath"))
-                .Append(new ImageResizingEstimator(env, "ImageReal", targetDimension, targetDimension, "ImageReal",
+                .Append(new ImageResizingEstimator(env, "ImageReal", imageWidth, imageHeight, "ImageReal",
                     resizing: ImageResizingEstimator.ResizingKind.Fill));
 
             var rowView = pipe.Preview(data).RowView;
@@ -867,7 +868,6 @@ namespace Microsoft.ML.Tests
                     Assert.True(c.B < 6);
                 });
             }
-
             Done();
         }
 

--- a/test/Microsoft.ML.Tests/ImagesTests.cs
+++ b/test/Microsoft.ML.Tests/ImagesTests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.ML.Tests
             }, new MultiFileSource(dataFile));
 
             var pipe = new ImageLoadingEstimator(env, imageFolder, ("ImageReal", "ImagePath"))
-                .Append(new ImageResizingEstimator(env, "ImageReal", 100, 100, "ImageReal"))
+                .Append(new ImageResizingEstimator(env, "ImageReal", 800, 534, "ImageReal"))
                 .Append(new ImagePixelExtractingEstimator(env, "ImagePixels", "ImageReal"))
                 .Append(new ImageGrayscalingEstimator(env, ("ImageGray", "ImageReal")));
 
@@ -815,10 +815,8 @@ namespace Microsoft.ML.Tests
             }
         }
 
-        [Theory]
-        [CombinatorialData]
-        public void ImageResizerTransformResizingModeFillSameSIze([CombinatorialValues(200, 50)] int imageWidth,
-            [CombinatorialValues(100, 50)] int imageHeight)
+        [Fact]
+        public void ImageResizerTransformResizingModeFill()
         {
             var env = new MLContext(1);
             var dataFile = GetDataPath("images/fillmode.tsv");
@@ -831,8 +829,9 @@ namespace Microsoft.ML.Tests
                 }
             }, new MultiFileSource(dataFile));
 
+            const int targetDimension = 50;
             var pipe = new ImageLoadingEstimator(env, imageFolder, ("ImageReal", "ImagePath"))
-                .Append(new ImageResizingEstimator(env, "ImageReal", imageWidth, imageHeight, "ImageReal",
+                .Append(new ImageResizingEstimator(env, "ImageReal", targetDimension, targetDimension, "ImageReal",
                     resizing: ImageResizingEstimator.ResizingKind.Fill));
 
             var rowView = pipe.Preview(data).RowView;


### PR DESCRIPTION
This PR fixes #5469. The issue is coming from the assumption that `ImageResizer` creates a separate `Bitmap`, but when image is already the target dimension `ImageResizer` actually simply returns the source image. Other image methods are likely to dispose of the source image. For example, in this test a getter method get's called twice, and on the second call the source image gets disposed, causing the error. 

A transformer should only be responsible of disposing the objects it creates. One attempt to solve this issue was to keep track of the last Bitmap created to ensure we don't dispose of an object that was not created within  `ImageResizer.` However, the issue encountered with this approach is that the object created by another transformer may be deleted if that transform gets called again. This happens because the source buffers get reused, so image transforms will dispose the previous source image object when they get called again.  


https://github.com/dotnet/machinelearning/blob/master/src/Microsoft.ML.ImageAnalytics/ImageLoader.cs#L238