### PR TITLE
Offer suggestions for possibly mistyped label column names in AutoML (#5574)

### DIFF
--- a/src/Microsoft.ML.AutoML/Utils/StringEditDistance.cs
+++ b/src/Microsoft.ML.AutoML/Utils/StringEditDistance.cs
@@ -2,9 +2,9 @@
 
 namespace Microsoft.ML.AutoML.Utils
 {
-    public static class StringEditDistance
+    internal static class StringEditDistance
     {
-        public static int GetEditDistance(string first, string second)
+        public static int GetLevenshteinDistance(string first, string second)
         {
             if (first is null)
             {

--- a/src/Microsoft.ML.AutoML/Utils/StringEditDistance.cs
+++ b/src/Microsoft.ML.AutoML/Utils/StringEditDistance.cs
@@ -1,0 +1,60 @@
+﻿using System;
+
+namespace Microsoft.ML.AutoML.Utils
+{
+    public static class StringEditDistance
+    {
+        public static int GetEditDistance(string first, string second)
+        {
+            if (first is null)
+            {
+                throw new ArgumentNullException(nameof(first));
+            }
+
+            if (second is null)
+            {
+                throw new ArgumentNullException(nameof(second));
+            }
+
+            if (first.Length == 0 || second.Length == 0)
+            {
+                return first.Length + second.Length;
+            }
+
+            var currentRow = 0;
+            var nextRow = 1;
+            var rows = new int[second.Length + 1, second.Length + 1];
+
+            for (var j = 0; j <= second.Length; ++j)
+            {
+                rows[currentRow, j] = j;
+            }
+
+            for (var i = 1; i <= first.Length; ++i)
+            {
+                rows[nextRow, 0] = i;
+                for (var j = 1; j <= second.Length; ++j)
+                {
+                    var deletion = rows[currentRow, j] + 1;
+                    var insertion = rows[nextRow, j - 1] + 1;
+                    var substitution = rows[currentRow, j - 1] + (first[i - 1].Equals(second[j - 1]) ? 0 : 1);
+
+                    rows[nextRow, j] = Math.Min(deletion, Math.Min(insertion, substitution));
+                }
+
+                if (currentRow == 0)
+                {
+                    currentRow = 1;
+                    nextRow = 0;
+                }
+                else
+                {
+                    currentRow = 0;
+                    nextRow = 1;
+                }
+            }
+
+            return rows[currentRow, second.Length];
+        }
+    }
+}

--- a/src/Microsoft.ML.AutoML/Utils/UserInputValidationUtil.cs
+++ b/src/Microsoft.ML.AutoML/Utils/UserInputValidationUtil.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Microsoft.ML.AutoML.Utils;
 using Microsoft.ML.Data;
 
 namespace Microsoft.ML.AutoML
@@ -248,6 +249,11 @@ namespace Microsoft.ML.AutoML
             var nullableColumn = trainData.Schema.GetColumnOrNull(columnName);
             if (nullableColumn == null)
             {
+                var closestNamed = ClosestNamed(trainData, columnName, 2);
+                if (closestNamed != string.Empty)
+                {
+                    throw new ArgumentException($"Provided {columnPurpose} column '{columnName}' not found in training data. Did you mean '{closestNamed}'.");
+                }
                 throw new ArgumentException($"Provided {columnPurpose} column '{columnName}' not found in training data.");
             }
 
@@ -270,6 +276,23 @@ namespace Microsoft.ML.AutoML
                         $"but only types {string.Join(", ", allowedTypes)} are allowed.");
                 }
             }
+        }
+
+        private static string ClosestNamed(IDataView trainData, string columnName, int maxAllowableEditDistance = int.MaxValue)
+        {
+            var minEditDistance = int.MaxValue;
+            var closestNamed = string.Empty;
+            foreach (var column in trainData.Schema)
+            {
+                var editDistance = StringEditDistance.GetEditDistance(column.Name, columnName);
+                if (editDistance < minEditDistance)
+                {
+                    minEditDistance = editDistance;
+                    closestNamed = column.Name;
+                }
+            }
+
+            return minEditDistance <= maxAllowableEditDistance ? closestNamed : string.Empty;
         }
 
         private static string FindFirstDuplicate(IEnumerable<string> values)

--- a/src/Microsoft.ML.AutoML/Utils/UserInputValidationUtil.cs
+++ b/src/Microsoft.ML.AutoML/Utils/UserInputValidationUtil.cs
@@ -249,12 +249,15 @@ namespace Microsoft.ML.AutoML
             var nullableColumn = trainData.Schema.GetColumnOrNull(columnName);
             if (nullableColumn == null)
             {
-                var closestNamed = ClosestNamed(trainData, columnName, 2);
+                var closestNamed = ClosestNamed(trainData, columnName, 7);
+
+                var exceptionMessage = $"Provided {columnPurpose} column '{columnName}' not found in training data.";
                 if (closestNamed != string.Empty)
                 {
-                    throw new ArgumentException($"Provided {columnPurpose} column '{columnName}' not found in training data. Did you mean '{closestNamed}'.");
+                    exceptionMessage += $" Did you mean '{closestNamed}'.";
                 }
-                throw new ArgumentException($"Provided {columnPurpose} column '{columnName}' not found in training data.");
+
+                throw new ArgumentException(exceptionMessage);
             }
 
             if(allowedTypes == null)
@@ -284,7 +287,7 @@ namespace Microsoft.ML.AutoML
             var closestNamed = string.Empty;
             foreach (var column in trainData.Schema)
             {
-                var editDistance = StringEditDistance.GetEditDistance(column.Name, columnName);
+                var editDistance = StringEditDistance.GetLevenshteinDistance(column.Name, columnName);
                 if (editDistance < minEditDistance)
                 {
                     minEditDistance = editDistance;

--- a/test/Microsoft.ML.AutoML.Tests/UserInputValidationTests.cs
+++ b/test/Microsoft.ML.AutoML.Tests/UserInputValidationTests.cs
@@ -44,10 +44,11 @@ namespace Microsoft.ML.AutoML.Test
         {
             foreach (var task in new[] { TaskKind.Recommendation, TaskKind.Regression, TaskKind.Ranking })
             {
+                const string columnName = "ReallyLongNonExistingColumnName";
                 var ex = Assert.Throws<ArgumentException>(() => UserInputValidationUtil.ValidateExperimentExecuteArgs(_data,
-                new ColumnInformation() { LabelColumnName = "L" }, null, task));
+                new ColumnInformation() { LabelColumnName = columnName }, null, task));
 
-                Assert.Equal("Provided label column 'L' not found in training data.", ex.Message);
+                Assert.Equal($"Provided label column '{columnName}' not found in training data.", ex.Message);
             }
         }
 

--- a/test/Microsoft.ML.AutoML.Tests/UserInputValidationTests.cs
+++ b/test/Microsoft.ML.AutoML.Tests/UserInputValidationTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.ML.Data;
 using Microsoft.ML.TestFramework;
@@ -47,6 +48,21 @@ namespace Microsoft.ML.AutoML.Test
                 new ColumnInformation() { LabelColumnName = "L" }, null, task));
 
                 Assert.Equal("Provided label column 'L' not found in training data.", ex.Message);
+            }
+        }
+
+        [Fact]
+        public void ValidateExperimentExecuteLabelNotInTrainMistyped()
+        {
+            foreach (var task in new[] { TaskKind.Recommendation, TaskKind.Regression, TaskKind.Ranking })
+            {
+                var originalColumnName = _data.Schema.First().Name;
+                var mistypedColumnName = originalColumnName + "a";
+                var ex = Assert.Throws<ArgumentException>(() => UserInputValidationUtil.ValidateExperimentExecuteArgs(_data,
+                    new ColumnInformation() { LabelColumnName = mistypedColumnName }, null, task));
+
+                Assert.Equal($"Provided label column '{mistypedColumnName}' not found in training data. Did you mean '{originalColumnName}'.",
+                    ex.Message);
             }
         }
 


### PR DESCRIPTION
Inconvenience is described in the issue: https://github.com/dotnet/machinelearning/issues/5574.

Closest named column is found using the Levenshtein distance (https://en.wikipedia.org/wiki/Levenshtein_distance).
Allowable distance is set to 2, as I think this is a good approximation of a small typo. Anyway, code is written in a way that allows this to be changed easily.

Accompanying unit test is also written.
