### PR TITLE
Fixed leak in object pool

### DIFF
--- a/src/Microsoft.ML.Data/Data/DataViewUtils.cs
+++ b/src/Microsoft.ML.Data/Data/DataViewUtils.cs
@@ -942,8 +942,10 @@ namespace Microsoft.ML.Data
                     public override void Unset()
                     {
                         Contracts.Assert(_index <= _count);
-                        if (Values != null)
-                            _pool.Return(Values);
+                        // Remove all the objects from the pool
+                        // to free up references to those objects
+                        while (_pool.Count > 0)
+                            _pool.Get();
                         Values = null;
                         _count = 0;
                         _index = 0;

--- a/test/Microsoft.ML.TestFramework/BaseTestClass.cs
+++ b/test/Microsoft.ML.TestFramework/BaseTestClass.cs
@@ -81,7 +81,7 @@ namespace Microsoft.ML.TestFramework
             Cleanup();
             Process proc = Process.GetCurrentProcess();
             Console.WriteLine($"Finished test: {FullTestName} " +
-                $"with memory usage {proc.PrivateMemorySize64.ToString("N", CultureInfo.InvariantCulture)}");
+                $"with memory usage {proc.WorkingSet64.ToString("N", CultureInfo.InvariantCulture)}");
         }
 
         protected virtual void Initialize()


### PR DESCRIPTION
I noticed this issue when running `OneHotHashEncodingOnnxConversionTest` for several iterations. Even after the Onnx related memory leaks were fixed, memory usage kept increasing at each iteration. When I took memory snapshots at the beginning of each iteration I noticed that about 1400 `Single[]` objects were being leaked (amounting to about 180MB). 
The allocation of these objects can be traced to the object pool implemented using `ConcurrentBag`. It appears that the `ConcurrentBag` objects stay on in memory associated with the threads. (I haven't figured how these should be disposed off correctly yet). But removing the objects in the pool gets rid of those objects from the managed heap by the start of the second iteration and memory usage remains far more stable across iterations.

This also fixes memory leaks in my local x86 builds.

Since this is part of core ML.NET code that has been untouched for a long time, it is possible I may have overlooked something. Please review this.

