### PR TITLE
Fixed AutoML CrossValSummaryRunner for TopKAccuracyForAllK

### DIFF
--- a/src/Microsoft.ML.AutoML/Experiment/Runners/CrossValSummaryRunner.cs
+++ b/src/Microsoft.ML.AutoML/Experiment/Runners/CrossValSummaryRunner.cs
@@ -159,6 +159,16 @@ namespace Microsoft.ML.AutoML
 
         private static double[] GetAverageOfNonNaNScoresInNestedEnumerable(IEnumerable<IEnumerable<double>> results)
         {
+            if (results.Contains(null))
+            {
+                // If any of the nested enumerables is null, we can't take the average from it.
+                // This is expected to happen on Multiclass metrics where the TopKAccuracyForAllK
+                // array can be null if the topKPredictionCount isn't a valid number.
+                // In that case all of the results sub arrays will be null anyway, and so
+                // returning null is the expected solution.
+                return null;
+            }
+
             double[] arr = new double[results.ElementAt(0).Count()];
             for (int i = 0; i < arr.Length; i++)
             {

--- a/src/Microsoft.ML.AutoML/Experiment/Runners/CrossValSummaryRunner.cs
+++ b/src/Microsoft.ML.AutoML/Experiment/Runners/CrossValSummaryRunner.cs
@@ -159,15 +159,18 @@ namespace Microsoft.ML.AutoML
 
         private static double[] GetAverageOfNonNaNScoresInNestedEnumerable(IEnumerable<IEnumerable<double>> results)
         {
-            if (results.Contains(null))
+            if (results.All(result => result == null))
             {
-                // If any of the nested enumerables is null, we can't take the average from it.
+                // If all nested enumerables are null, we say the average is a null enumerable as well.
                 // This is expected to happen on Multiclass metrics where the TopKAccuracyForAllK
                 // array can be null if the topKPredictionCount isn't a valid number.
-                // In that case all of the results sub arrays will be null anyway, and so
+                // In that case all of the "results" enumerables will be null anyway, and so
                 // returning null is the expected solution.
                 return null;
             }
+
+            // In case there are only some null elements, we'll ignore them:
+            results = results.Where(result => result != null);
 
             double[] arr = new double[results.ElementAt(0).Count()];
             for (int i = 0; i < arr.Length; i++)

--- a/test/Microsoft.ML.AutoML.Tests/AutoFitTests.cs
+++ b/test/Microsoft.ML.AutoML.Tests/AutoFitTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.ML.AutoML.Test
             var textLoader = context.Data.CreateTextLoader(columnInference.TextLoaderOptions);
             var trainData = textLoader.Load(DatasetUtil.TrivialMulticlassDatasetPath);
 
-            if(useNumberOfCVFolds)
+            if (useNumberOfCVFolds)
             {
                 // When setting numberOfCVFolds
                 // The results object is a CrossValidationExperimentResults<> object
@@ -67,7 +67,7 @@ namespace Microsoft.ML.AutoML.Test
             }
             else
             {
-                // When using this API, if the trainset is under the
+                // When using this other API, if the trainset is under the
                 // crossValRowCounThreshold, AutoML will also perform CrossValidation
                 // but through a very different path that the one above,
                 // throw a CrossValSummaryRunner and will return
@@ -75,7 +75,7 @@ namespace Microsoft.ML.AutoML.Test
                 // simply a ExperimentResult<> object
 
                 int crossValRowCountThreshold = 15000;
-                trainData = context.Data.TakeRows(trainData, crossValRowCountThreshold);
+                trainData = context.Data.TakeRows(trainData, crossValRowCountThreshold - 1);
                 var result = context.Auto()
                     .CreateMulticlassClassificationExperiment(0)
                     .Execute(trainData, DatasetUtil.TrivialMulticlassDatasetLabel);

--- a/test/Microsoft.ML.AutoML.Tests/AutoFitTests.cs
+++ b/test/Microsoft.ML.AutoML.Tests/AutoFitTests.cs
@@ -42,19 +42,48 @@ namespace Microsoft.ML.AutoML.Test
             Assert.NotNull(result.BestRun.TrainerName);
         }
 
-        [Fact]
-        public void AutoFitMultiTest()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void AutoFitMultiTest(bool useNumberOfCVFolds)
         {
             var context = new MLContext(0);
             var columnInference = context.Auto().InferColumns(DatasetUtil.TrivialMulticlassDatasetPath, DatasetUtil.TrivialMulticlassDatasetLabel);
             var textLoader = context.Data.CreateTextLoader(columnInference.TextLoaderOptions);
             var trainData = textLoader.Load(DatasetUtil.TrivialMulticlassDatasetPath);
-            var result = context.Auto()
-                .CreateMulticlassClassificationExperiment(0)
-                .Execute(trainData, 5, DatasetUtil.TrivialMulticlassDatasetLabel);
-            Assert.True(result.BestRun.Results.First().ValidationMetrics.MicroAccuracy >= 0.7);
-            var scoredData = result.BestRun.Results.First().Model.Transform(trainData);
-            Assert.Equal(NumberDataViewType.Single, scoredData.Schema[DefaultColumnNames.PredictedLabel].Type);
+
+            if(useNumberOfCVFolds)
+            {
+                // When setting numberOfCVFolds
+                // The results object is a CrossValidationExperimentResults<> object
+                uint numberOfCVFolds = 5;
+                var result = context.Auto()
+                    .CreateMulticlassClassificationExperiment(0)
+                    .Execute(trainData, numberOfCVFolds, DatasetUtil.TrivialMulticlassDatasetLabel);
+
+                Assert.True(result.BestRun.Results.First().ValidationMetrics.MicroAccuracy >= 0.7);
+                var scoredData = result.BestRun.Results.First().Model.Transform(trainData);
+                Assert.Equal(NumberDataViewType.Single, scoredData.Schema[DefaultColumnNames.PredictedLabel].Type);
+            }
+            else
+            {
+                // When using this API, if the trainset is under the
+                // crossValRowCounThreshold, AutoML will also perform CrossValidation
+                // but through a very different path that the one above,
+                // throw a CrossValSummaryRunner and will return
+                // a different type of object as "result" which would now be
+                // simply a ExperimentResult<> object
+
+                int crossValRowCountThreshold = 15000;
+                trainData = context.Data.TakeRows(trainData, crossValRowCountThreshold);
+                var result = context.Auto()
+                    .CreateMulticlassClassificationExperiment(0)
+                    .Execute(trainData, DatasetUtil.TrivialMulticlassDatasetLabel);
+
+                Assert.True(result.BestRun.ValidationMetrics.MicroAccuracy >= 0.7);
+                var scoredData = result.BestRun.Model.Transform(trainData);
+                Assert.Equal(NumberDataViewType.Single, scoredData.Schema[DefaultColumnNames.PredictedLabel].Type);
+            }
         }
 
         [TensorFlowFact]


### PR DESCRIPTION
PR #5395 introduced a new TopKAccuracyForAllK array for the MulticlassClassificationMetrics. But there's a bug in how it was handled on AutoML CrossValidationSummaryRunner, because if the array is null (which is expected if topKPredictionCount isn't a valid number), then the GetAverageOfNonNaNScoresInNestedEnumerable() would throw an error.

This wasn't catched on our existing tests, because we didn't have a test that runs AutoML multiclass task with CrossValidationSummaryRunner. So I've also added a test for this.