### PR TITLE
Fix AutoFitMaxExperimentTimeTest

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -27,7 +27,8 @@ jobs:
         _config_short: RI
         _includeBenchmarkData: true
         _targetFramework: netcoreapp3.1
-    innerLoop: true
+    innerLoop: false
+    runSpecific: true
     pool:
       name:  Hosted Ubuntu 1604
 
@@ -36,7 +37,8 @@ jobs:
     name: Ubuntu_x64_NetCoreApp21
     buildScript: ./build.sh
     container: UbuntuContainer
-    innerLoop: true
+    innerLoop: false
+    runSpecific: true
     pool:
       name:  Hosted Ubuntu 1604
 
@@ -44,7 +46,8 @@ jobs:
   parameters:
     name: MacOS_x64_NetCoreApp21
     buildScript: ./build.sh
-    innerLoop: true
+    innerLoop: false
+    runSpecific: true
     pool:
       name: Hosted macOS
 
@@ -63,7 +66,8 @@ jobs:
         _config_short: RI
         _includeBenchmarkData: true
         _targetFramework: netcoreapp3.1
-    innerLoop: true
+    innerLoop: false
+    runSpecific: true
     vsTestConfiguration: "/Framework:.NETCoreApp,Version=v3.0"
     pool:
       name: Hosted VS2017
@@ -72,7 +76,8 @@ jobs:
   parameters:
     name: Windows_x64_NetCoreApp21
     buildScript: build.cmd
-    innerLoop: true
+    innerLoop: false
+    runSpecific: true
     vsTestConfiguration: "/Framework:.NETCoreApp,Version=v2.1"
     pool:
       name: Hosted VS2017
@@ -92,7 +97,8 @@ jobs:
         _config_short: RFX
         _includeBenchmarkData: false
         _targetFramework: win-x64
-    innerLoop: true
+    innerLoop: false
+    runSpecific: true
     vsTestConfiguration: "/Framework:.NETCoreApp,Version=v4.0"
     pool:
       name: Hosted VS2017
@@ -102,7 +108,8 @@ jobs:
     name: Windows_x86_NetCoreApp21
     architecture: x86
     buildScript: build.cmd
-    innerLoop: true
+    innerLoop: false
+    runSpecific: true
     vsTestConfiguration: "/Framework:.NETCoreApp,Version=v2.1"
     pool:
       name: Hosted VS2017

--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -27,8 +27,7 @@ jobs:
         _config_short: RI
         _includeBenchmarkData: true
         _targetFramework: netcoreapp3.1
-    innerLoop: false
-    runSpecific: true
+    innerLoop: true
     pool:
       name:  Hosted Ubuntu 1604
 
@@ -37,8 +36,7 @@ jobs:
     name: Ubuntu_x64_NetCoreApp21
     buildScript: ./build.sh
     container: UbuntuContainer
-    innerLoop: false
-    runSpecific: true
+    innerLoop: true
     pool:
       name:  Hosted Ubuntu 1604
 
@@ -46,8 +44,7 @@ jobs:
   parameters:
     name: MacOS_x64_NetCoreApp21
     buildScript: ./build.sh
-    innerLoop: false
-    runSpecific: true
+    innerLoop: true
     pool:
       name: Hosted macOS
 
@@ -66,8 +63,7 @@ jobs:
         _config_short: RI
         _includeBenchmarkData: true
         _targetFramework: netcoreapp3.1
-    innerLoop: false
-    runSpecific: true
+    innerLoop: true
     vsTestConfiguration: "/Framework:.NETCoreApp,Version=v3.0"
     pool:
       name: Hosted VS2017
@@ -76,8 +72,7 @@ jobs:
   parameters:
     name: Windows_x64_NetCoreApp21
     buildScript: build.cmd
-    innerLoop: false
-    runSpecific: true
+    innerLoop: true
     vsTestConfiguration: "/Framework:.NETCoreApp,Version=v2.1"
     pool:
       name: Hosted VS2017
