### PR TITLE
Disabling AutoFitMaxExperimentTimeTest

### DIFF
--- a/test/Microsoft.ML.AutoML.Tests/AutoFitTests.cs
+++ b/test/Microsoft.ML.AutoML.Tests/AutoFitTests.cs
@@ -375,6 +375,8 @@ namespace Microsoft.ML.AutoML.Test
         }
 
         [LightGBMFact]
+        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
+        [Trait("Category", "SkipInCI")]
         public void AutoFitMaxExperimentTimeTest()
         {
             // A single binary classification experiment takes less than 5 seconds.


### PR DESCRIPTION
The test is sometimes causing CI failures which block PRs.
Disabling it temporally, while the root cause is investigated on #5506 
