### PR TITLE
Add back missing test project from running on arcade

### DIFF
--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -148,7 +148,7 @@ jobs:
     - script: $(dotnetPath) msbuild -restore build/Codecoverage.proj
       displayName: Upload coverage to codecov.io
       condition: and(succeeded(), eq(${{ parameters.codeCoverage }}, True))
-	  - task: PublishTestResults@2
+    - task: PublishTestResults@2
       displayName: Publish Test Results
       condition: succeededOrFailed()
       inputs:

--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -148,6 +148,16 @@ jobs:
     - script: $(dotnetPath) msbuild -restore build/Codecoverage.proj
       displayName: Upload coverage to codecov.io
       condition: and(succeeded(), eq(${{ parameters.codeCoverage }}, True))
+	  - task: PublishTestResults@2
+      displayName: Publish Test Results
+      condition: succeededOrFailed()
+      inputs:
+        testRunner: 'xUnit'
+        searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults'
+        testResultsFiles: '**/*.xml'
+        testRunTitle: Machinelearning_Tests_${{ parameters.name }}_$(_configuration)_$(Build.BuildNumber)
+        configuration: $(_configuration)
+        mergeTestResults: true
     - task: CopyFiles@2
       displayName: Stage build logs
       condition: not(succeeded())

--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -154,7 +154,12 @@ jobs:
       inputs:
         testRunner: 'xUnit'
         searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults'
-        testResultsFiles: '**/*.xml'
+        # Upload all test results except performance test project. On CI by default performance tests
+        # will not run and test result files will still be generate without details. Avoid uploading 
+        # performance test result to avoid warnings on publish test result stage.
+        testResultsFiles: |
+          **/*.xml
+          !**/*PerformanceTests*.xml
         testRunTitle: Machinelearning_Tests_${{ parameters.name }}_$(_configuration)_$(Build.BuildNumber)
         configuration: $(_configuration)
         mergeTestResults: true

--- a/test/Microsoft.ML.OnnxTransformerTest/Microsoft.ML.OnnxTransformerTest.csproj
+++ b/test/Microsoft.ML.OnnxTransformerTest/Microsoft.ML.OnnxTransformerTest.csproj
@@ -1,4 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <IsUnitTestProject>true</IsUnitTestProject>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.ML.Data\Microsoft.ML.Data.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.ML.Maml\Microsoft.ML.Maml.csproj" />

--- a/test/Microsoft.ML.TestFramework/Microsoft.ML.TestFramework.csproj
+++ b/test/Microsoft.ML.TestFramework/Microsoft.ML.TestFramework.csproj
@@ -1,4 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <IsUnitTestProject>true</IsUnitTestProject>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.ML.Core\Microsoft.ML.Core.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.ML.Data\Microsoft.ML.Data.csproj" />


### PR DESCRIPTION
1. add back missing test projects from running on arcade
2. Correct test result publish so we can view test results on build pipeline

