### PR TITLE
Update to the latest Microsoft.DotNet.Interactive

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -26,3 +26,8 @@ dotnet_diagnostic.MSML_ExtendBaseTestClass.severity = none
 # The MSML_RelaxTestNaming suppressor for VSTHRD200 is not active for CodeAnalyzer.Tests, so we disable it altogether.
 # VSTHRD200: Use "Async" suffix for async methods
 dotnet_diagnostic.VSTHRD200.severity = none
+
+# Xml project files
+[*.{csproj}]
+indent_size = 2
+charset = utf-8

--- a/NuGet.config
+++ b/NuGet.config
@@ -7,6 +7,7 @@
     <clear />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
+    <add key="dotnet-libraries" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="vs-buildservices" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-buildservices/nuget/v3/index.json" />
     <add key="dotnet5-roslyn" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -33,8 +33,8 @@
     <TensorFlowMajorVersion>2</TensorFlowMajorVersion>
     <TensorflowDotNETVersion>0.20.1</TensorflowDotNETVersion>
     <MicrosoftCodeAnalysisCSharpInternalAnalyzerVersion>3.3.1</MicrosoftCodeAnalysisCSharpInternalAnalyzerVersion>
-    <MicrosoftDotNetInteractiveVersion>1.0.0-beta.20410.1</MicrosoftDotNetInteractiveVersion>
-    <MicrosoftDotNetInteractiveFormattingVersion>1.0.0-beta.20410.1</MicrosoftDotNetInteractiveFormattingVersion>
+    <MicrosoftDotNetInteractiveVersion>1.0.0-beta.21155.3</MicrosoftDotNetInteractiveVersion>
+    <MicrosoftDotNetInteractiveFormattingVersion>1.0.0-beta.21155.3</MicrosoftDotNetInteractiveFormattingVersion>
     <ApacheArrowVersion>2.0.0</ApacheArrowVersion>
     <SystemTextEncodingVersion>4.3.0</SystemTextEncodingVersion>
     <MicrosoftCSharpVersion>4.5.0</MicrosoftCSharpVersion>

