### PR TITLE
Fixing failing Arcade Windows Builds

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -30,7 +30,6 @@ jobs:
     innerLoop: true
     pool:
       name: Hosted Ubuntu 1604
-    spaceValue: '%20'
 
 - template: /build/ci/job-template.yml
   parameters:
@@ -40,7 +39,6 @@ jobs:
     innerLoop: true
     pool:
       name: Hosted Ubuntu 1604
-    spaceValue: '%20'
 
 - template: /build/ci/job-template.yml
   parameters:
@@ -49,7 +47,6 @@ jobs:
     innerLoop: true
     pool:
       name: Hosted macOS
-    spaceValue: '%20'
 
 - template: /build/ci/job-template.yml
   parameters:
@@ -70,7 +67,6 @@ jobs:
     vsTestConfiguration: "/Framework:.NETCoreApp,Version=v3.0"
     pool:
       name: Hosted VS2017
-    spaceValue: ' '
 
 - template: /build/ci/job-template.yml
   parameters:
@@ -80,7 +76,6 @@ jobs:
     vsTestConfiguration: "/Framework:.NETCoreApp,Version=v2.1"
     pool:
       name: Hosted VS2017
-    spaceValue: ' '
 
 - template: /build/ci/job-template.yml
   parameters:
@@ -101,7 +96,6 @@ jobs:
     vsTestConfiguration: "/Framework:.NETCoreApp,Version=v4.0"
     pool:
       name: Hosted VS2017
-    spaceValue: ' '
 
 - template: /build/ci/job-template.yml
   parameters:
@@ -112,4 +106,3 @@ jobs:
     vsTestConfiguration: "/Framework:.NETCoreApp,Version=v2.1"
     pool:
       name: Hosted VS2017
-    spaceValue: ' '

--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -30,6 +30,7 @@ jobs:
     innerLoop: true
     pool:
       name: Hosted Ubuntu 1604
+    spaceValue: '%20'
 
 - template: /build/ci/job-template.yml
   parameters:
@@ -39,6 +40,7 @@ jobs:
     innerLoop: true
     pool:
       name: Hosted Ubuntu 1604
+    spaceValue: '%20'
 
 - template: /build/ci/job-template.yml
   parameters:
@@ -47,6 +49,7 @@ jobs:
     innerLoop: true
     pool:
       name: Hosted macOS
+    spaceValue: '%20'
 
 - template: /build/ci/job-template.yml
   parameters:
@@ -67,6 +70,7 @@ jobs:
     vsTestConfiguration: "/Framework:.NETCoreApp,Version=v3.0"
     pool:
       name: Hosted VS2017
+    spaceValue: ' '
 
 - template: /build/ci/job-template.yml
   parameters:
@@ -76,6 +80,7 @@ jobs:
     vsTestConfiguration: "/Framework:.NETCoreApp,Version=v2.1"
     pool:
       name: Hosted VS2017
+    spaceValue: ' '
 
 - template: /build/ci/job-template.yml
   parameters:
@@ -96,6 +101,7 @@ jobs:
     vsTestConfiguration: "/Framework:.NETCoreApp,Version=v4.0"
     pool:
       name: Hosted VS2017
+    spaceValue: ' '
 
 - template: /build/ci/job-template.yml
   parameters:
@@ -106,3 +112,4 @@ jobs:
     vsTestConfiguration: "/Framework:.NETCoreApp,Version=v2.1"
     pool:
       name: Hosted VS2017
+    spaceValue: ' '

--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -11,6 +11,7 @@ parameters:
   runSpecific: false
   container: ''
   useVSTestTask: false
+  spaceValue : ' '
 
 jobs:
   - job: ${{ parameters.name }}
@@ -48,6 +49,8 @@ jobs:
     pool: ${{ parameters.pool }}
     ${{ if ne(parameters.container, '') }}:
       container: ${{ parameters.container }}
