### PR TITLE
Fix NetFX builds by ensuring assembly version is set correctly

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,9 +2,16 @@
 <Project>
   <PropertyGroup>
     <!-- This repo version -->
-    <DotNetUseShippingVersions>false</DotNetUseShippingVersions>
+    <!-- 
+      Arcade automatically changes the version of assemblies to 42.42.42.42 unless DotNetUseShippingVersions
+      is set to true.
+      Details in Arcade documentation:
+        https://github.com/dotnet/arcade/blob/c788ffa83b088cafe9dbffc1cbc8155ba88b2553/Documentation/CorePackages/Versioning.md#output
+    -->
+    <DotNetUseShippingVersions>true</DotNetUseShippingVersions>
     <VersionPrefix>1.5.3</VersionPrefix>
     <PreReleaseVersionLabel>dev</PreReleaseVersionLabel>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
 
     <!--ML.NET Core dependencies-->
     <NewtonsoftJsonPackageVersion>10.0.3</NewtonsoftJsonPackageVersion>


### PR DESCRIPTION
Arcade SDK by default sets the version of generated `dll`s to `42.42.42.42`, which breaks some of our unit tests on .Net Frameworks v4.6.1. These failing unit tests are testing backwards compatibility of models by loading them. They are using the `dll`s they came with, which is version `1.0.0.0`. We also generate the same `1.0.0.0` version `dll`s currently, but without this change we make those `dll`s have version `42.42.42.42`.

CI Build: https://dev.azure.com/dnceng/public/_build/results?buildId=895013&view=results