### PR TITLE
Treat TensorFlow output as non-batched.

### DIFF
--- a/src/Microsoft.ML.TensorFlow/TensorFlowModel.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorFlowModel.cs
@@ -18,6 +18,7 @@ namespace Microsoft.ML.Transforms
     {
         internal Session Session { get; }
         internal string ModelPath { get; }
+        internal bool TreatOutputAsBatched { get; }
 
         private readonly IHostEnvironment _env;
 
@@ -27,10 +28,12 @@ namespace Microsoft.ML.Transforms
         /// <param name="env">An <see cref="IHostEnvironment"/> object.</param>
         /// <param name="session">TensorFlow session object.</param>
         /// <param name="modelLocation">Location of the model from where <paramref name="session"/> was loaded.</param>
-        internal TensorFlowModel(IHostEnvironment env, Session session, string modelLocation)
+        /// <param name="treatOutputAsBatched">If the first dimension of the output is unknown, should it be treated as batched or not.</param>
+        internal TensorFlowModel(IHostEnvironment env, Session session, string modelLocation, bool treatOutputAsBatched = true)
         {
             Session = session;
             ModelPath = modelLocation;
+            TreatOutputAsBatched = treatOutputAsBatched;
             _env = env;
             _disposed = false;
         }
@@ -40,7 +43,7 @@ namespace Microsoft.ML.Transforms
         /// </summary>
         public DataViewSchema GetModelSchema()
         {
-            return TensorFlowUtils.GetModelSchema(_env, Session.graph);
+            return TensorFlowUtils.GetModelSchema(_env, Session.graph, treatOutputAsBatched: TreatOutputAsBatched);
         }
 
         /// <summary>

--- a/src/Microsoft.ML.TensorFlow/TensorFlowModel.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorFlowModel.cs
@@ -43,7 +43,7 @@ namespace Microsoft.ML.Transforms
         /// </summary>
         public DataViewSchema GetModelSchema()
         {
-            return TensorFlowUtils.GetModelSchema(_env, Session.graph, treatOutputAsBatched: TreatOutputAsBatched);
+            return TensorFlowUtils.GetModelSchema(_env, Session.graph, TreatOutputAsBatched);
         }
 
         /// <summary>
@@ -52,7 +52,7 @@ namespace Microsoft.ML.Transforms
         /// </summary>
         public DataViewSchema GetInputSchema()
         {
-            return TensorFlowUtils.GetModelSchema(_env, Session.graph, "Placeholder");
+            return TensorFlowUtils.GetModelSchema(_env, Session.graph, TreatOutputAsBatched, "Placeholder");
         }
 
         /// <summary>

--- a/src/Microsoft.ML.TensorFlow/TensorflowCatalog.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorflowCatalog.cs
@@ -35,5 +35,31 @@ namespace Microsoft.ML
         /// </example>
         public static TensorFlowModel LoadTensorFlowModel(this ModelOperationsCatalog catalog, string modelLocation)
             => TensorFlowUtils.LoadTensorFlowModel(CatalogUtils.GetEnvironment(catalog), modelLocation);
+
+        /// <summary>
+        /// Load TensorFlow model into memory. This is the convenience method that allows the model to be loaded once and subsequently use it for querying schema and creation of
+        /// <see cref="TensorFlowEstimator"/> using <see cref="TensorFlowModel.ScoreTensorFlowModel(string, string, bool)"/>.
+        /// usage of this API requires additional NuGet dependencies on TensorFlow redist, see linked document for more information.
+        /// <see cref="TensorFlowModel"/> also holds references to unmanaged resources that need to be freed either with an explicit
+        /// call to Dispose() or implicitly by declaring the variable with the "using" syntax/>
+        ///
+        /// <format type="text/markdown">
+        /// <![CDATA[
+        /// [!include[io](~/../docs/samples/docs/api-reference/tensorflow-usage.md)]
+        /// ]]>
+        /// </format>
+        /// </summary>
+        /// <param name="catalog">The transform's catalog.</param>
+        /// <param name="modelLocation">Location of the TensorFlow model.</param>
+        /// <param name="treatOutputAsBatched">If the first dimension of the output is unknown, should it be treated as batched or not.</param>
+        /// <example>
+        /// <format type="text/markdown">
+        /// <![CDATA[
+        /// [!code-csharp[LoadTensorFlowModel](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/TensorFlow/TextClassification.cs)]
+        /// ]]>
+        /// </format>
+        /// </example>
+        public static TensorFlowModel LoadTensorFlowModel(this ModelOperationsCatalog catalog, string modelLocation, bool treatOutputAsBatched)
+            => TensorFlowUtils.LoadTensorFlowModel(CatalogUtils.GetEnvironment(catalog), modelLocation, treatOutputAsBatched);
     }
 }

