### PR TITLE
Documentation updates

### DIFF
--- a/docs/api-reference/tensorflow-usage.md
+++ b/docs/api-reference/tensorflow-usage.md
@@ -1,6 +1,6 @@
 ## Using TensorFlow based APIs
-In order to run any TensorFlow based ML.Net APIs you must first add a NuGet dependency 
-on the TensorFlow redist library. There are currently two versions you can use. One which is 
+In order to run any TensorFlow based ML.Net APIs you must first add a NuGet dependency
+on the TensorFlow redist library. There are currently two versions you can use. One which is
 compiled for GPU support, and one which has CPU support only.
 
 ### CPU only
@@ -22,18 +22,18 @@ As of now TensorFlow does not support running on GPUs for MacOS, so we cannot su
 You must have at least one CUDA compatible GPU, for a list of compatible GPUs see
 [Nvidia's Guide](https://developer.nvidia.com/cuda-gpus).
 
-Install [CUDA v10.0](https://developer.nvidia.com/cuda-10.0-download-archive) and [CUDNN v7.6.4](https://developer.nvidia.com/rdp/cudnn-download). 
+Install [CUDA v10.1](https://developer.nvidia.com/cuda-10.1-download-archive-update2) and [CUDNN v7.6.4](https://developer.nvidia.com/rdp/cudnn-download).
 
-Make sure you install CUDA v10.0, not any other newer version.
+Make sure you install CUDA v10.1, not any other newer version.
 After downloading CUDNN v7.6.4 .zip file and unpacking it, you need to do the following steps:
 
-`copy <CUDNN_zip_files_path>\cuda\bin\cudnn64_7.dll to <YOUR_DRIVE>\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.0\bin`
+`copy <CUDNN_zip_files_path>\cuda\bin\cudnn64_7.dll to <YOUR_DRIVE>\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.1\bin`
 
 For C/C++ development:
 
-`Copy <CUDNN_zip_files_path>\cuda\ include\cudnn.h to <YOUR_DRIVE>\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.0\include`
+`Copy <CUDNN_zip_files_path>\cuda\ include\cudnn.h to <YOUR_DRIVE>\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.1\include`
 
-`Copy <CUDNN_zip_files_path>\cuda\lib\x64\cudnn.lib to <YOUR_DRIVE>\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.0\lib\x64`
+`Copy <CUDNN_zip_files_path>\cuda\lib\x64\cudnn.lib to <YOUR_DRIVE>\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.1\lib\x64`
 
 For further details in cuDNN you can follow the [cuDNN Installation guide](https://docs.nvidia.com/deeplearning/sdk/cudnn-install/index.html#installwindows).
 

--- a/docs/building/unix-instructions.md
+++ b/docs/building/unix-instructions.md
@@ -54,3 +54,5 @@ One way of obtaining CMake and other required libraries is via [Homebrew](https:
 ```sh
 $ brew update && brew install cmake https://raw.githubusercontent.com/dotnet/machinelearning/master/build/libomp.rb mono-libgdiplus gettext && brew link gettext --force && brew link libomp --force
 ```
+
+Please note that newer versionf of Homebrew [don't allow installing directly from a URL](https://github.com/Homebrew/brew/issues/8791). If you run into this issue, you may need to download libomp.rb first and install it will the local file instead.

--- a/docs/building/unix-instructions.md
+++ b/docs/building/unix-instructions.md
@@ -55,4 +55,4 @@ One way of obtaining CMake and other required libraries is via [Homebrew](https:
 $ brew update && brew install cmake https://raw.githubusercontent.com/dotnet/machinelearning/master/build/libomp.rb mono-libgdiplus gettext && brew link gettext --force && brew link libomp --force
 ```
 
-Please note that newer versions of Homebrew [don't allow installing directly from a URL](https://github.com/Homebrew/brew/issues/8791). If you run into this issue, you may need to download libomp.rb first and install it will the local file instead.
+Please note that newer versions of Homebrew [don't allow installing directly from a URL](https://github.com/Homebrew/brew/issues/8791). If you run into this issue, you may need to download libomp.rb first and install it with the local file instead.

--- a/docs/building/unix-instructions.md
+++ b/docs/building/unix-instructions.md
@@ -55,4 +55,4 @@ One way of obtaining CMake and other required libraries is via [Homebrew](https:
 $ brew update && brew install cmake https://raw.githubusercontent.com/dotnet/machinelearning/master/build/libomp.rb mono-libgdiplus gettext && brew link gettext --force && brew link libomp --force
 ```
 
-Please note that newer versionf of Homebrew [don't allow installing directly from a URL](https://github.com/Homebrew/brew/issues/8791). If you run into this issue, you may need to download libomp.rb first and install it will the local file instead.
+Please note that newer versions of Homebrew [don't allow installing directly from a URL](https://github.com/Homebrew/brew/issues/8791). If you run into this issue, you may need to download libomp.rb first and install it will the local file instead.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ApplyONNXModelWithInMemoryImages.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ApplyONNXModelWithInMemoryImages.cs
@@ -13,7 +13,7 @@ namespace Samples.Dynamic
         public static void Example()
         {
             // Download the squeeznet image model from ONNX model zoo, version 1.2
-            // https://github.com/onnx/models/tree/master/squeezenet or use
+            // https://github.com/onnx/models/tree/master/vision/classification/squeezenet or use
             // Microsoft.ML.Onnx.TestModels nuget.
             // It's a multiclass classifier. It consumes an input "data_0" and
             // produces an output "softmaxout_1".
@@ -45,7 +45,7 @@ namespace Samples.Dynamic
             // Map column "data_0" to column "softmaxout_1"
             var pipeline = mlContext.Transforms.ExtractPixels("data_0", "Image")
                 .Append(mlContext.Transforms.ApplyOnnxModel("softmaxout_1",
-                "data_0", modelPath)); 
+                "data_0", modelPath));
 
             var model = pipeline.Fit(dataView);
             var onnx = model.Transform(dataView);
@@ -60,12 +60,12 @@ namespace Samples.Dynamic
                 ImageDataPoint>(onnx, false).ToList();
 
             // The scores are probabilities of all possible classes, so they should
-            // all be positive. 
+            // all be positive.
             foreach (var dataPoint in transformedDataPoints)
             {
                 var firstClassProb = dataPoint.Scores.First();
                 var lastClassProb = dataPoint.Scores.Last();
-                Console.WriteLine("The probability of being the first class is " + 
+                Console.WriteLine("The probability of being the first class is " +
                     (firstClassProb * 100) + "%.");
 
                 Console.WriteLine($"The probability of being the last class is " +


### PR DESCRIPTION
Just documentation changes and updates that fixes #5615, fixes #5594, and fixes #5588. 

Updates to document the correct version of CUDA for TensorFlow.
Documents an issue with brew and installing libomp.
Changes an ONNX url to be the correct URL.