+    ${{ if eq(parameters.buildScript, './build.sh') }}:
+      parameters.spaceValue: '%20'
 
     steps:
     # Work around MacOS Homebrew image/environment bug: https://github.com/actions/virtual-environments/issues/1811
@@ -115,7 +118,7 @@ jobs:
           - script: ${{ parameters.buildScript }} -configuration $(_configuration) -test -ci #-coverage=${{ parameters.codeCoverage }}
             displayName: Run All Tests.
         - ${{ if and(eq(parameters.runSpecific, 'true'), eq(parameters.useVSTestTask, 'false')) }}:
-          - script: ${{ parameters.buildScript }} -configuration $(_configuration) -ci /p:TestRunnerAdditionalArguments='-trait Category=RunSpecificTest' #-coverage=${{ parameters.codeCoverage }}
+          - script: ${{ parameters.buildScript }} -configuration $(_configuration) -ci /p:TestRunnerAdditionalArguments='-trait${{ parameters.spaceValue }}Category=RunSpecificTest' #-coverage=${{ parameters.codeCoverage }}
             displayName: Run Specific Tests.
         - ${{ if and(eq(parameters.buildScript, 'build.cmd'), eq(parameters.useVSTestTask, 'true')) }}:
           - task: VSTest@2
@@ -139,7 +142,7 @@ jobs:
               collectDumpOn: onAbortOnly
               publishRunAttachments: true
       - ${{ if eq(parameters.innerLoop, 'true') }}:
-        - script: ${{ parameters.buildScript }} -configuration $(_configuration) -test -ci /p:TestRunnerAdditionalArguments='-notrait Category=SkipInCI' #-coverage=${{ parameters.codeCoverage }}
+        - script: ${{ parameters.buildScript }} -configuration $(_configuration) -test -ci /p:TestRunnerAdditionalArguments='-notrait${{ parameters.spaceValue }}Category=SkipInCI' #-coverage=${{ parameters.codeCoverage }}
           displayName: Run CI Tests.
     - script: $(dotnetPath) msbuild -restore build/Codecoverage.proj
       displayName: Upload coverage to codecov.io

--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -115,7 +115,7 @@ jobs:
           - script: ${{ parameters.buildScript }} -configuration $(_configuration) -test -ci #-coverage=${{ parameters.codeCoverage }}
             displayName: Run All Tests.
         - ${{ if and(eq(parameters.runSpecific, 'true'), eq(parameters.useVSTestTask, 'false')) }}:
-          - script: ${{ parameters.buildScript }} -configuration $(_configuration) -ci /p:TestRunnerAdditionalArguments='-trait%20Category=RunSpecificTest' #-coverage=${{ parameters.codeCoverage }}
+          - script: ${{ parameters.buildScript }} -configuration $(_configuration) -ci /p:TestRunnerAdditionalArguments='-trait Category=RunSpecificTest' #-coverage=${{ parameters.codeCoverage }}
             displayName: Run Specific Tests.
         - ${{ if and(eq(parameters.buildScript, 'build.cmd'), eq(parameters.useVSTestTask, 'true')) }}:
           - task: VSTest@2
@@ -139,7 +139,7 @@ jobs:
               collectDumpOn: onAbortOnly
               publishRunAttachments: true
       - ${{ if eq(parameters.innerLoop, 'true') }}:
-        - script: ${{ parameters.buildScript }} -configuration $(_configuration) -test -ci /p:TestRunnerAdditionalArguments='-notrait%20Category=SkipInCI' #-coverage=${{ parameters.codeCoverage }}
+        - script: ${{ parameters.buildScript }} -configuration $(_configuration) -test -ci /p:TestRunnerAdditionalArguments='-notrait Category=SkipInCI' #-coverage=${{ parameters.codeCoverage }}
           displayName: Run CI Tests.
     - script: $(dotnetPath) msbuild -restore build/Codecoverage.proj
       displayName: Upload coverage to codecov.io