--- a/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
@@ -82,16 +82,17 @@ namespace Microsoft.ML.Transforms
         /// Transform for scoring Tensorflow models. Input data column names/types must exactly match
         /// all model input names. Only the output columns specified will be generated.
         /// This convenience method avoids reloading of TensorFlow model.
-        /// It is useful in a situation where user has already loaded TensorFlow model using <see cref="TensorFlowUtils.LoadTensorFlowModel(IHostEnvironment, string)"/> for inspecting model schema.
+        /// It is useful in a situation where user has already loaded TensorFlow model using <see cref="TensorFlowUtils.LoadTensorFlowModel(IHostEnvironment, string, bool)"/> for inspecting model schema.
         /// </summary>
         /// <param name="env">The environment to use.</param>
-        /// <param name="tfModelInfo"> <see cref="TensorFlowModel"/> object created with <see cref="TensorFlowUtils.LoadTensorFlowModel(IHostEnvironment, string)"/>.</param>
+        /// <param name="tfModelInfo"> <see cref="TensorFlowModel"/> object created with <see cref="TensorFlowUtils.LoadTensorFlowModel(IHostEnvironment, string, bool)"/>.</param>
         /// <param name="outputColumnName">The output columns to generate. Names must match model specifications. Data types are inferred from model.</param>
         /// <param name="inputColumnName">The name of the input data columns. Must match model's input names. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
         /// <param name="addBatchDimensionInput">Add a batch dimension to the input e.g. input = [224, 224, 3] => [-1, 224, 224, 3].
         /// This parameter is used to deal with models that have unknown shape but the internal operators in the model require data to have batch dimension as well.</param>
-        internal TensorFlowTransformer(IHostEnvironment env, TensorFlowModel tfModelInfo, string outputColumnName, string inputColumnName = null, bool addBatchDimensionInput = false)
-            : this(env, tfModelInfo.Session, new[] { outputColumnName }, new[] { inputColumnName ?? outputColumnName }, IsSavedModel(env, tfModelInfo.ModelPath) ? tfModelInfo.ModelPath : null, false, addBatchDimensionInput)
+        /// <param name="treatOutputAsBatched">If the first dimension of the output is unknown, should it be treated as batched or not.</param>
+        internal TensorFlowTransformer(IHostEnvironment env, TensorFlowModel tfModelInfo, string outputColumnName, string inputColumnName = null, bool addBatchDimensionInput = false, bool treatOutputAsBatched = true)
+            : this(env, tfModelInfo.Session, new[] { outputColumnName }, new[] { inputColumnName ?? outputColumnName }, IsSavedModel(env, tfModelInfo.ModelPath) ? tfModelInfo.ModelPath : null, false, addBatchDimensionInput, treatOutputAsBatched: treatOutputAsBatched)
         {
         }
 
@@ -99,10 +100,10 @@ namespace Microsoft.ML.Transforms
         /// Transform for scoring Tensorflow models. Input data column names/types must exactly match
         /// all model input names. Only the output columns specified will be generated.
         /// This convenience method avoids reloading of TensorFlow model.
-        /// It is useful in a situation where user has already loaded TensorFlow model using <see cref="TensorFlowUtils.LoadTensorFlowModel(IHostEnvironment, string)"/> for inspecting model schema.
+        /// It is useful in a situation where user has already loaded TensorFlow model using <see cref="TensorFlowUtils.LoadTensorFlowModel(IHostEnvironment, string, bool)"/> for inspecting model schema.
         /// </summary>
         /// <param name="env">The environment to use.</param>
