### PR TITLE
OS X libomp CI fix.

### DIFF
--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -63,8 +63,9 @@ jobs:
         continueOnError: true
     # Extra MacOS step required to install OS-specific dependencies
     - ${{ if eq(parameters.pool.name, 'Hosted macOS') }}:
-      - script: brew update && brew install mono-libgdiplus && brew install libomp && brew link libomp --force
+      - script: brew update && brew install mono-libgdiplus && brew install $(Build.SourcesDirectory)/build/libomp.rb --build-from-source && brew link libomp --force
         displayName: Install MacOS build dependencies
+        continueOnError: true
     - ${{ if and( eq(parameters.nightlyBuild, 'true'), eq(parameters.pool.name, 'Hosted Ubuntu 1604')) }}:
       - bash: echo "##vso[task.setvariable variable=LD_LIBRARY_PATH]$(nightlyBuildRunPath):$LD_LIBRARY_PATH"
         displayName: Set LD_LIBRARY_PATH for Ubuntu and CentOS to locate Native shared library in current running path

--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -63,7 +63,7 @@ jobs:
         continueOnError: true
     # Extra MacOS step required to install OS-specific dependencies
     - ${{ if eq(parameters.pool.name, 'Hosted macOS') }}:
-      - script: brew update && brew install mono-libgdiplus && brew install $(Build.SourcesDirectory)/build/libomp.rb && brew link libomp --force
+      - script: brew update && brew install mono-libgdiplus && brew install libomp && brew link libomp --force
         displayName: Install MacOS build dependencies
     - ${{ if and( eq(parameters.nightlyBuild, 'true'), eq(parameters.pool.name, 'Hosted Ubuntu 1604')) }}:
       - bash: echo "##vso[task.setvariable variable=LD_LIBRARY_PATH]$(nightlyBuildRunPath):$LD_LIBRARY_PATH"

--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -63,9 +63,8 @@ jobs:
         continueOnError: true
     # Extra MacOS step required to install OS-specific dependencies
     - ${{ if eq(parameters.pool.name, 'Hosted macOS') }}:
-      - script: brew update && brew install mono-libgdiplus && brew install $(Build.SourcesDirectory)/build/libomp.rb --build-from-source && brew link libomp --force
+      - script: brew update && brew install mono-libgdiplus && brew install $(Build.SourcesDirectory)/build/libomp.rb --build-from-source --formula && brew link libomp --force
         displayName: Install MacOS build dependencies
-        continueOnError: true
     - ${{ if and( eq(parameters.nightlyBuild, 'true'), eq(parameters.pool.name, 'Hosted Ubuntu 1604')) }}:
       - bash: echo "##vso[task.setvariable variable=LD_LIBRARY_PATH]$(nightlyBuildRunPath):$LD_LIBRARY_PATH"
         displayName: Set LD_LIBRARY_PATH for Ubuntu and CentOS to locate Native shared library in current running path

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -55,8 +55,9 @@ phases:
       rm -rf /usr/local/bin/2to3
     displayName: MacOS Homebrew bug Workaround
     continueOnError: true
-  - script: brew update && brew unlink python@3.8 && brew install mono-libgdiplus && brew install libomp. && brew link libomp --force
+  - script: brew update && brew unlink python@3.8 && brew install mono-libgdiplus && brew install $(Build.SourcesDirectory)/build/libomp.rb --build-from-source && brew link libomp --force
     displayName: Install build dependencies
+    continueOnError: true
   - script: ./restore.sh
     displayName: restore all projects
   - script: ./build.sh -configuration $(BuildConfig) /p:CopyPackageAssets=true /p:SkipRIDAgnosticAssets=true -projects $(Build.SourcesDirectory)/src/Redist/Microsoft.ML.DnnImageFeaturizer.ModelRedist/Microsoft.ML.DnnImageFeaturizer.ModelRedist.proj

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -55,7 +55,7 @@ phases:
       rm -rf /usr/local/bin/2to3
     displayName: MacOS Homebrew bug Workaround
     continueOnError: true
-  - script: brew update && brew unlink python@3.8 && brew install mono-libgdiplus && brew install $(Build.SourcesDirectory)/build/libomp.rb && brew link libomp --force
+  - script: brew update && brew unlink python@3.8 && brew install mono-libgdiplus && brew install libomp. && brew link libomp --force
     displayName: Install build dependencies
   - script: ./restore.sh
     displayName: restore all projects

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -55,9 +55,8 @@ phases:
       rm -rf /usr/local/bin/2to3
     displayName: MacOS Homebrew bug Workaround
     continueOnError: true
-  - script: brew update && brew unlink python@3.8 && brew install mono-libgdiplus && brew install $(Build.SourcesDirectory)/build/libomp.rb --build-from-source && brew link libomp --force
+  - script: brew update && brew unlink python@3.8 && brew install mono-libgdiplus && brew install $(Build.SourcesDirectory)/build/libomp.rb --build-from-source --formula && brew link libomp --force
     displayName: Install build dependencies
-    continueOnError: true
   - script: ./restore.sh
     displayName: restore all projects
   - script: ./build.sh -configuration $(BuildConfig) /p:CopyPackageAssets=true /p:SkipRIDAgnosticAssets=true -projects $(Build.SourcesDirectory)/src/Redist/Microsoft.ML.DnnImageFeaturizer.ModelRedist/Microsoft.ML.DnnImageFeaturizer.ModelRedist.proj

--- a/docs/building/unix-instructions.md
+++ b/docs/building/unix-instructions.md
@@ -56,3 +56,5 @@ $ brew update && brew install cmake https://raw.githubusercontent.com/dotnet/mac
 ```
 
 Please note that newer versions of Homebrew [don't allow installing directly from a URL](https://github.com/Homebrew/brew/issues/8791). If you run into this issue, you may need to download libomp.rb first and install it with the local file instead.
+
+Also, libomp version 7.0.0 doesn't have a cask for Big Sur. You can work around this by downloading the libomp.rb file and then calling `brew install libomp.rb --build-from-source --formula`.


### PR DESCRIPTION
Fixed the CI issue with libomp.

The issue is that version 7 of libomp doesn't have a bottle for Big Sur. The build machines must have just upgraded to it. If I tell it to build from source it is able to successfully build version 7, and when the tests run they are able to find the intel mkl library as well as pass all the tests. Version 7 of libomp seems to be linked with intel mkl somehow and thats why we need to keep using version 7.0.0 for now.