### PR TITLE
Added in note in the documentation that the PredictionEngine is not thread safe.

### DIFF
--- a/src/Microsoft.ML.Data/Prediction/PredictionEngine.cs
+++ b/src/Microsoft.ML.Data/Prediction/PredictionEngine.cs
@@ -62,6 +62,8 @@ namespace Microsoft.ML
     /// <remarks>
     /// This class can also be used with trained pipelines that do not end with a predictor: in this case, the
     /// 'prediction' will be just the outcome of all the transformations.
+    ///
+    /// The PredictionEngine is NOT thread safe. Using it in a threaded environment can cause unexpected issues.
     /// </remarks>
     public sealed class PredictionEngine<TSrc, TDst> : PredictionEngineBase<TSrc, TDst>
        where TSrc : class


### PR DESCRIPTION
Since we have had several questions about PredictionEngine and whether its thread safe (#5582 for example), I have just added a small comment to the PredictionEngine class docs saying its not thread safe.