-        /// <param name="tfModelInfo"> <see cref="TensorFlowModel"/> object created with <see cref="TensorFlowUtils.LoadTensorFlowModel(IHostEnvironment, string)"/>.</param>
+        /// <param name="tfModelInfo"> <see cref="TensorFlowModel"/> object created with <see cref="TensorFlowUtils.LoadTensorFlowModel(IHostEnvironment, string, bool)"/>.</param>
         /// <param name="inputColumnNames">The name of the input data columns. Must match model's input names.</param>
         /// <param name="outputColumnNames">The output columns to generate. Names must match model specifications. Data types are inferred from model.</param>
         /// <param name="addBatchDimensionInput">Add a batch dimension to the input e.g. input = [224, 224, 3] => [-1, 224, 224, 3].
@@ -267,7 +268,7 @@ namespace Microsoft.ML.Transforms
 
         internal TensorFlowTransformer(IHostEnvironment env, Session session, string[] outputColumnNames,
             string[] inputColumnNames, string savedModelPath, bool isTemporarySavedModel,
-            bool addBatchDimensionInput, int batchSize = 1, TensorFlowEstimator.Options options = null, IDataView input = null)
+            bool addBatchDimensionInput, int batchSize = 1, TensorFlowEstimator.Options options = null, IDataView input = null, bool treatOutputAsBatched = true)
             : base(Contracts.CheckRef(env, nameof(env)).Register(nameof(TensorFlowTransformer)))
 
         {
@@ -283,7 +284,7 @@ namespace Microsoft.ML.Transforms
             Outputs = outputColumnNames;
             tf.compat.v1.disable_eager_execution();
 
-            (TFOutputTypes, OutputTypes, TFOutputOperations) = GetOutputInfo(Host, Session, Outputs);
+            (TFOutputTypes, OutputTypes, TFOutputOperations) = GetOutputInfo(Host, Session, Outputs, treatOutputAsBatched);
             (TFInputTypes, TFInputShapes, TFInputOperations) = GetInputInfo(Host, Session, Inputs, batchSize);
 
             TFInputNodes = new TF_Output[Inputs.Length];
@@ -359,7 +360,7 @@ namespace Microsoft.ML.Transforms
             return new TensorShape(dims.Select(x => (int)x).ToArray());
         }
 
-        internal static (TF_DataType[] tfOutputTypes, DataViewType[] outputTypes, (Operation, int)[]) GetOutputInfo(IHost host, Session session, string[] outputs)
+        internal static (TF_DataType[] tfOutputTypes, DataViewType[] outputTypes, (Operation, int)[]) GetOutputInfo(IHost host, Session session, string[] outputs, bool treatOutputAsBatched)
         {
             var tfOutputTypes = new TF_DataType[outputs.Length];
             var outputTypes = new DataViewType[outputs.Length];
@@ -384,7 +385,12 @@ namespace Microsoft.ML.Transforms
                 // If there are other dimension that are unknown the transformer will return a variable length vector.
                 // This is the work around in absence of reshape transformer.
                 var idims = shape.dims;
-                int[] dims = shape.ndim > 0 ? idims.Skip(idims[0] == -1 ? 1 : 0).ToArray() : new int[0];
+
+                int[] dims = idims;
+                if (treatOutputAsBatched)
+                {
+                    dims = shape.ndim > 0 ? idims.Skip(idims[0] == -1 ? 1 : 0).ToArray() : new int[0];
+                }
                 for (int j = 0; j < dims.Length; j++)
                     dims[j] = dims[j] == -1 ? 0 : dims[j];
                 if (dims == null || dims.Length == 0)
@@ -876,6 +882,15 @@ namespace Microsoft.ML.Transforms
             /// </remarks>
             [Argument(ArgumentType.AtMostOnce, HelpText = "Add a batch dimension to the input e.g. input = [224, 224, 3] => [-1, 224, 224, 3].", SortOrder = 16)]
             public bool AddBatchDimensionInputs = false;
+
+            /// <summary>
+            /// If the first dimension of the output is unknown, should it be treated as batched or not. e.g. output = [-1] will be read as a vector of unknown length when this is false.
+            /// </summary>
+            /// <remarks>
+            /// This parameter is used to deal with models that have unknown output shape and it needs to be interpreted in ML.NET as a vector of unkown length and not as a batch dimension.
+            /// </remarks>
+            [Argument(ArgumentType.AtMostOnce, HelpText = "If the first dimension of the output is unknown, should it be treated as batched or not. e.g. output = [-1] will be read as a vector of unkown length when this is false.", SortOrder = 17)]
+            public bool TreatOutputAsBatched = true;
         }
 
         private readonly IHost _host;