--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -11,6 +11,7 @@ parameters:
   runSpecific: false
   container: ''
   useVSTestTask: false
+  spaceValue : ' '
 
 jobs:
   - job: ${{ parameters.name }}
@@ -29,9 +30,6 @@ jobs:
       packageUpdaterProjPath: $(Build.SourcesDirectory)/test/Microsoft.ML.NugetPackageVersionUpdater/Microsoft.ML.NugetPackageVersionUpdater.csproj
       versionFilePath: $(Build.SourcesDirectory)/test/Microsoft.ML.NugetPackageVersionUpdater/latest_versions.txt
       PROCDUMP_PATH: '$(Build.SourcesDirectory)/Tools/ProcDump/'
-      spaceValue : ' '
-      ${{ if eq(parameters.buildScript, './build.sh') }}:
-        spaceValue: '%20'
     strategy:
       matrix:
         ${{ if eq(parameters.customMatrixes, '') }}:
@@ -118,7 +116,7 @@ jobs:
           - script: ${{ parameters.buildScript }} -configuration $(_configuration) -test -ci #-coverage=${{ parameters.codeCoverage }}
             displayName: Run All Tests.
         - ${{ if and(eq(parameters.runSpecific, 'true'), eq(parameters.useVSTestTask, 'false')) }}:
-          - script: ${{ parameters.buildScript }} -configuration $(_configuration) -ci /p:TestRunnerAdditionalArguments='-trait$(spaceValue)Category=RunSpecificTest' #-coverage=${{ parameters.codeCoverage }}
+          - script: ${{ parameters.buildScript }} -configuration $(_configuration) -ci /p:TestRunnerAdditionalArguments='-trait${{ parameters.spaceValue }}Category=RunSpecificTest' #-coverage=${{ parameters.codeCoverage }}
             displayName: Run Specific Tests.
         - ${{ if and(eq(parameters.buildScript, 'build.cmd'), eq(parameters.useVSTestTask, 'true')) }}:
           - task: VSTest@2
@@ -142,7 +140,7 @@ jobs:
               collectDumpOn: onAbortOnly
               publishRunAttachments: true
       - ${{ if eq(parameters.innerLoop, 'true') }}:
-        - script: ${{ parameters.buildScript }} -configuration $(_configuration) -test -ci /p:TestRunnerAdditionalArguments='-notrait$(spaceValue)Category=SkipInCI' #-coverage=${{ parameters.codeCoverage }}
+        - script: ${{ parameters.buildScript }} -configuration $(_configuration) -test -ci /p:TestRunnerAdditionalArguments='-notrait${{ parameters.spaceValue }}Category=SkipInCI' #-coverage=${{ parameters.codeCoverage }}
           displayName: Run CI Tests.
     - script: $(dotnetPath) msbuild -restore build/Codecoverage.proj
       displayName: Upload coverage to codecov.io

--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -11,7 +11,6 @@ parameters:
   runSpecific: false
   container: ''
   useVSTestTask: false
-  spaceValue : ' '
 
 jobs:
   - job: ${{ parameters.name }}
@@ -30,6 +29,10 @@ jobs:
       packageUpdaterProjPath: $(Build.SourcesDirectory)/test/Microsoft.ML.NugetPackageVersionUpdater/Microsoft.ML.NugetPackageVersionUpdater.csproj
       versionFilePath: $(Build.SourcesDirectory)/test/Microsoft.ML.NugetPackageVersionUpdater/latest_versions.txt
       PROCDUMP_PATH: '$(Build.SourcesDirectory)/Tools/ProcDump/'
+      ${{ if eq(parameters.buildScript, 'build.cmd') }}:
+        spaceValue: ' '
+      ${{ if eq(parameters.buildScript, './build.sh') }}:
+        spaceValue: '%20'
     strategy:
       matrix:
         ${{ if eq(parameters.customMatrixes, '') }}:
@@ -116,7 +119,7 @@ jobs:
           - script: ${{ parameters.buildScript }} -configuration $(_configuration) -test -ci #-coverage=${{ parameters.codeCoverage }}
             displayName: Run All Tests.
         - ${{ if and(eq(parameters.runSpecific, 'true'), eq(parameters.useVSTestTask, 'false')) }}:
-          - script: ${{ parameters.buildScript }} -configuration $(_configuration) -ci /p:TestRunnerAdditionalArguments='-trait${{ parameters.spaceValue }}Category=RunSpecificTest' #-coverage=${{ parameters.codeCoverage }}
+          - script: ${{ parameters.buildScript }} -configuration $(_configuration) -ci /p:TestRunnerAdditionalArguments='-trait$(spaceValue)Category=RunSpecificTest' #-coverage=${{ parameters.codeCoverage }}
             displayName: Run Specific Tests.
         - ${{ if and(eq(parameters.buildScript, 'build.cmd'), eq(parameters.useVSTestTask, 'true')) }}:
           - task: VSTest@2
@@ -140,7 +143,7 @@ jobs:
               collectDumpOn: onAbortOnly
               publishRunAttachments: true
       - ${{ if eq(parameters.innerLoop, 'true') }}:
-        - script: ${{ parameters.buildScript }} -configuration $(_configuration) -test -ci /p:TestRunnerAdditionalArguments='-notrait${{ parameters.spaceValue }}Category=SkipInCI' #-coverage=${{ parameters.codeCoverage }}
+        - script: ${{ parameters.buildScript }} -configuration $(_configuration) -test -ci /p:TestRunnerAdditionalArguments='-notrait$(spaceValue)Category=SkipInCI' #-coverage=${{ parameters.codeCoverage }}
           displayName: Run CI Tests.
     - script: $(dotnetPath) msbuild -restore build/Codecoverage.proj
       displayName: Upload coverage to codecov.io

--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -112,10 +112,10 @@ jobs:
       - ${{ if eq(parameters.innerLoop, 'false') }}:
         - ${{ if and(eq(parameters.runSpecific, 'false'), eq(parameters.useVSTestTask, 'false')) }}:
           # TODO: Code coverage needs to be fixed.
-          - script: ${{ parameters.buildScript }} -configuration $(_configuration) -test -ci /p:TestRunnerAdditionalArguments=-notrait%20Category=SkipInCI #-coverage=${{ parameters.codeCoverage }}
+          - script: ${{ parameters.buildScript }} -configuration $(_configuration) -test -ci #-coverage=${{ parameters.codeCoverage }}
             displayName: Run All Tests.
         - ${{ if and(eq(parameters.runSpecific, 'true'), eq(parameters.useVSTestTask, 'false')) }}:
-          - script: ${{ parameters.buildScript }} -configuration $(_configuration) -ci /p:TestRunnerAdditionalArguments=-trait%20Category=RunSpecificTest #-coverage=${{ parameters.codeCoverage }}
+          - script: ${{ parameters.buildScript }} -configuration $(_configuration) -ci /p:TestRunnerAdditionalArguments='-trait%20Category=RunSpecificTest' #-coverage=${{ parameters.codeCoverage }}
             displayName: Run Specific Tests.
         - ${{ if and(eq(parameters.buildScript, 'build.cmd'), eq(parameters.useVSTestTask, 'true')) }}:
           - task: VSTest@2
@@ -139,7 +139,7 @@ jobs:
               collectDumpOn: onAbortOnly
               publishRunAttachments: true
       - ${{ if eq(parameters.innerLoop, 'true') }}:
