### PR TITLE
Update to OnnxRuntime 1.6.0 and fixed bug with sequences outputs

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -14,7 +14,6 @@
     <add key="myget-roslyn" value="https://dotnet.myget.org/F/roslyn-analyzers/api/v3/index.json" />
     <add key="mlnet-daily" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/MachineLearning/nuget/v3/index.json" />
     <add key="mlnet-testdata" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/machinelearning-testdata/nuget/v3/index.json" />
-    <add key="onnx-prerelease" value="https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/NuGet.config
+++ b/NuGet.config
@@ -14,6 +14,7 @@
     <add key="myget-roslyn" value="https://dotnet.myget.org/F/roslyn-analyzers/api/v3/index.json" />
     <add key="mlnet-daily" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/MachineLearning/nuget/v3/index.json" />
     <add key="mlnet-testdata" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/machinelearning-testdata/nuget/v3/index.json" />
+    <add key="onnx-prerelease" value="https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -23,7 +23,7 @@
     <GoogleProtobufPackageVersion>3.10.1</GoogleProtobufPackageVersion>
     <LightGBMPackageVersion>2.2.3</LightGBMPackageVersion>
     <MicrosoftExtensionsPackageVersion>2.1.0</MicrosoftExtensionsPackageVersion>
-    <MicrosoftMLOnnxRuntimePackageVersion>1.5.2</MicrosoftMLOnnxRuntimePackageVersion>
+    <MicrosoftMLOnnxRuntimePackageVersion>1.5.2-dev-20201204-0513-14f6eb14</MicrosoftMLOnnxRuntimePackageVersion>
     <MlNetMklDepsPackageVersion>0.0.0.9</MlNetMklDepsPackageVersion>
     <ParquetDotNetPackageVersion>2.1.3</ParquetDotNetPackageVersion>
     <SystemDrawingCommonPackageVersion>4.5.0</SystemDrawingCommonPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -23,7 +23,7 @@
     <GoogleProtobufPackageVersion>3.10.1</GoogleProtobufPackageVersion>
     <LightGBMPackageVersion>2.2.3</LightGBMPackageVersion>
     <MicrosoftExtensionsPackageVersion>2.1.0</MicrosoftExtensionsPackageVersion>
-    <MicrosoftMLOnnxRuntimePackageVersion>1.5.2-dev-20201204-0513-14f6eb14</MicrosoftMLOnnxRuntimePackageVersion>
+    <MicrosoftMLOnnxRuntimePackageVersion>1.6.0</MicrosoftMLOnnxRuntimePackageVersion>
     <MlNetMklDepsPackageVersion>0.0.0.9</MlNetMklDepsPackageVersion>
     <ParquetDotNetPackageVersion>2.1.3</ParquetDotNetPackageVersion>
     <SystemDrawingCommonPackageVersion>4.5.0</SystemDrawingCommonPackageVersion>

--- a/src/Microsoft.ML.OnnxTransformer/OnnxTransform.cs
+++ b/src/Microsoft.ML.OnnxTransformer/OnnxTransform.cs
@@ -765,7 +765,7 @@ namespace Microsoft.ML.Transforms.Onnx
     /// | Does this estimator need to look at the data to train its parameters? | No |
     /// | Input column data type | Known-sized vector of <xref:System.Single> or <xref:System.Double> types |
     /// | Output column data type | As specified by the ONNX model |
-    /// | Required NuGet in addition to Microsoft.ML | Microsoft.ML.OnnxTransformer (always),  either Microsoft.ML.OnnxRuntime 1.5.2 (for CPU processing) or Microsoft.ML.OnnxRuntime.Gpu 1.5.2 (for GPU processing if GPU is available) |
+    /// | Required NuGet in addition to Microsoft.ML | Microsoft.ML.OnnxTransformer (always),  either Microsoft.ML.OnnxRuntime 1.6.0 (for CPU processing) or Microsoft.ML.OnnxRuntime.Gpu 1.6.0 (for GPU processing if GPU is available) |
     /// | Exportable to ONNX | No |
     ///
     /// To create this estimator use the following APIs:

--- a/src/Microsoft.ML.OnnxTransformer/OnnxTypeParser.cs
+++ b/src/Microsoft.ML.OnnxTransformer/OnnxTypeParser.cs
@@ -267,7 +267,13 @@ namespace Microsoft.ML.Transforms.Onnx
 
             public static IEnumerable<TDst> CastOnnxSequenceToIEnumerable<TSrc, TDst>(IEnumerable<TSrc> o, Func<TSrc, object> caster)
             {
-                return o.Select(v => (TDst)caster(v));
+                // Since now we're disposing the NamedOnnxValue objects
+                // after running inference on each output, we need
+                // to copy (enumerate) the output through ".ToList()"
+                // else, if our users try the keep the past sequence
+                // outputs of their OnnxTransformer, they would
+                // end up with empty sequences.
+                return o.Select(v => (TDst)caster(v)).ToList();
             }
         }
 


### PR DESCRIPTION
Besides updating to ORT 1.6.0 this PR fixes a bug that was uncovered by the update.

In PR #5518 a memory leak in OnnxTransformer was fixed by manually disposing the output NamedOnnxValue objects (in particular, when running ORT with input N, we would call dispose on the output of N - 1). This seemed to work correctly when we tested it with ORT 1.5.2, but it turns out that there was a memory leak on ORT itself, which got fixed for ORT 1.6.0 on this PR:
https://github.com/microsoft/onnxruntime/pull/5743

After updating to 1.6.0, two of our tests were failing because of this: `TestOnnxZipMapWithInt64Keys` and `TestOnnxZipMapWithStringKeys`.

The bug on our implementation was that we weren't copying the output of sequences when we got them from ORT's output. And so when we called dispose on them, those outputs were gone. In the failing tests we call `ML.Data.CreateEnumerable()` from the output of OnnxTransformer, whereas the onnx model has output of type sequence. The problem was that when creating the enumerable, the listed objects appeared to have an empty enumerable as output. This got fixed by simply forcing the copy the output of ORT in the `CastOnnxSequenceToIEnumerable` into a new IEnumerable which is now returned to the user. This way, when we dispose the ORT's NamedOnnxValue output, we don't empty the actual IEnumerable that the user has.