@@ -897,7 +912,7 @@ namespace Microsoft.ML.Transforms
         }
 
         internal TensorFlowEstimator(IHostEnvironment env, Options options)
-            : this(env, options, TensorFlowUtils.LoadTensorFlowModel(env, options.ModelLocation))
+            : this(env, options, TensorFlowUtils.LoadTensorFlowModel(env, options.ModelLocation, options.TreatOutputAsBatched))
         {
         }
 
@@ -906,20 +921,23 @@ namespace Microsoft.ML.Transforms
             _host = Contracts.CheckRef(env, nameof(env)).Register(nameof(TensorFlowEstimator));
             _options = options;
             _tensorFlowModel = tensorFlowModel;
+            if (!tensorFlowModel.TreatOutputAsBatched)
+                _options.TreatOutputAsBatched = tensorFlowModel.TreatOutputAsBatched;
             tensorFlowModel.Session.graph.as_default();
-            var inputTuple = TensorFlowTransformer.GetInputInfo(_host, tensorFlowModel.Session, options.InputColumns);
+            var inputTuple = TensorFlowTransformer.GetInputInfo(_host, tensorFlowModel.Session, _options.InputColumns);
             _tfInputTypes = inputTuple.tfInputTypes;
-            var outputTuple = TensorFlowTransformer.GetOutputInfo(_host, tensorFlowModel.Session, options.OutputColumns);
+            var outputTuple = TensorFlowTransformer.GetOutputInfo(_host, tensorFlowModel.Session, _options.OutputColumns, _options.TreatOutputAsBatched);
             _outputTypes = outputTuple.outputTypes;
         }
 
-        private static Options CreateArguments(TensorFlowModel tensorFlowModel, string[] outputColumnNames, string[] inputColumnName, bool addBatchDimensionInput)
+        private static Options CreateArguments(TensorFlowModel tensorFlowModel, string[] outputColumnNames, string[] inputColumnName, bool addBatchDimensionInput, bool treatOutputAsBatched = true)
         {
             var options = new Options();
             options.ModelLocation = tensorFlowModel.ModelPath;
             options.InputColumns = inputColumnName;
             options.OutputColumns = outputColumnNames;
             options.AddBatchDimensionInputs = addBatchDimensionInput;
+            options.TreatOutputAsBatched = treatOutputAsBatched;
             return options;
         }
 
@@ -959,7 +977,7 @@ namespace Microsoft.ML.Transforms
             if (_transformer == null)
             {
                 _transformer = new TensorFlowTransformer(_host, _tensorFlowModel.Session, _options.OutputColumns, _options.InputColumns,
-                    IsSavedModel(_host, _options.ModelLocation) ? _options.ModelLocation : null, false, _options.AddBatchDimensionInputs);
+                    IsSavedModel(_host, _options.ModelLocation) ? _options.ModelLocation : null, false, _options.AddBatchDimensionInputs, treatOutputAsBatched: _options.TreatOutputAsBatched);
             }
             // Validate input schema.
             _transformer.GetOutputSchema(input.Schema);

--- a/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
@@ -110,8 +110,9 @@ namespace Microsoft.ML.Transforms
         /// <param name="outputColumnNames">The output columns to generate. Names must match model specifications. Data types are inferred from model.</param>
         /// <param name="addBatchDimensionInput">Add a batch dimension to the input e.g. input = [224, 224, 3] => [-1, 224, 224, 3].
         /// This parameter is used to deal with models that have unknown shape but the internal operators in the model require data to have batch dimension as well.</param>