@@ -97,8 +92,7 @@ jobs:
         _config_short: RFX
         _includeBenchmarkData: false
         _targetFramework: win-x64
-    innerLoop: false
-    runSpecific: true
+    innerLoop: true
     vsTestConfiguration: "/Framework:.NETCoreApp,Version=v4.0"
     pool:
       name: Hosted VS2017
@@ -108,8 +102,7 @@ jobs:
     name: Windows_x86_NetCoreApp21
     architecture: x86
     buildScript: build.cmd
-    innerLoop: false
-    runSpecific: true
+    innerLoop: true
     vsTestConfiguration: "/Framework:.NETCoreApp,Version=v2.1"
     pool:
       name: Hosted VS2017

--- a/test/Microsoft.ML.AutoML.Tests/AutoFitTests.cs
+++ b/test/Microsoft.ML.AutoML.Tests/AutoFitTests.cs
@@ -408,9 +408,15 @@ namespace Microsoft.ML.AutoML.Test
                     // exception and all of them are grouped inside an AggregateException
                     // Must check that all exceptions are the expected one.
                     containsMessage = true;
+                    Output.WriteLine("Printing inner exceptions ... ");
                     foreach (var ex in lastAggregateException.Flatten().InnerExceptions)
+                    {
+                        Output.WriteLine(ex.Message);
                         if (!ex.Message.Contains("Operation was cancelled"))
+                        {
                             containsMessage = false;
+                        }
+                    }
                 }
 
 

--- a/test/Microsoft.ML.AutoML.Tests/AutoFitTests.cs
+++ b/test/Microsoft.ML.AutoML.Tests/AutoFitTests.cs
@@ -410,7 +410,7 @@ namespace Microsoft.ML.AutoML.Test
                         Console.WriteLine("Printing inner exceptions...");
                         foreach (var ex in ((AggregateException)lastException).Flatten().InnerExceptions)
                         {
-                            Console.WriteLine($"Exception Message: { ex.Message}, -InnerException Message: { ex.InnerException?.Message}")
+                            Console.WriteLine($"Exception Message: { ex.Message}, -InnerException Message: { ex.InnerException?.Message}");
                         }
                     }
                 }

--- a/test/Microsoft.ML.AutoML.Tests/AutoFitTests.cs
+++ b/test/Microsoft.ML.AutoML.Tests/AutoFitTests.cs
@@ -404,13 +404,14 @@ namespace Microsoft.ML.AutoML.Test
                 if(!containsMessage)
                 {
                     var isAggregate = lastException is AggregateException;
-                    Console.WriteLine($"Type: {lastException.GetType()} - IsAggregate: {isAggregate} - Exception Message: {lastException.Message}, - InnerException Message: {lastException.InnerException?.Message}");
+                    Output.WriteLine($"Type: {lastException.GetType()} - IsAggregate: {isAggregate} - Exception Message: {lastException.Message}, - InnerException Message: {lastException.InnerException?.Message}");
+
                     if(isAggregate)
                     {
-                        Console.WriteLine("Printing inner exceptions...");
+                        Output.WriteLine("Printing inner exceptions...");
                         foreach (var ex in ((AggregateException)lastException).Flatten().InnerExceptions)
                         {
-                            Console.WriteLine($"Exception Message: { ex.Message}, -InnerException Message: { ex.InnerException?.Message}");
+                            Output.WriteLine($"Exception Message: { ex.Message}, -InnerException Message: { ex.InnerException?.Message}");
                         }
                     }
                 }

--- a/test/Microsoft.ML.AutoML.Tests/AutoFitTests.cs
+++ b/test/Microsoft.ML.AutoML.Tests/AutoFitTests.cs
@@ -12,6 +12,7 @@ using Microsoft.ML.Runtime;
 using Microsoft.ML.TestFramework;
 using Microsoft.ML.TestFramework.Attributes;
 using Microsoft.ML.TestFrameworkCommon;