-        - script: ${{ parameters.buildScript }} -configuration $(_configuration) -test -ci /p:TestRunnerAdditionalArguments=-notrait%20Category=SkipInCI #-coverage=${{ parameters.codeCoverage }}
+        - script: ${{ parameters.buildScript }} -configuration $(_configuration) -test -ci /p:TestRunnerAdditionalArguments='-notrait%20Category=SkipInCI' #-coverage=${{ parameters.codeCoverage }}
           displayName: Run CI Tests.
     - script: $(dotnetPath) msbuild -restore build/Codecoverage.proj
       displayName: Upload coverage to codecov.io

--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -11,7 +11,6 @@ parameters:
   runSpecific: false
   container: ''
   useVSTestTask: false
-  spaceValue : ' '
 
 jobs:
   - job: ${{ parameters.name }}
@@ -30,6 +29,9 @@ jobs:
       packageUpdaterProjPath: $(Build.SourcesDirectory)/test/Microsoft.ML.NugetPackageVersionUpdater/Microsoft.ML.NugetPackageVersionUpdater.csproj
       versionFilePath: $(Build.SourcesDirectory)/test/Microsoft.ML.NugetPackageVersionUpdater/latest_versions.txt
       PROCDUMP_PATH: '$(Build.SourcesDirectory)/Tools/ProcDump/'
+      spaceValue : ' '
+      ${{ if eq(parameters.buildScript, './build.sh') }}:
+        spaceValue: '%20'
     strategy:
       matrix:
         ${{ if eq(parameters.customMatrixes, '') }}:
@@ -49,8 +51,6 @@ jobs:
     pool: ${{ parameters.pool }}
     ${{ if ne(parameters.container, '') }}:
       container: ${{ parameters.container }}
-    ${{ if eq(parameters.buildScript, './build.sh') }}:
-      parameters.spaceValue: '%20'
 
     steps:
     # Work around MacOS Homebrew image/environment bug: https://github.com/actions/virtual-environments/issues/1811
@@ -118,7 +118,7 @@ jobs:
           - script: ${{ parameters.buildScript }} -configuration $(_configuration) -test -ci #-coverage=${{ parameters.codeCoverage }}
             displayName: Run All Tests.
         - ${{ if and(eq(parameters.runSpecific, 'true'), eq(parameters.useVSTestTask, 'false')) }}:
-          - script: ${{ parameters.buildScript }} -configuration $(_configuration) -ci /p:TestRunnerAdditionalArguments='-trait${{ parameters.spaceValue }}Category=RunSpecificTest' #-coverage=${{ parameters.codeCoverage }}
+          - script: ${{ parameters.buildScript }} -configuration $(_configuration) -ci /p:TestRunnerAdditionalArguments='-trait$(spaceValue)Category=RunSpecificTest' #-coverage=${{ parameters.codeCoverage }}
             displayName: Run Specific Tests.
         - ${{ if and(eq(parameters.buildScript, 'build.cmd'), eq(parameters.useVSTestTask, 'true')) }}:
           - task: VSTest@2
@@ -142,7 +142,7 @@ jobs:
               collectDumpOn: onAbortOnly
               publishRunAttachments: true
       - ${{ if eq(parameters.innerLoop, 'true') }}:
-        - script: ${{ parameters.buildScript }} -configuration $(_configuration) -test -ci /p:TestRunnerAdditionalArguments='-notrait${{ parameters.spaceValue }}Category=SkipInCI' #-coverage=${{ parameters.codeCoverage }}
+        - script: ${{ parameters.buildScript }} -configuration $(_configuration) -test -ci /p:TestRunnerAdditionalArguments='-notrait$(spaceValue)Category=SkipInCI' #-coverage=${{ parameters.codeCoverage }}
           displayName: Run CI Tests.
     - script: $(dotnetPath) msbuild -restore build/Codecoverage.proj
       displayName: Upload coverage to codecov.io


### PR DESCRIPTION
Fixed the `%20` space error causing Arcade Windows builds to fail, added conditional space variable to be `' '` in Linux/MacOS and `'%20'` on Windows.