-        internal TensorFlowTransformer(IHostEnvironment env, TensorFlowModel tfModelInfo, string[] outputColumnNames, string[] inputColumnNames, bool addBatchDimensionInput = false)
-            : this(env, tfModelInfo.Session, outputColumnNames, inputColumnNames, IsSavedModel(env, tfModelInfo.ModelPath) ? tfModelInfo.ModelPath : null, false, addBatchDimensionInput)
+        /// <param name="treatOutputAsBatched">If the first dimension of the output is unknown, should it be treated as batched or not.</param>
+        internal TensorFlowTransformer(IHostEnvironment env, TensorFlowModel tfModelInfo, string[] outputColumnNames, string[] inputColumnNames, bool addBatchDimensionInput = false, bool treatOutputAsBatched = true)
+            : this(env, tfModelInfo.Session, outputColumnNames, inputColumnNames, IsSavedModel(env, tfModelInfo.ModelPath) ? tfModelInfo.ModelPath : null, false, addBatchDimensionInput, treatOutputAsBatched: treatOutputAsBatched)
         {
         }
 
@@ -898,9 +899,9 @@ namespace Microsoft.ML.Transforms
             /// If the first dimension of the output is unknown, should it be treated as batched or not. e.g. output = [-1] will be read as a vector of unknown length when this is false.
             /// </summary>
             /// <remarks>
-            /// This parameter is used to deal with models that have unknown output shape and it needs to be interpreted in ML.NET as a vector of unkown length and not as a batch dimension.
+            /// This parameter is used to deal with models that have unknown output shape and it needs to be interpreted in ML.NET as a vector of unknown length and not as a batch dimension.
             /// </remarks>
-            [Argument(ArgumentType.AtMostOnce, HelpText = "If the first dimension of the output is unknown, should it be treated as batched or not. e.g. output = [-1] will be read as a vector of unkown length when this is false.", SortOrder = 17)]
+            [Argument(ArgumentType.AtMostOnce, HelpText = "If the first dimension of the output is unknown, should it be treated as batched or not. e.g. output = [-1] will be read as a vector of unknown length when this is false.", SortOrder = 17)]
             public bool TreatOutputAsBatched = true;
         }
 

--- a/src/Microsoft.ML.TensorFlow/TensorflowUtils.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorflowUtils.cs
@@ -99,9 +99,9 @@ namespace Microsoft.ML.TensorFlow
                             columnType = new VectorDataViewType(mlType, tensorShape[0] > 0 ? tensorShape : tensorShape.Skip(1).ToArray());
                         }
                         // When treatOutputAsBatched is false, if the first value is less than 0 we want to set it to 0. TensorFlow