--- a/src/Microsoft.Data.Analysis.Interactive/DataFrameKernelExtension.cs
+++ b/src/Microsoft.Data.Analysis.Interactive/DataFrameKernelExtension.cs
@@ -24,10 +24,10 @@ namespace Microsoft.Data.Analysis.Interactive
 
         public static void RegisterDataFrame()
         {
-            Formatter<DataFrame>.Register((df, writer) =>
+            Formatter.Register<DataFrame>((df, writer) =>
             {
-                const int MAX = 10000;
-                const int SIZE = 10;
+                const int maxRowCount = 10000;
+                const int rowsPerPage = 25;
 
                 var uniqueId = DateTime.Now.Ticks;
 
@@ -37,15 +37,15 @@ namespace Microsoft.Data.Analysis.Interactive
                 };
                 header.AddRange(df.Columns.Select(c => (IHtmlContent)th(c.Name)));
 
-                if (df.Rows.Count > SIZE)
+                if (df.Rows.Count > rowsPerPage)
                 {
-                    var maxMessage = df.Rows.Count > MAX ? $" (showing a max of {MAX} rows)" : string.Empty;
+                    var maxMessage = df.Rows.Count > maxRowCount ? $" (showing a max of {maxRowCount} rows)" : string.Empty;
                     var title = h3[style: "text-align: center;"]($"DataFrame - {df.Rows.Count} rows {maxMessage}");
 
                     // table body
-                    var maxRows = Math.Min(MAX, df.Rows.Count);
+                    var rowCount = Math.Min(maxRowCount, df.Rows.Count);
                     var rows = new List<List<IHtmlContent>>();
-                    for (var index = 0; index < maxRows; index++)
+                    for (var index = 0; index < rowCount; index++)
                     {
                         var cells = new List<IHtmlContent>
                         {
@@ -58,29 +58,29 @@ namespace Microsoft.Data.Analysis.Interactive
                         rows.Add(cells);
                     }
 
-                    //navigator      
+                    //navigator
                     var footer = new List<IHtmlContent>();
                     BuildHideRowsScript(uniqueId);
 
-                    var paginateScriptFirst = BuildHideRowsScript(uniqueId) + GotoPageIndex(uniqueId, 0) + BuildPageScript(uniqueId, SIZE);
+                    var paginateScriptFirst = BuildHideRowsScript(uniqueId) + GotoPageIndex(uniqueId, 0) + BuildPageScript(uniqueId, rowsPerPage);
                     footer.Add(button[style: "margin: 2px;", onclick: paginateScriptFirst]("⏮"));
 
-                    var paginateScriptPrevTen = BuildHideRowsScript(uniqueId) + UpdatePageIndex(uniqueId, -10, (maxRows - 1) / SIZE) + BuildPageScript(uniqueId, SIZE);
+                    var paginateScriptPrevTen = BuildHideRowsScript(uniqueId) + UpdatePageIndex(uniqueId, -10, (rowCount - 1) / rowsPerPage) + BuildPageScript(uniqueId, rowsPerPage);
                     footer.Add(button[style: "margin: 2px;", onclick: paginateScriptPrevTen]("⏪"));
 
-                    var paginateScriptPrev = BuildHideRowsScript(uniqueId) + UpdatePageIndex(uniqueId, -1, (maxRows - 1) / SIZE) + BuildPageScript(uniqueId, SIZE);
+                    var paginateScriptPrev = BuildHideRowsScript(uniqueId) + UpdatePageIndex(uniqueId, -1, (rowCount - 1) / rowsPerPage) + BuildPageScript(uniqueId, rowsPerPage);
                     footer.Add(button[style: "margin: 2px;", onclick: paginateScriptPrev]("◀️"));
 
                     footer.Add(b[style: "margin: 2px;"]("Page"));
                     footer.Add(b[id: $"page_{uniqueId}", style: "margin: 2px;"]("1"));
 
-                    var paginateScriptNext = BuildHideRowsScript(uniqueId) + UpdatePageIndex(uniqueId, 1, (maxRows - 1) / SIZE) + BuildPageScript(uniqueId, SIZE);
+                    var paginateScriptNext = BuildHideRowsScript(uniqueId) + UpdatePageIndex(uniqueId, 1, (rowCount - 1) / rowsPerPage) + BuildPageScript(uniqueId, rowsPerPage);
                     footer.Add(button[style: "margin: 2px;", onclick: paginateScriptNext]("▶️"));
 
-                    var paginateScriptNextTen = BuildHideRowsScript(uniqueId) + UpdatePageIndex(uniqueId, 10, (maxRows - 1) / SIZE) + BuildPageScript(uniqueId, SIZE);
+                    var paginateScriptNextTen = BuildHideRowsScript(uniqueId) + UpdatePageIndex(uniqueId, 10, (rowCount - 1) / rowsPerPage) + BuildPageScript(uniqueId, rowsPerPage);
                     footer.Add(button[style: "margin: 2px;", onclick: paginateScriptNextTen]("⏩"));
 
-                    var paginateScriptLast = BuildHideRowsScript(uniqueId) + GotoPageIndex(uniqueId, (maxRows - 1) / SIZE) + BuildPageScript(uniqueId, SIZE);
+                    var paginateScriptLast = BuildHideRowsScript(uniqueId) + GotoPageIndex(uniqueId, (rowCount - 1) / rowsPerPage) + BuildPageScript(uniqueId, rowsPerPage);
                     footer.Add(button[style: "margin: 2px;", onclick: paginateScriptLast]("⏭️"));
 
                     //table
@@ -93,7 +93,7 @@ namespace Microsoft.Data.Analysis.Interactive
                     writer.Write(t);
 
                     //show first page
-                    writer.Write($"<script>{BuildPageScript(uniqueId, SIZE)}</script>");
+                    writer.Write($"<script>{BuildPageScript(uniqueId, rowsPerPage)}</script>");
                 }
                 else
                 {

--- a/src/Microsoft.Data.Analysis.Interactive/Microsoft.Data.Analysis.Interactive.csproj
+++ b/src/Microsoft.Data.Analysis.Interactive/Microsoft.Data.Analysis.Interactive.csproj
@@ -1,18 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
-        <IsPackable>false</IsPackable>
-        <NoWarn>$(NoWarn);MSML_ParameterLocalVarName;SA1028</NoWarn>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.DotNet.Interactive" Version="$(MicrosoftDotNetInteractiveVersion)" />
-        <PackageReference Include="Microsoft.DotNet.Interactive.Formatting" Version="$(MicrosoftDotNetInteractiveFormattingVersion)" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.Interactive" Version="$(MicrosoftDotNetInteractiveVersion)" />
+    <PackageReference Include="Microsoft.DotNet.Interactive.Formatting" Version="$(MicrosoftDotNetInteractiveFormattingVersion)" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\Microsoft.Data.Analysis\Microsoft.Data.Analysis.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Data.Analysis\Microsoft.Data.Analysis.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/src/Microsoft.Data.Analysis.Interactive/Microsoft.Data.Analysis.Interactive.csproj
+++ b/src/Microsoft.Data.Analysis.Interactive/Microsoft.Data.Analysis.Interactive.csproj
@@ -8,9 +8,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.Interactive" Version="$(MicrosoftDotNetInteractiveVersion)" />
     <PackageReference Include="Microsoft.DotNet.Interactive.Formatting" Version="$(MicrosoftDotNetInteractiveFormattingVersion)" />
-    
-    <!-- work around https://github.com/dotnet/runtime/issues/45560 until System.Text.Json is fixed and Microsoft.DotNet.Interactive updates to the new version -->
-    <PackageReference Include=" System.Text.Encodings.Web" Version="5.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Data.Analysis.Interactive/Microsoft.Data.Analysis.Interactive.csproj
+++ b/src/Microsoft.Data.Analysis.Interactive/Microsoft.Data.Analysis.Interactive.csproj
@@ -8,6 +8,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.Interactive" Version="$(MicrosoftDotNetInteractiveVersion)" />
     <PackageReference Include="Microsoft.DotNet.Interactive.Formatting" Version="$(MicrosoftDotNetInteractiveFormattingVersion)" />
+    
+    <!-- work around https://github.com/dotnet/runtime/issues/45560 until System.Text.Json is fixed and Microsoft.DotNet.Interactive updates to the new version -->
+    <PackageReference Include=" System.Text.Encodings.Web" Version="5.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Data.Analysis/Microsoft.Data.Analysis.csproj
+++ b/src/Microsoft.Data.Analysis/Microsoft.Data.Analysis.csproj
@@ -1,250 +1,250 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-    <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
-        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <SuppressFinalPackageVersion>false</SuppressFinalPackageVersion>
-        <Description>This package contains easy-to-use and high-performance libraries for data analysis and transformation.</Description>
-        <PackageReleaseNotes>Initial preview of robust and extensible types and algorithms for manipulating structured data that supports aggregations, statistical funtions, sorting, grouping, joins, merges, handling missing values and more. </PackageReleaseNotes>
-        <PackageTags>ML.NET ML Machine Learning Data Science DataFrame Preparation DataView Analytics Exploration</PackageTags>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <!-- 
+  <Import Project="$(RepoRoot)eng/pkg/Pack.props" />
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <SuppressFinalPackageVersion>false</SuppressFinalPackageVersion>
+    <Description>This package contains easy-to-use and high-performance libraries for data analysis and transformation.</Description>
+    <PackageReleaseNotes>Initial preview of robust and extensible types and algorithms for manipulating structured data that supports aggregations, statistical funtions, sorting, grouping, joins, merges, handling missing values and more. </PackageReleaseNotes>
+    <PackageTags>ML.NET ML Machine Learning Data Science DataFrame Preparation DataView Analytics Exploration</PackageTags>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <!-- 
       1591: Documentation warnings
       NU5100: Warning that gets triggered because a .dll is not placed under lib folder on package. This is by design as we want MDAI to be under interactive-extensions folder.
        -->
-        <NoWarn>$(NoWarn);1591;NU5100;MSML_GeneralName;MSML_ParameterLocalVarName;MSML_PrivateFieldName;MSML_TypeParamName;SA1028;SA1507;SX1101;MSML_NoInstanceInitializers</NoWarn>
-        <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);AddMDAIToInteractiveExtensionsFolder</TargetsForTfmSpecificContentInPackage>
-    </PropertyGroup>
+    <NoWarn>$(NoWarn);1591;NU5100;MSML_GeneralName;MSML_ParameterLocalVarName;MSML_PrivateFieldName;MSML_TypeParamName;SA1028;SA1507;SX1101;MSML_NoInstanceInitializers</NoWarn>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);AddMDAIToInteractiveExtensionsFolder</TargetsForTfmSpecificContentInPackage>
+  </PropertyGroup>
 
-    <!-- The following properties are set to package M.D.A.Interactive with the M.D.A nuget package. If M.D.A.I undergoes TFM or dependency changes, we need to update the TargetFramework passed in below-->
-    <Target Name="AddMDAIToInteractiveExtensionsFolder">
-        <MSBuild Projects="./../Microsoft.Data.Analysis.Interactive/Microsoft.Data.Analysis.Interactive.csproj" Targets="_GetBuildOutputFilesWithTfm" Properties="TargetFramework=netcoreapp3.1">
-            <!-- Manually hardcoding the TargetFramework to netcoreapp3.1 as that is the one that MDAI targets -->
-            <Output TaskParameter="TargetOutputs" ItemName="_ItemsToIncludeForInteractive" />
-        </MSBuild>
-
-        <ItemGroup>
-            <_ItemsToIncludeForInteractive Update="@(_ItemsToIncludeForInteractive)" PackagePath="interactive-extensions/dotnet" />
-            <TfmSpecificPackageFile Include="@(_ItemsToIncludeForInteractive)" />
-        </ItemGroup>
-    </Target>
+  <!-- The following properties are set to package M.D.A.Interactive with the M.D.A nuget package. If M.D.A.I undergoes TFM or dependency changes, we need to update the TargetFramework passed in below-->
+  <Target Name="AddMDAIToInteractiveExtensionsFolder">
+    <MSBuild Projects="./../Microsoft.Data.Analysis.Interactive/Microsoft.Data.Analysis.Interactive.csproj" Targets="_GetBuildOutputFilesWithTfm" Properties="TargetFramework=netcoreapp3.1">
+      <!-- Manually hardcoding the TargetFramework to netcoreapp3.1 as that is the one that MDAI targets -->
+      <Output TaskParameter="TargetOutputs" ItemName="_ItemsToIncludeForInteractive" />
+    </MSBuild>
 
     <ItemGroup>
-        <None Include="Converters.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>Converters.tt</DependentUpon>
-        </None>
-        <None Include="PrimitiveDataFrameColumn.BinaryOperators.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>PrimitiveDataFrameColumn.BinaryOperators.tt</DependentUpon>
-        </None>
+      <_ItemsToIncludeForInteractive Update="@(_ItemsToIncludeForInteractive)" PackagePath="interactive-extensions/dotnet" />
+      <TfmSpecificPackageFile Include="@(_ItemsToIncludeForInteractive)" />
     </ItemGroup>
+  </Target>
 
-    <ItemGroup>
-        <PackageReference Include="Apache.Arrow" Version="$(ApacheArrowVersion)" />
-        <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
-        <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="$(SystemRuntimeCompilerServicesUnsafeVersion)" />
-        <PackageReference Include="System.Buffers" Version="$(SystemBuffersVersion)" />
-        <PackageReference Include="System.Text.Encoding" Version="$(SystemTextEncodingVersion)" />
-    </ItemGroup>
+  <ItemGroup>
+    <None Include="Converters.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Converters.tt</DependentUpon>
+    </None>
+    <None Include="PrimitiveDataFrameColumn.BinaryOperators.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>PrimitiveDataFrameColumn.BinaryOperators.tt</DependentUpon>
+    </None>
+  </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\Microsoft.ML.DataView\Microsoft.ML.DataView.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Apache.Arrow" Version="$(ApacheArrowVersion)" />
+    <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="$(SystemRuntimeCompilerServicesUnsafeVersion)" />
+    <PackageReference Include="System.Buffers" Version="$(SystemBuffersVersion)" />
+    <PackageReference Include="System.Text.Encoding" Version="$(SystemTextEncodingVersion)" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <None Update="Converters.tt">
-            <Generator>TextTemplatingFileGenerator</Generator>
-            <LastGenOutput>Converters.cs</LastGenOutput>
-        </None>
-        <None Update="PrimitiveDataFrameColumn.BinaryOperationAPIs.ExplodedColumns.tt">
-            <Generator>TextTemplatingFileGenerator</Generator>
-            <LastGenOutput>PrimitiveDataFrameColumn.BinaryOperationAPIs.ExplodedColumns.cs</LastGenOutput>
-        </None>
-        <None Update="PrimitiveDataFrameColumn.BinaryOperationImplementations.Exploded.tt">
-            <Generator>TextTemplatingFileGenerator</Generator>
-            <LastGenOutput>PrimitiveDataFrameColumn.BinaryOperationImplementations.Exploded.cs</LastGenOutput>
-        </None>
-        <None Update="DataFrameColumn.BinaryOperations.tt">
-            <Generator>TextTemplatingFileGenerator</Generator>
-            <LastGenOutput>DataFrameColumn.BinaryOperations.cs</LastGenOutput>
-        </None>
-        <None Update="DataFrameColumn.BinaryOperators.tt">
-            <Generator>TextTemplatingFileGenerator</Generator>
-            <LastGenOutput>DataFrameColumn.BinaryOperators.cs</LastGenOutput>
-        </None>
-        <None Update="DataFrameColumn.Computations.tt">
-            <Generator>TextTemplatingFileGenerator</Generator>
-            <LastGenOutput>DataFrameColumn.Computations.cs</LastGenOutput>
-        </None>
-        <None Update="DataFrame.BinaryOperations.tt">
-            <Generator>TextTemplatingFileGenerator</Generator>
-            <LastGenOutput>DataFrame.BinaryOperations.cs</LastGenOutput>
-        </None>
-        <None Update="DataFrame.BinaryOperators.tt">
-            <Generator>TextTemplatingFileGenerator</Generator>
-            <LastGenOutput>DataFrame.BinaryOperators.cs</LastGenOutput>
-        </None>
-        <None Update="DataFrameBinaryOperators.tt">
-            <Generator>TextTemplatingFileGenerator</Generator>
-            <LastGenOutput>DataFrameBinaryOperators.cs</LastGenOutput>
-        </None>
-        <None Update="PrimitiveDataFrameColumn.BinaryOperations.Combinations.tt">
-            <Generator>TextTemplatingFileGenerator</Generator>
-            <LastGenOutput>PrimitiveDataFrameColumn.BinaryOperations.Combinations.ttinclude</LastGenOutput>
-        </None>
-        <None Update="PrimitiveDataFrameColumn.BinaryOperations.Combinations.ttinclude">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>PrimitiveDataFrameColumn.BinaryOperations.Combinations.tt</DependentUpon>
-        </None>
-        <None Update="PrimitiveDataFrameColumn.BinaryOperations.tt">
-            <Generator>TextTemplatingFileGenerator</Generator>
-            <LastGenOutput>PrimitiveDataFrameColumn.BinaryOperations.cs</LastGenOutput>
-        </None>
-        <None Update="PrimitiveDataFrameColumn.BinaryOperators.tt">
-            <Generator>TextTemplatingFileGenerator</Generator>
-            <LastGenOutput>PrimitiveDataFrameColumn.BinaryOperators.cs</LastGenOutput>
-        </None>
-        <None Update="PrimitiveDataFrameColumn.Computations.tt">
-            <Generator>TextTemplatingFileGenerator</Generator>
-            <LastGenOutput>PrimitiveDataFrameColumn.Computations.cs</LastGenOutput>
-        </None>
-        <None Update="PrimitiveDataFrameColumn.ReversedBinaryOperations.tt">
-            <Generator>TextTemplatingFileGenerator</Generator>
-            <LastGenOutput>PrimitiveDataFrameColumn.ReversedBinaryOperations.cs</LastGenOutput>
-        </None>
-        <None Update="PrimitiveDataFrameColumnArithmetic.tt">
-            <Generator>TextTemplatingFileGenerator</Generator>
-            <LastGenOutput>PrimitiveColumnArithmetic.cs</LastGenOutput>
-        </None>
-        <None Update="PrimitiveDataFrameColumnComputations.tt">
-            <Generator>TextTemplatingFileGenerator</Generator>
-            <LastGenOutput>PrimitiveDataFrameColumnComputations.cs</LastGenOutput>
-        </None>
-        <None Update="PrimitiveColumnContainer.BinaryOperations.tt">
-            <Generator>TextTemplatingFileGenerator</Generator>
-            <LastGenOutput>PrimitiveColumnContainer.BinaryOperations.cs</LastGenOutput>
-        </None>
-        <None Update="PrimitiveDataFrameColumnArithmetic.tt">
-            <Generator>TextTemplatingFileGenerator</Generator>
-            <LastGenOutput>PrimitiveDataFrameColumnArithmetic.cs</LastGenOutput>
-        </None>
-        <None Update="PrimitiveColumnContainer.BinaryOperations.tt">
-            <Generator>TextTemplatingFileGenerator</Generator>
-            <LastGenOutput>PrimitiveColumnContainer.BinaryOperations.cs</LastGenOutput>
-        </None>
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.ML.DataView\Microsoft.ML.DataView.csproj" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
-    </ItemGroup>
+  <ItemGroup>
+    <None Update="Converters.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>Converters.cs</LastGenOutput>
+    </None>
+    <None Update="PrimitiveDataFrameColumn.BinaryOperationAPIs.ExplodedColumns.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>PrimitiveDataFrameColumn.BinaryOperationAPIs.ExplodedColumns.cs</LastGenOutput>
+    </None>
+    <None Update="PrimitiveDataFrameColumn.BinaryOperationImplementations.Exploded.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>PrimitiveDataFrameColumn.BinaryOperationImplementations.Exploded.cs</LastGenOutput>
+    </None>
+    <None Update="DataFrameColumn.BinaryOperations.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>DataFrameColumn.BinaryOperations.cs</LastGenOutput>
+    </None>
+    <None Update="DataFrameColumn.BinaryOperators.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>DataFrameColumn.BinaryOperators.cs</LastGenOutput>
+    </None>
+    <None Update="DataFrameColumn.Computations.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>DataFrameColumn.Computations.cs</LastGenOutput>
+    </None>
+    <None Update="DataFrame.BinaryOperations.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>DataFrame.BinaryOperations.cs</LastGenOutput>
+    </None>
+    <None Update="DataFrame.BinaryOperators.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>DataFrame.BinaryOperators.cs</LastGenOutput>
+    </None>
+    <None Update="DataFrameBinaryOperators.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>DataFrameBinaryOperators.cs</LastGenOutput>
+    </None>
+    <None Update="PrimitiveDataFrameColumn.BinaryOperations.Combinations.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>PrimitiveDataFrameColumn.BinaryOperations.Combinations.ttinclude</LastGenOutput>
+    </None>
+    <None Update="PrimitiveDataFrameColumn.BinaryOperations.Combinations.ttinclude">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>PrimitiveDataFrameColumn.BinaryOperations.Combinations.tt</DependentUpon>
+    </None>
+    <None Update="PrimitiveDataFrameColumn.BinaryOperations.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>PrimitiveDataFrameColumn.BinaryOperations.cs</LastGenOutput>
+    </None>
+    <None Update="PrimitiveDataFrameColumn.BinaryOperators.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>PrimitiveDataFrameColumn.BinaryOperators.cs</LastGenOutput>
+    </None>
+    <None Update="PrimitiveDataFrameColumn.Computations.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>PrimitiveDataFrameColumn.Computations.cs</LastGenOutput>
+    </None>
+    <None Update="PrimitiveDataFrameColumn.ReversedBinaryOperations.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>PrimitiveDataFrameColumn.ReversedBinaryOperations.cs</LastGenOutput>
+    </None>
+    <None Update="PrimitiveDataFrameColumnArithmetic.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>PrimitiveColumnArithmetic.cs</LastGenOutput>
+    </None>
+    <None Update="PrimitiveDataFrameColumnComputations.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>PrimitiveDataFrameColumnComputations.cs</LastGenOutput>
+    </None>
+    <None Update="PrimitiveColumnContainer.BinaryOperations.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>PrimitiveColumnContainer.BinaryOperations.cs</LastGenOutput>
+    </None>
+    <None Update="PrimitiveDataFrameColumnArithmetic.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>PrimitiveDataFrameColumnArithmetic.cs</LastGenOutput>
+    </None>
+    <None Update="PrimitiveColumnContainer.BinaryOperations.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>PrimitiveColumnContainer.BinaryOperations.cs</LastGenOutput>
+    </None>
+  </ItemGroup>
 
-    <ItemGroup>
-        <Compile Update="Converters.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>Converters.tt</DependentUpon>
-        </Compile>
-        <Compile Update="PrimitiveDataFrameColumn.BinaryOperationImplementations.Exploded.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>PrimitiveDataFrameColumn.BinaryOperationImplementations.Exploded.tt</DependentUpon>
-        </Compile>
-        <Compile Update="DataFrameColumn.BinaryOperations.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>DataFrameColumn.BinaryOperations.tt</DependentUpon>
-        </Compile>
-        <Compile Update="PrimitiveDataFrameColumn.BinaryOperationAPIs.ExplodedColumns.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>PrimitiveDataFrameColumn.BinaryOperationAPIs.ExplodedColumns.tt</DependentUpon>
-        </Compile>
-        <Compile Update="DataFrameColumn.BinaryOperators.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>DataFrameColumn.BinaryOperators.tt</DependentUpon>
-        </Compile>
-        <Compile Update="DataFrameColumn.Computations.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>DataFrameColumn.Computations.tt</DependentUpon>
-        </Compile>
-        <Compile Update="DataFrame.BinaryOperations.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>DataFrame.BinaryOperations.tt</DependentUpon>
-        </Compile>
-        <Compile Update="DataFrame.BinaryOperators.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>DataFrame.BinaryOperators.tt</DependentUpon>
-        </Compile>
-        <Compile Update="DataFrameBinaryOperators.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>DataFrameBinaryOperators.tt</DependentUpon>
-        </Compile>
-        <Compile Update="PrimitiveDataFrameColumn.BinaryOperations.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>PrimitiveDataFrameColumn.BinaryOperations.tt</DependentUpon>
-        </Compile>
-        <Compile Update="PrimitiveDataFrameColumn.BinaryOperators.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>PrimitiveDataFrameColumn.BinaryOperators.tt</DependentUpon>
-        </Compile>
-        <Compile Update="PrimitiveDataFrameColumn.Computations.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>PrimitiveDataFrameColumn.Computations.tt</DependentUpon>
-        </Compile>
-        <Compile Update="PrimitiveDataFrameColumn.ReversedBinaryOperations.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>PrimitiveDataFrameColumn.ReversedBinaryOperations.tt</DependentUpon>
-        </Compile>
-        <Compile Update="PrimitiveDataFrameColumnArithmetic.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>PrimitiveColumnArithmetic.tt</DependentUpon>
-        </Compile>
-        <Compile Update="PrimitiveDataFrameColumnComputations.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>PrimitiveDataFrameColumnComputations.tt</DependentUpon>
-        </Compile>
-        <Compile Update="PrimitiveColumnContainer.BinaryOperations.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>PrimitiveColumnContainer.BinaryOperations.tt</DependentUpon>
-        </Compile>
-        <Compile Update="PrimitiveDataFrameColumnArithmetic.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>PrimitiveDataFrameColumnArithmetic.tt</DependentUpon>
-        </Compile>
-        <Compile Update="PrimitiveColumnContainer.BinaryOperations.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>PrimitiveColumnContainer.BinaryOperations.tt</DependentUpon>
-        </Compile>
-        <Compile Update="Strings.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>Strings.resx</DependentUpon>
-        </Compile>
-    </ItemGroup>
+  <ItemGroup>
+    <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <EmbeddedResource Update="Strings.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>Strings.Designer.cs</LastGenOutput>
-            <CustomToolNamespace>Microsoft.Data</CustomToolNamespace>
-        </EmbeddedResource>
-    </ItemGroup>
+  <ItemGroup>
+    <Compile Update="Converters.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Converters.tt</DependentUpon>
+    </Compile>
+    <Compile Update="PrimitiveDataFrameColumn.BinaryOperationImplementations.Exploded.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>PrimitiveDataFrameColumn.BinaryOperationImplementations.Exploded.tt</DependentUpon>
+    </Compile>
+    <Compile Update="DataFrameColumn.BinaryOperations.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>DataFrameColumn.BinaryOperations.tt</DependentUpon>
+    </Compile>
+    <Compile Update="PrimitiveDataFrameColumn.BinaryOperationAPIs.ExplodedColumns.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>PrimitiveDataFrameColumn.BinaryOperationAPIs.ExplodedColumns.tt</DependentUpon>
+    </Compile>
+    <Compile Update="DataFrameColumn.BinaryOperators.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>DataFrameColumn.BinaryOperators.tt</DependentUpon>
+    </Compile>
+    <Compile Update="DataFrameColumn.Computations.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>DataFrameColumn.Computations.tt</DependentUpon>
+    </Compile>
+    <Compile Update="DataFrame.BinaryOperations.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>DataFrame.BinaryOperations.tt</DependentUpon>
+    </Compile>
+    <Compile Update="DataFrame.BinaryOperators.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>DataFrame.BinaryOperators.tt</DependentUpon>
+    </Compile>
+    <Compile Update="DataFrameBinaryOperators.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>DataFrameBinaryOperators.tt</DependentUpon>
+    </Compile>
+    <Compile Update="PrimitiveDataFrameColumn.BinaryOperations.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>PrimitiveDataFrameColumn.BinaryOperations.tt</DependentUpon>
+    </Compile>
+    <Compile Update="PrimitiveDataFrameColumn.BinaryOperators.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>PrimitiveDataFrameColumn.BinaryOperators.tt</DependentUpon>
+    </Compile>
+    <Compile Update="PrimitiveDataFrameColumn.Computations.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>PrimitiveDataFrameColumn.Computations.tt</DependentUpon>
+    </Compile>
+    <Compile Update="PrimitiveDataFrameColumn.ReversedBinaryOperations.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>PrimitiveDataFrameColumn.ReversedBinaryOperations.tt</DependentUpon>
+    </Compile>
+    <Compile Update="PrimitiveDataFrameColumnArithmetic.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>PrimitiveColumnArithmetic.tt</DependentUpon>
+    </Compile>
+    <Compile Update="PrimitiveDataFrameColumnComputations.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>PrimitiveDataFrameColumnComputations.tt</DependentUpon>
+    </Compile>
+    <Compile Update="PrimitiveColumnContainer.BinaryOperations.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>PrimitiveColumnContainer.BinaryOperations.tt</DependentUpon>
+    </Compile>
+    <Compile Update="PrimitiveDataFrameColumnArithmetic.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>PrimitiveDataFrameColumnArithmetic.tt</DependentUpon>
+    </Compile>
+    <Compile Update="PrimitiveColumnContainer.BinaryOperations.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>PrimitiveColumnContainer.BinaryOperations.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Strings.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Strings.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Update="Strings.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Strings.Designer.cs</LastGenOutput>
+      <CustomToolNamespace>Microsoft.Data</CustomToolNamespace>
+    </EmbeddedResource>
+  </ItemGroup>
 </Project>

--- a/test/Microsoft.Data.Analysis.Interactive.Tests/DataFrameInteractiveTests.cs
+++ b/test/Microsoft.Data.Analysis.Interactive.Tests/DataFrameInteractiveTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Data.Analysis.Interactive.Tests
     public partial class DataFrameInteractiveTests
     {
         private const string BUTTON_HTML_PART = "button onclick";
-        private const string TABLE_HTML_PART = "";
+        private const string TABLE_HTML_PART = "<table";
 
         public static DataFrame MakeDataFrameWithTwoColumns(int length, bool withNulls = true)
         {
@@ -29,7 +29,7 @@ namespace Microsoft.Data.Analysis.Interactive.Tests
         }
 
         [Fact]
-        public void LessThanTenRowsDataFrameTest()
+        public void LessThanOnePageDataFrameTest()
         {
             DataFrame dataFrame = MakeDataFrameWithTwoColumns(length: 5);
             DataFrameKernelExtension.RegisterDataFrame();
@@ -40,9 +40,9 @@ namespace Microsoft.Data.Analysis.Interactive.Tests
         }
 
         [Fact]
-        public void MoreThanTenRowsDataFrameTest()
+        public void MoreThanOnePageDataFrameTest()
         {
-            DataFrame dataFrame = MakeDataFrameWithTwoColumns(length: 21);
+            DataFrame dataFrame = MakeDataFrameWithTwoColumns(length: 26);
             DataFrameKernelExtension.RegisterDataFrame();
             var html = dataFrame.ToDisplayString("text/html");
 

--- a/test/Microsoft.Data.Analysis.Interactive.Tests/DataFrameInteractiveTests.cs
+++ b/test/Microsoft.Data.Analysis.Interactive.Tests/DataFrameInteractiveTests.cs
@@ -8,10 +8,10 @@ using Microsoft.DotNet.Interactive.Formatting;
 
 namespace Microsoft.Data.Analysis.Interactive.Tests
 {
-    public partial class DataFrameInteractiveTests
+    public class DataFrameInteractiveTests
     {
-        private const string BUTTON_HTML_PART = "button onclick";
-        private const string TABLE_HTML_PART = "<table";
+        private const string ButtonHtmlPart = "button onclick";
+        private const string TableHtmlPart = "<table";
 
         public static DataFrame MakeDataFrameWithTwoColumns(int length, bool withNulls = true)
         {
@@ -35,8 +35,8 @@ namespace Microsoft.Data.Analysis.Interactive.Tests
             DataFrameKernelExtension.RegisterDataFrame();
             var html = dataFrame.ToDisplayString("text/html");
 
-            Assert.Contains(TABLE_HTML_PART, html);
-            Assert.DoesNotContain(BUTTON_HTML_PART, html);
+            Assert.Contains(TableHtmlPart, html);
+            Assert.DoesNotContain(ButtonHtmlPart, html);
         }
 
         [Fact]
@@ -46,8 +46,8 @@ namespace Microsoft.Data.Analysis.Interactive.Tests
             DataFrameKernelExtension.RegisterDataFrame();
             var html = dataFrame.ToDisplayString("text/html");
 
-            Assert.Contains(TABLE_HTML_PART, html);
-            Assert.Contains(BUTTON_HTML_PART, html);
+            Assert.Contains(TableHtmlPart, html);
+            Assert.Contains(ButtonHtmlPart, html);
         }
 
         [Fact]
@@ -57,8 +57,8 @@ namespace Microsoft.Data.Analysis.Interactive.Tests
             DataFrameKernelExtension.RegisterDataFrame();
             var html = dataFrame.Info().ToDisplayString("text/html");
 
-            Assert.Contains(TABLE_HTML_PART, html);
-            Assert.DoesNotContain(BUTTON_HTML_PART, html);
+            Assert.Contains(TableHtmlPart, html);
+            Assert.DoesNotContain(ButtonHtmlPart, html);
         }
     }
 }

--- a/test/Microsoft.Data.Analysis.Interactive.Tests/Microsoft.Data.Analysis.Interactive.Tests.csproj
+++ b/test/Microsoft.Data.Analysis.Interactive.Tests/Microsoft.Data.Analysis.Interactive.Tests.csproj
@@ -1,15 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
-        <NoWarn>$(NoWarn);MSML_PrivateFieldName;MSML_ExtendBaseTestClass</NoWarn>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <NoWarn>$(NoWarn);MSML_ExtendBaseTestClass</NoWarn>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\..\src\Microsoft.Data.Analysis.Interactive\Microsoft.Data.Analysis.Interactive.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.Data.Analysis.Interactive\Microsoft.Data.Analysis.Interactive.csproj" />
 
-    <!-- register for test discovery in Visual Studio -->
-    <ItemGroup>
-        <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-    </ItemGroup>
+    <!-- work around https://github.com/dotnet/runtime/issues/45560 until System.Text.Json is fixed and Microsoft.DotNet.Interactive updates to the new version -->
+    <PackageReference Include=" System.Text.Encodings.Web" Version="5.0.1" />
+  </ItemGroup>
+
+  <!-- register for test discovery in Visual Studio -->
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
This allows the DataFrame extension to work with the latest .NET Interactive.

I also needed to change the DataFrame .csproj so it gets packed by including the right Pack.props file. 

Added an .editorconfig entry so .csproj files are uniform in their spacing.

The only meaningful code change is the rows per page going from 10 to 25. 10 is just too small IMO.

