### PR TITLE
Fix publishing problems

### DIFF
--- a/build/publish.proj
+++ b/build/publish.proj
@@ -1,12 +1,6 @@
 <Project>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.BuildTools" Version="$(BuildToolsPackageVersion)" />
-  </ItemGroup>
   
   <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.props" />
-
-  <UsingTask TaskName="ExecWithRetriesForNuGetPush" AssemblyFile="$(NuGetPackageRoot)\microsoft.dotnet.buildtools\$(BuildToolsPackageVersion)\lib\Microsoft.DotNet.Build.Tasks.dll" />
 
   <PropertyGroup>
     <PublishSymbolsPackage>Microsoft.SymbolUploader.Build.Task</PublishSymbolsPackage>
@@ -15,37 +9,6 @@
   </PropertyGroup>
 
   <Import Project="$(NuGetPackageRoot)\$(PublishSymbolsPackage.ToLower())\$(MicrosoftSymbolUploaderBuildTaskVersion)\build\PublishSymbols.targets" />
-
-  <Target Name="PublishPackages">
-    <Error Condition="'$(NuGetFeedUrl)' == ''" Text="Missing required property NuGetFeedUrl" />
-    <Error Condition="'$(NuGetApiKey)' == ''" Text="Missing required property NuGetApiKey" />
-
-    <ItemGroup>
-      <NuGetPackages Include="$(ArtifactsDir)packages\**\*.nupkg"
-                     Exclude="$(ArtifactsDir)packages\**\*.snupkg" />
-
-      <!--
-      IgnorableErrorMessages applies to the "ExectWithRetriesForNuGetPush" task.
-      There's a very special failure scenario that we want to ignore.  That scenario is
-      when NuGet hits a timeout on one "push" attempt, and then gets a "Forbidden" response
-      because the package "already exists" on the next response.  This indicates that the
-      timeout occurred, but the push was actually successful.
-      -->
-      <IgnorableErrorMessages Include="Overwriting existing packages is forbidden according to the package retention settings for this feed.">
-        <ConditionalErrorMessage>Pushing took too long</ConditionalErrorMessage>
-      </IgnorableErrorMessages>
-    </ItemGroup>
-    
-    <Message Text="Pushing ML.NET packages to $(NuGetFeedUrl)" />
-    
-    <PropertyGroup>
-      <DotnetToolCommand>$(MSBuildThisFileDirectory)..\.dotnet\dotnet</DotnetToolCommand>
-      <NuGetPushCommand>$(DotnetToolCommand) nuget push --source $(NuGetFeedUrl) --api-key $(NuGetApiKey) --timeout $(NuGetPushTimeoutSeconds)</NuGetPushCommand>
-    </PropertyGroup>
-
-    <ExecWithRetriesForNuGetPush Command="$(NuGetPushCommand) %(NuGetPackages.Identity)"
-                                 IgnoredErrorMessagesWithConditional="@(IgnorableErrorMessages)" />
-  </Target>
   
   <Target Name="PublishSymbolPackages"
           Condition="'$(EnablePublishSymbols)'=='true'"

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -189,6 +189,7 @@ phases:
   variables:
     BuildConfig: Release
     OfficialBuildId: $(BUILD.BUILDNUMBER)
+    DotnetVersionKind: $[variables.VERSIONKIND] # If not "VERSIONKIND" variable is set when queuing the publishing task, this defaults to empty string.
     DOTNET_CLI_TELEMETRY_OPTOUT: 1
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
     DOTNET_MULTILEVEL_LOOKUP: 0
@@ -230,10 +231,14 @@ phases:
       sourceFolder: $(Build.SourcesDirectory)/artifacts/pkgassets/PackageAssets
       targetFolder: $(Build.SourcesDirectory)/artifacts/pkgassets
 
-  - script: ./build.cmd -pack -configuration $(BuildConfig)
+  # Depending on the value of DotNetFinalVersionKind, the name of the package will change.
+  # For our nightly builds we want it to be empty, and when creating the official nugets, we want it to be "release"
+  # the value of the version kind is set when queuing the publishing job on AzureDevOps by adding a VERSIONKIND variable
+  # See more info in: https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/Versioning.md#package-version 
+  - script: ./build.cmd -configuration $(BuildConfig) -pack -ci /p:OfficialBuildId=$(OfficialBuildId) /p:DotNetFinalVersionKind=$(DotnetVersionKind)  /p:RestorePackagesPath=$(Build.SourcesDirectory)\packages /p:NUGET_PACKAGES=$(Build.SourcesDirectory)\packages
     displayName: Build Packages
 
-  - script: ./sign.cmd /p:SignNugetPackages=true
+  - script: ./sign.cmd /p:SignNugetPackages=true  /p:RestorePackagesPath=$(Build.SourcesDirectory)\packages /p:NUGET_PACKAGES=$(Build.SourcesDirectory)\packages
     displayName: sign packages
     continueOnError: false
 