-                        // represents an unkown size as -1, but ML.NET represents it as 0 so we need to convert it.
-                        // I.E. if the input dimensions are [-1, 5], ML.NET will read the -1 as a dimension of unkown length, and so the ML.NET
-                        // data type will be a vector of 2 dimensions, where the first dimension is unkown and the second has a length of 5.
+                        // represents an unknown size as -1, but ML.NET represents it as 0 so we need to convert it.
+                        // I.E. if the input dimensions are [-1, 5], ML.NET will read the -1 as a dimension of unknown length, and so the ML.NET
+                        // data type will be a vector of 2 dimensions, where the first dimension is unknown and the second has a length of 5.
                         else
                         {
                             if (tensorShape[0] < 0)

--- a/src/Microsoft.ML.TensorFlow/TensorflowUtils.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorflowUtils.cs
@@ -90,7 +90,7 @@ namespace Microsoft.ML.TensorFlow
                     DataViewType columnType = new VectorDataViewType(mlType);
                     if (!(Utils.Size(tensorShape) == 1 && tensorShape[0] <= 0) &&
                         (Utils.Size(tensorShape) > 0 && tensorShape.Skip(1).All(x => x > 0)))
-                        // When treatOutputAsBatched is true we keep the existing behaviour. This means that if the first dimension is greater
+                        // treatOutputAsBatched == true means that if the first dimension is greater
                         // than 0 we take the tensor shape as is. If the first value is less then 0, we treat it as the batch input so we can
                         // ignore it for the shape of the ML.NET vector. I.E. if the input dimensions are [-1, 5], ML.NET will read the -1 as
                         // batch input, and so the ML.NET data type will be a vector of length 5.

--- a/src/Microsoft.ML.TensorFlow/TensorflowUtils.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorflowUtils.cs
@@ -32,7 +32,7 @@ namespace Microsoft.ML.TensorFlow
         /// </summary>
         internal const string TensorflowUpstreamOperatorsKind = "TensorflowUpstreamOperators";
 
-        internal static DataViewSchema GetModelSchema(IExceptionContext ectx, Graph graph, string opType = null, bool treatOutputAsBatched = true)
+        internal static DataViewSchema GetModelSchema(IExceptionContext ectx, Graph graph, bool treatOutputAsBatched, string opType = null)
         {
             var schemaBuilder = new DataViewSchema.Builder();
             foreach (Operation op in graph)
@@ -99,9 +99,9 @@ namespace Microsoft.ML.TensorFlow
                             columnType = new VectorDataViewType(mlType, tensorShape[0] > 0 ? tensorShape : tensorShape.Skip(1).ToArray());
                         }
                         // When treatOutputAsBatched is false, if the first value is less than 0 we want to set it to 0. TensorFlow
-                        // represents and unkown size as -1, but ML.NET represents it as 0 so we need to convert it.
-                        //I.E. if the input dimensions are [-1, 5], ML.NET will read the -1 as a dimension of unkown length, and so the ML.NET
-                        //data type will be a vector of 2 dimensions, where the first dimension is unkown and the second has a length of 5.
+                        // represents an unkown size as -1, but ML.NET represents it as 0 so we need to convert it.
+                        // I.E. if the input dimensions are [-1, 5], ML.NET will read the -1 as a dimension of unkown length, and so the ML.NET
+                        // data type will be a vector of 2 dimensions, where the first dimension is unkown and the second has a length of 5.
                         else
                         {
                             if (tensorShape[0] < 0)
@@ -129,7 +129,7 @@ namespace Microsoft.ML.TensorFlow
         internal static DataViewSchema GetModelSchema(IHostEnvironment env, string modelPath, bool treatOutputAsBatched = true)
         {
             using var model = LoadTensorFlowModel(env, modelPath, treatOutputAsBatched);
-            return GetModelSchema(env, model.Session.graph, treatOutputAsBatched: treatOutputAsBatched);
+            return GetModelSchema(env, model.Session.graph, treatOutputAsBatched);
         }
 
         /// <summary>

--- a/test/BaselineOutput/Common/EntryPoints/core_manifest.json
+++ b/test/BaselineOutput/Common/EntryPoints/core_manifest.json
@@ -23613,6 +23613,15 @@
           "SortOrder": 16.0,
           "IsNullable": false,
           "Default": false
+        },
+        {
+          "Name": "TreatOutputAsBatched",
+          "Type": "Bool",
+          "Desc": "If the first dimension of the output is unknown, should it be treated as batched or not. e.g. output = [-1] will be read as a vector of unkown length when this is false.",
+          "Required": false,
+          "SortOrder": 17.0,
+          "IsNullable": false,
+          "Default": true
         }
       ],
       "Outputs": [

--- a/test/BaselineOutput/Common/EntryPoints/core_manifest.json
+++ b/test/BaselineOutput/Common/EntryPoints/core_manifest.json
@@ -23617,7 +23617,7 @@
         {
           "Name": "TreatOutputAsBatched",
           "Type": "Bool",
-          "Desc": "If the first dimension of the output is unknown, should it be treated as batched or not. e.g. output = [-1] will be read as a vector of unkown length when this is false.",
+          "Desc": "If the first dimension of the output is unknown, should it be treated as batched or not. e.g. output = [-1] will be read as a vector of unknown length when this is false.",
           "Required": false,
           "SortOrder": 17.0,
           "IsNullable": false,

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -1162,7 +1162,7 @@ namespace Microsoft.ML.Scenarios
 
             string modelLocation = @"model_string_test";
 
-            // When treatOutputAsBatched is defaultd to true, make sure the output is correct.
+            // When treatOutputAsBatched is defaulted to true, make sure the output is correct.
             using var model = mlContext.Model.LoadTensorFlowModel(modelLocation).ScoreTensorFlowModel(new[] { "Original_A", "Joined_Splited_Text" }, new[] { "A", "B" })
                 .Fit(dataView);
 

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -1152,38 +1152,6 @@ namespace Microsoft.ML.Scenarios
             }
         }
 
