### PR TITLE
AutoML aggregate exception

### DIFF
--- a/src/Microsoft.ML.AutoML/Experiment/Experiment.cs
+++ b/src/Microsoft.ML.AutoML/Experiment/Experiment.cs
@@ -200,7 +200,7 @@ namespace Microsoft.ML.AutoML
                 {
                     // This exception is thrown when the IHost/MLContext of the trainer is canceled due to
                     // reaching maximum experiment time. Simply catch this exception and return finished
-                    // iteration results. For some trainers, Like FastTree, because training is done in parallel
+                    // iteration results. For some trainers, like FastTree, because training is done in parallel
                     // in can throw multiple OperationCancelledExceptions. This causes them to be returned as an
                     // AggregateException and misses the first catch block. This is to handle that case.
                     if (e.InnerExceptions.All( exception => exception is OperationCanceledException))

--- a/src/Microsoft.ML.AutoML/Experiment/Experiment.cs
+++ b/src/Microsoft.ML.AutoML/Experiment/Experiment.cs
@@ -206,7 +206,7 @@ namespace Microsoft.ML.AutoML
                     // iteration results. For some trainers, like FastTree, because training is done in parallel
                     // in can throw multiple OperationCancelledExceptions. This causes them to be returned as an
                     // AggregateException and misses the first catch block. This is to handle that case.
-                    if (e.InnerExceptions.All( exception => exception is OperationCanceledException))
+                    if (e.InnerExceptions.All(exception => exception is OperationCanceledException))
                     {
                         _logger.Warning(_operationCancelledMessage, e.Message);
                         return iterationResults;

--- a/src/Microsoft.ML.AutoML/Experiment/Experiment.cs
+++ b/src/Microsoft.ML.AutoML/Experiment/Experiment.cs
@@ -27,6 +27,10 @@ namespace Microsoft.ML.AutoML
         private readonly IRunner<TRunDetail> _runner;
         private readonly IList<SuggestedPipelineRunDetail> _history;
         private readonly IChannel _logger;
+
+        private readonly string _operationCancelledMessage = "OperationCanceledException has been caught after maximum experiment time" +
+                        "was reached, and the running MLContext was stopped. Details: {0}";
+
         private Timer _maxExperimentTimeTimer;
         private Timer _mainContextCanceledTimer;
         private bool _experimentTimerExpired;
@@ -192,8 +196,7 @@ namespace Microsoft.ML.AutoML
                     // This exception is thrown when the IHost/MLContext of the trainer is canceled due to
                     // reaching maximum experiment time. Simply catch this exception and return finished
                     // iteration results.
-                    _logger.Warning("OperationCanceledException has been caught after maximum experiment time" +
-                        "was reached, and the running MLContext was stopped. Details: {0}", e.Message);
+                    _logger.Warning(_operationCancelledMessage, e.Message);
                     return iterationResults;
                 }
                 catch (AggregateException e)
@@ -205,8 +208,7 @@ namespace Microsoft.ML.AutoML
                     // AggregateException and misses the first catch block. This is to handle that case.
                     if (e.InnerExceptions.All( exception => exception is OperationCanceledException))
                     {
-                        _logger.Warning("OperationCanceledException has been caught after maximum experiment time" +
-                        "was reached, and the running MLContext was stopped. Details: {0}", e.Message);
+                        _logger.Warning(_operationCancelledMessage, e.Message);
                         return iterationResults;
                     }
 

--- a/src/Microsoft.ML.AutoML/Experiment/Experiment.cs
+++ b/src/Microsoft.ML.AutoML/Experiment/Experiment.cs
@@ -210,7 +210,7 @@ namespace Microsoft.ML.AutoML
                         return iterationResults;
                     }
 
-                    Console.WriteLine(e.Message);
+                    throw;
                 }
             } while (_history.Count < _experimentSettings.MaxModels &&
                     !_experimentSettings.CancellationToken.IsCancellationRequested &&


### PR DESCRIPTION
Fixes #5612. In AutoML when the max experiment time is up a cancellation token is used to cancel any runs in progress. We catch the `OperationCanceledException` so that it doesn't prevent the finished models from being returned. However for some trainers, like FastTree, because training is done in parallel it can throw multiple `OperationCancelledExceptions` grouped together in an `AggregateException`. This was missing the original `catch` block and so was causing no results to be returned. This PR adds in another check for the `AggregateException` where all inner exceptions are of type `OperationCancelledException`, and treats it the same was as a plain `OperationCancelledException`.

I was not sure how to really add tests for this, It was brought up by a user and you _can_ repro it locally though its not consistent. If any of you have ideas for good tests let me know.