### PR TITLE
Added Forward Compatibility Error

### DIFF
--- a/src/Microsoft.ML.Core/Data/ModelHeader.cs
+++ b/src/Microsoft.ML.Core/Data/ModelHeader.cs
@@ -348,18 +348,19 @@ namespace Microsoft.ML
         /// </summary>
         public static void CheckVersionInfo(ref ModelHeader header, VersionInfo ver)
         {
-
             Contracts.CheckDecode(header.ModelSignature == ver.ModelSignature, "Unknown file type");
             Contracts.CheckDecode(header.ModelVerReadable <= header.ModelVerWritten, "Corrupt file header");
             if (header.ModelVerReadable > ver.VerWrittenCur)
-                throw Contracts.ExceptDecode("Cause: ML.NET {0} cannont read component '{1}' of the model, because the model is too new.\n" +
+                throw Contracts.ExceptDecode("Cause: ML.NET {0} cannot read component '{1}' of the model, because the model is too new.\n" +
                                 "Suggestion: Make sure the model is trained with ML.NET {0} or older.\n" +
                                 "Debug details: Maximum expected version {2}, got {3}.",
                                 typeof(VersionInfo).Assembly.GetName().Version, ver.LoaderSignature, header.ModelVerReadable, ver.VerWrittenCur);
             if (header.ModelVerWritten > ver.VerWrittenCur)
             {
-                throw Contracts.ExceptDecode("Model was trained on a newer version of ML․NET. " +
-                    "Forward compatibility is not guaranteed. Please update your ML.NET version");
+                throw Contracts.ExceptDecode("The model was trained on a newer version of ML․NET.\n" +
+                    "Please update your ML.NET version, as forward compatibility is not guaranteed.\n" +
+                    "Debug details: Maximum expected version {0}, got {1}.",
+                    ver.VerWrittenCur, header.ModelVerWritten);
             }
             if (header.ModelVerWritten < ver.VerWeCanReadBack)
             {

--- a/src/Microsoft.ML.Core/Data/ModelHeader.cs
+++ b/src/Microsoft.ML.Core/Data/ModelHeader.cs
@@ -355,10 +355,12 @@ namespace Microsoft.ML
                                 "Suggestion: Make sure the model is trained with ML.NET {0} or older.\n" +
                                 "Debug details: Maximum expected version {2}, got {3}.",
                                 typeof(VersionInfo).Assembly.GetName().Version, ver.LoaderSignature, header.ModelVerReadable, ver.VerWrittenCur);
-            if (header.ModelVerWritten > ver.VerWrittenCur)
+            var envVar = Environment.GetEnvironmentVariable("NEWER_MODEL_VERSION_ALLOWED");
+            if (envVar != "TRUE" && header.ModelVerWritten > ver.VerWrittenCur)
             {
                 throw Contracts.ExceptDecode("The model was trained on a newer version of ML․NET.\n" +
                     "Please update your ML.NET version, as forward compatibility is not guaranteed.\n" +
+                    "To ignore exception and continue, set environment variable NEWER_MODEL_VERSION_ALLOWED to TRUE.\n" +
                     "Debug details: Maximum expected version {0}, got {1}.",
                     ver.VerWrittenCur, header.ModelVerWritten);
             }

--- a/src/Microsoft.ML.Core/Data/ModelHeader.cs
+++ b/src/Microsoft.ML.Core/Data/ModelHeader.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -348,6 +348,7 @@ namespace Microsoft.ML
         /// </summary>
         public static void CheckVersionInfo(ref ModelHeader header, VersionInfo ver)
         {
+
             Contracts.CheckDecode(header.ModelSignature == ver.ModelSignature, "Unknown file type");
             Contracts.CheckDecode(header.ModelVerReadable <= header.ModelVerWritten, "Corrupt file header");
             if (header.ModelVerReadable > ver.VerWrittenCur)
@@ -355,6 +356,11 @@ namespace Microsoft.ML
                                 "Suggestion: Make sure the model is trained with ML.NET {0} or older.\n" +
                                 "Debug details: Maximum expected version {2}, got {3}.",
                                 typeof(VersionInfo).Assembly.GetName().Version, ver.LoaderSignature, header.ModelVerReadable, ver.VerWrittenCur);
+            if (header.ModelVerWritten > ver.VerWrittenCur)
+            {
+                throw Contracts.ExceptDecode("Model was trained on a newer version of ML․NET. " +
+                    "Forward compatibility is not guaranteed. Please update your ML.NET version");
+            }
             if (header.ModelVerWritten < ver.VerWeCanReadBack)
             {
                 // Breaking backwards compatibility is something we should avoid if at all possible. If


### PR DESCRIPTION
To resolve #5311. 

It was suggested we either throw an error or print out a warning if the model is trained with a newer mlnet version than the version reading the model. Given that warnings get logged and a model might still have a silent bug, I'm proposing that we throw an error anytime the model is trained with a newer mlnet version than the one reading the model. 