-        // This test has been created as result of https://github.com/dotnet/machinelearning/issues/5364.
-        [TensorFlowFact]
-        public void TreatOutputAsBatched()
-        {
-            MLContext mlContext = new MLContext();
-
-            var dataView = mlContext.Data.CreateTextLoader<TextInput>().Load(new MultiFileSource(null));
-
-            string modelLocation = @"model_string_test";
-
-            // When treatOutputAsBatched is defaulted to true, make sure the output is correct.
-            using var model = mlContext.Model.LoadTensorFlowModel(modelLocation).ScoreTensorFlowModel(new[] { "Original_A", "Joined_Splited_Text" }, new[] { "A", "B" })
-                .Fit(dataView);
-
-            var modelSchema = model.GetOutputSchema(dataView.Schema);
-
-            Assert.Equal(4, modelSchema.Count);
-            Assert.Equal(new VectorDataViewType(TextDataViewType.Instance, 2), modelSchema[2].Type);
-            Assert.Equal(new VectorDataViewType(TextDataViewType.Instance, 1,1), modelSchema[3].Type);
-
-            using var modelNonBatched = mlContext.Model.LoadTensorFlowModel(modelLocation, false).ScoreTensorFlowModel(new[] { "Original_A", "Joined_Splited_Text" }, new[] { "A", "B" })
-                .Fit(dataView);
-
-            modelSchema = modelNonBatched.GetOutputSchema(dataView.Schema);
-
-            Assert.Equal(4, modelSchema.Count);
-            Assert.Equal(new VectorDataViewType(TextDataViewType.Instance, 0, 2), modelSchema[2].Type);
-            Assert.Equal(new VectorDataViewType(TextDataViewType.Instance, 1, 1), modelSchema[3].Type);
-
-        }
-
-
         [TensorFlowFact]
         public void TensorFlowTransformCifarInvalidShape()
         {

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -1226,12 +1226,10 @@ namespace Microsoft.ML.Scenarios
             // For explanation on how was the `sentiment_model` created 
             // c.f. https://github.com/dotnet/machinelearning-testdata/blob/master/Microsoft.ML.TensorFlow.TestModels/sentiment_model/README.md
             string modelLocation = @"sentiment_model";
-            using var pipelineModel = _mlContext.Model.LoadTensorFlowModel(modelLocation, false).ScoreTensorFlowModel(new[] { "Prediction/Softmax" }, new[] { "Features" })
+            using var pipelineModel = _mlContext.Model.LoadTensorFlowModel(modelLocation).ScoreTensorFlowModel(new[] { "Prediction/Softmax" }, new[] { "Features" })
                 .Append(_mlContext.Transforms.CopyColumns("Prediction", "Prediction/Softmax"))
                 .Fit(dataView);
             using var tfEnginePipe = _mlContext.Model.CreatePredictionEngine<TensorFlowSentiment, TensorFlowSentiment>(pipelineModel);
-
-            var schema = pipelineModel.GetOutputSchema(dataView.Schema);
 
             var processedData = dataPipe.Predict(data[0]);
             Array.Resize(ref processedData.Features, 600);

--- a/test/Microsoft.ML.Tests/TensorFlowEstimatorTests.cs
+++ b/test/Microsoft.ML.Tests/TensorFlowEstimatorTests.cs
@@ -183,6 +183,52 @@ namespace Microsoft.ML.Tests
                 Assert.Equal(4, numRows);
             }
         }
