### PR TITLE
Use Official package for SharpZipLib

### DIFF
--- a/src/Microsoft.ML.SamplesUtils/Microsoft.ML.SamplesUtils.csproj
+++ b/src/Microsoft.ML.SamplesUtils/Microsoft.ML.SamplesUtils.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SharpZipLib.NETStandard" Version="1.0.7" />
+    <PackageReference Include="SharpZipLib" Version="1.3.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
In reviewing our package usage in ML.NET I found we were using [SharpZipLib.NETStandard](https://www.nuget.org/packages/SharpZipLib.NETStandard/), a [fork](https://github.com/PingmanTools/SharpZipLib) of [SharpZipLib](https://www.nuget.org/packages/SharpZipLib/) rather than the official release.  The fork added a `netstandard1.3`  target (presumably not supported at the time the fork was created) but the latest SharpZipLib supports netstandard2.0 and did [at the time](https://github.com/dotnet/machinelearning/pull/3249) this dependency was added.

This package is used only in samples, but we should still use the official release and not a fork.  Looking at how this works, we don't even use this assembly in the project that references it, but do in https://github.com/dotnet/machinelearning/blob/main/docs/samples/Microsoft.ML.Samples/Microsoft.ML.Samples.csproj.  I'm assuming that's intentional and done so that folks can copy-paste our samples and only reference a single package, but if that's not intentional we could clean things up by moving this dependency to Microsoft.ML.Samples.csproj which doesn't produce a package.