### PR TITLE
continueOnError on Brew Workaround

### DIFF
--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -63,6 +63,7 @@ jobs:
           brew untap local/openssl |
           brew untap local/python2
         displayName: MacOS Homebrew bug Workaround
+        continueOnError: true
     # Extra MacOS step required to install OS-specific dependencies
     - ${{ if eq(parameters.pool.name, 'Hosted macOS') }}:
       - script: brew update && brew unlink python@3.8 && brew install mono-libgdiplus && brew install $(Build.SourcesDirectory)/build/libomp.rb && brew link libomp --force

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -56,6 +56,7 @@ phases:
       brew untap local/openssl |
       brew untap local/python2
     displayName: MacOS Homebrew bug Workaround
+    continueOnError: true
   - script: brew update && brew unlink python@3.8 && brew install mono-libgdiplus && brew install $(Build.SourcesDirectory)/build/libomp.rb && brew link libomp --force
     displayName: Install build dependencies
   - script: ./restore.sh


### PR DESCRIPTION
The "Brew workaround" step has suddenly started failing on our nuget-producing pipelines.

It seems this is because this week they're updating the MacOS machines, and this is breaking the workaround:
https://github.com/actions/virtual-environments/issues/2248

It seems that for the machines where the update is done, the workaround not only breaks, but is no longer necessary. But it's still necessary on the CI machines that aren't updated.

Once all the machines are updated, we'll be able to remove the Workaround step completely.

NOTE: if the machine is updated, then the Brew Workaround step will fail, but the build will continue, and the nugets will be published. Still, since there was an error, the CI will show the error. We should simply ignore this. Once all of the machines are updated, we can remove the Brew Workaround step.

NOTE2: As suggested by Mustafa, I've also added this to our PR's CI builds, which has just started to fail because of this. With the change on the PR they do show a Failure on the logs, but they pass on github, so they aren't blocking the PRs.