+using Microsoft.ML.TestFrameworkCommon.Attributes;
 using Xunit;
 using Xunit.Abstractions;
 using static Microsoft.ML.DataOperationsCatalog;
@@ -374,8 +375,9 @@ namespace Microsoft.ML.AutoML.Test
 
         }
 
-        [LightGBMFact]
-        public void AutoFitMaxExperimentTimeTest()
+        [Theory, IterationData(25)]
+        [TestCategory("RunSpecificTest")]
+        public void AutoFitMaxExperimentTimeTest(int iteration)
         {
             // A single binary classification experiment takes less than 5 seconds.
             // System.OperationCanceledException is thrown when ongoing experiment
@@ -397,7 +399,7 @@ namespace Microsoft.ML.AutoML.Test
             if (experiment.RunDetails.Select(r => r.Exception == null).Count() > 1 && experiment.RunDetails.Last().Exception != null)
             {
                 Assert.True(experiment.RunDetails.Last().Exception.Message.Contains("Operation was canceled"),
-                            "Training process was not successfully canceled after maximum experiment time was reached.");
+                            "Iteration " + iteration + "Did not obtain 'Operation was canceled' error. Obtained unexpected error: " + experiment.RunDetails.Last().Exception.Message);
                 // Ensure that the best found model can still run after maximum experiment time was reached.
                 IDataView predictions = experiment.BestRun.Model.Transform(trainData);
             }

--- a/test/Microsoft.ML.AutoML.Tests/AutoFitTests.cs
+++ b/test/Microsoft.ML.AutoML.Tests/AutoFitTests.cs
@@ -408,11 +408,9 @@ namespace Microsoft.ML.AutoML.Test
                     // exception and all of them are grouped inside an AggregateException
                     // Must check that all exceptions are the expected one.
                     containsMessage = true;
-                    Output.WriteLine("Printing inner exceptions ... ");
                     foreach (var ex in lastAggregateException.Flatten().InnerExceptions)
                     {
-                        Output.WriteLine(ex.Message);
-                        if (!ex.Message.Contains("Operation was cancelled"))
+                        if (!ex.Message.Contains(expectedExceptionMessage))
                         {
                             containsMessage = false;
                         }

--- a/test/Microsoft.ML.AutoML.Tests/AutoFitTests.cs
+++ b/test/Microsoft.ML.AutoML.Tests/AutoFitTests.cs
@@ -375,9 +375,8 @@ namespace Microsoft.ML.AutoML.Test
 
         }
 
-        [Theory, IterationData(50)]
-        [TestCategory("RunSpecificTest")]
-        public void AutoFitMaxExperimentTimeTest(int iteration)
+        [LightGBMFact]
+        public void AutoFitMaxExperimentTimeTest()
         {
             // A single binary classification experiment takes less than 5 seconds.
             // System.OperationCanceledException is thrown when ongoing experiment

--- a/test/Microsoft.ML.AutoML.Tests/AutoFitTests.cs
+++ b/test/Microsoft.ML.AutoML.Tests/AutoFitTests.cs
@@ -418,7 +418,7 @@ namespace Microsoft.ML.AutoML.Test
 
 
                 Assert.True(containsMessage,
-                            $"Iteration {iteration} - Did not obtain '{expectedExceptionMessage}' error." +
+                            $"Did not obtain '{expectedExceptionMessage}' error." +
                             $"Obtained unexpected error of type {lastException.GetType()} with message: {lastException.Message}");
        
                 // Ensure that the best found model can still run after maximum experiment time was reached.


### PR DESCRIPTION
Edited by @antoniovs1029 : This PR now fixes the described problem

-------
Debugging occasional AutoFitMaxExperimentTimeTest failures, where sometimes the last model being trained is stopped and its provided exception is not "Operation was canceled".