@@ -241,14 +246,20 @@ phases:
     inputs:
       nuGetServiceConnections: machinelearning-dnceng-public-feed # To allow publishing to a feed of another organization
 
-  - script: $(Build.SourcesDirectory)\.dotnet\dotnet.exe msbuild build\publish.proj /t:PublishPackages /p:NuGetFeedUrl=$(_AzureDevopsFeedUrl) /p:NuGetApiKey=AzureArtifacts
-    displayName: Publish Packages to AzureDevOps Feed
+  - task: NuGetCommand@2
+    displayName: Push packages to AzureDevOps feed
+    inputs:
+      command: push
+      packagesToPush: $(Build.SourcesDirectory)/artifacts/**/*.nupkg;!$(Build.SourcesDirectory)/artifacts/**/*.snupkg  
+      nuGetFeedType: external
+      publishFeedCredentials: machinelearning-dnceng-public-feed
+      allowPackageConflicts: true
 
   - task: MSBuild@1
     displayName: Publish Symbols to SymWeb Symbol Server
     inputs:
       solution: build/publish.proj
-      msbuildArguments: /t:PublishSymbolPackages /p:SymbolServerPath=$(_SymwebSymbolServerPath) /p:SymbolServerPAT=$(SymwebSymbolServerPAT)
+      msbuildArguments: /t:PublishSymbolPackages /p:SymbolServerPath=$(_SymwebSymbolServerPath) /p:SymbolServerPAT=$(SymwebSymbolServerPAT)  /p:RestorePackagesPath=$(Build.SourcesDirectory)\packages /p:NUGET_PACKAGES=$(Build.SourcesDirectory)\packages
       msbuildVersion: 15.0
     continueOnError: true
 
@@ -256,7 +267,7 @@ phases:
     displayName: Publish Symbols to Msdl Symbol Server
     inputs:
       solution: build/publish.proj
-      msbuildArguments: /t:PublishSymbolPackages /p:SymbolServerPath=$(_MsdlSymbolServerPath) /p:SymbolServerPAT=$(MsdlSymbolServerPAT)
+      msbuildArguments: /t:PublishSymbolPackages /p:SymbolServerPath=$(_MsdlSymbolServerPath) /p:SymbolServerPAT=$(MsdlSymbolServerPAT)  /p:RestorePackagesPath=$(Build.SourcesDirectory)\packages /p:NUGET_PACKAGES=$(Build.SourcesDirectory)\packages
       msbuildVersion: 15.0
     continueOnError: true
 

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -189,7 +189,7 @@ phases:
   variables:
     BuildConfig: Release
     OfficialBuildId: $(BUILD.BUILDNUMBER)
-    DotnetVersionKind: $[variables.VERSIONKIND] # If not "VERSIONKIND" variable is set when queuing the publishing task, this defaults to empty string.
+    DotnetVersionKind: $[variables.VERSIONKIND] # If no "VERSIONKIND" variable is set when queuing the publishing task, this defaults to empty string.
     DOTNET_CLI_TELEMETRY_OPTOUT: 1
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
     DOTNET_MULTILEVEL_LOOKUP: 0

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -253,7 +253,6 @@ phases:
       packagesToPush: $(Build.SourcesDirectory)/artifacts/**/*.nupkg;!$(Build.SourcesDirectory)/artifacts/**/*.snupkg  
       nuGetFeedType: external
       publishFeedCredentials: machinelearning-dnceng-public-feed
-      allowPackageConflicts: true
 
   - task: MSBuild@1
     displayName: Publish Symbols to SymWeb Symbol Server

--- a/src/Microsoft.ML.SamplesUtils/Microsoft.ML.SamplesUtils.csproj
+++ b/src/Microsoft.ML.SamplesUtils/Microsoft.ML.SamplesUtils.csproj
@@ -5,6 +5,11 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeInPackage>Microsoft.ML.SampleUtils</IncludeInPackage>
     <PackageDescription>Sample utils for Microsoft.ML.Samples</PackageDescription>
+
+    <!--The nuget we publish is named SampleUtils, so this is necessary.
+    Still, the namespace expected inside the nuget is named SamplesUtils,
+    So the project itself and its code is not to be renamed SampleUtils.-->
+    <PackageId>Microsoft.ML.SampleUtils</PackageId>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR fixes 3 problems:

1. Removed our dependency to BuildTools by using the NugetCommand Azure Task.
2. We should publish a nuget named "SampleUtils", but we were publishing it with the name "SamplesUtils"
3. The naming conventions of our published nugets didn't match the ones described on arcade's docs: [Versioning.md](https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/Versioning.md#package-version). I've also added the option so that when queuing the publishing build, we can pass the VERSIONKIND variable with value "release", so that it produces the nugets with arcade's conventions for "Release official build" nugets (as opposed to the "Daily official build" naming convention that's going to be used now by our CI that publishes nightly nugets).