+        
+        [TensorFlowFact]
+        public void TreatOutputAsBatched()
+        {
+            var modelLocation = "cifar_model/frozen_model.pb";
+
+            var mlContext = new MLContext(seed: 1);
+            var imageHeight = 32;
+            var imageWidth = 32;
+            var dataFile = GetDataPath("images/images.tsv");
+            var imageFolder = Path.GetDirectoryName(dataFile);
+
+            var data = ML.Data.LoadFromTextFile(dataFile, new[] {
+                new TextLoader.Column("imagePath", DataKind.String, 0),
+                new TextLoader.Column("name", DataKind.String, 1)
+            });
+
+            // Note that CamelCase column names are there to match the TF graph node names.
+            // Check and make sure save/load work correctly for the new TreatOutputAsBatched value.
+            var pipe = ML.Transforms.LoadImages("Input", imageFolder, "imagePath")
+                .Append(ML.Transforms.ResizeImages("Input", imageHeight, imageWidth))
+                .Append(ML.Transforms.ExtractPixels("Input", interleavePixelColors: true))
+                .Append(ML.Model.LoadTensorFlowModel(modelLocation, false).ScoreTensorFlowModel("Output", "Input"));
+
+            TestEstimatorCore(pipe, data);
+            var schema = pipe.Fit(data).Transform(data).Schema;
+
+            // The dimensions of the output with treatOutputAsBatched set to false should be * 10
+            // as the first dimension of -1 is treated as an unkown dimension.
+            Assert.Equal(new VectorDataViewType(NumberDataViewType.Single, 0, 10), schema["Output"].Type);
+
+            // Note that CamelCase column names are there to match the TF graph node names.
+            // Test with TreatOutputAsBatched set to default value of true.
+            pipe = ML.Transforms.LoadImages("Input", imageFolder, "imagePath")
+                .Append(ML.Transforms.ResizeImages("Input", imageHeight, imageWidth))
+                .Append(ML.Transforms.ExtractPixels("Input", interleavePixelColors: true))
+                .Append(ML.Model.LoadTensorFlowModel(modelLocation).ScoreTensorFlowModel("Output", "Input"));
+
+            TestEstimatorCore(pipe, data);
+            schema = pipe.Fit(data).Transform(data).Schema;
+
+            // The dimensions of the output with treatOutputAsBatched set to true should be 10
+            // as the first dimension of -1 is treated as the batch dimension.
+            Assert.Equal(new VectorDataViewType(NumberDataViewType.Single, 10), schema["Output"].Type);
+
+        }
 
         [TensorFlowFact]
         public void TestTensorFlowWithSchema()

--- a/test/Microsoft.ML.Tests/TensorFlowEstimatorTests.cs
+++ b/test/Microsoft.ML.Tests/TensorFlowEstimatorTests.cs
@@ -183,7 +183,7 @@ namespace Microsoft.ML.Tests
                 Assert.Equal(4, numRows);
             }
         }
-        
+
         [TensorFlowFact]
         public void TreatOutputAsBatched()
         {
@@ -211,7 +211,7 @@ namespace Microsoft.ML.Tests
             var schema = pipe.Fit(data).Transform(data).Schema;
 
             // The dimensions of the output with treatOutputAsBatched set to false should be * 10
-            // as the first dimension of -1 is treated as an unkown dimension.
+            // as the first dimension of -1 is treated as an unknown dimension.
             Assert.Equal(new VectorDataViewType(NumberDataViewType.Single, 0, 10), schema["Output"].Type);
 
             // Note that CamelCase column names are there to match the TF graph node names.


### PR DESCRIPTION
Currently, if TensorFlow has a -1 as the first dimension in an output tensor then ML.NET always treats it as the batch number. There are some cases where we don't want it treated as a batch number, but an actual dimension. This PR gives the user the ability to specify whether its batch output or not but keeps the default behavior of assuming it is batched.

This issue originally stems from #5364, though there was a lot of offline conversation about it.