### PR TITLE
Fix erroneous use of TaskContinuationOptions in ThreadUtils.cs

### DIFF
--- a/src/Microsoft.ML.Core/Utilities/ThreadUtils.cs
+++ b/src/Microsoft.ML.Core/Utilities/ThreadUtils.cs
@@ -58,7 +58,7 @@ namespace Microsoft.ML.Internal.Utilities
                 // Call sites only care about completion, not about the distinction between
                 // success and failure and do not expect exceptions to be propagated in this manner,
                 // so only SetResult is used.
-                var tcs = new TaskCompletionSource<bool>(TaskContinuationOptions.RunContinuationsAsynchronously);
+                var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
                 // Queue the work for a thread to pick up. If no thread is immediately available, it will create one.
                 Enqueue((threadStart, state, tcs));


### PR DESCRIPTION
This was supposed to be TaskCreationOptions.  TaskContinuationOptions here will end up binding to the wrong ctor, and won't actually have the desired effect, which is to avoid blocking the thread completing this TCS.

Thanks @sharwell for flagging it with CA2247.