### PR TITLE
Improvements to the Merge routine

### DIFF
--- a/src/Microsoft.Data.Analysis/ArrowStringDataFrameColumn.cs
+++ b/src/Microsoft.Data.Analysis/ArrowStringDataFrameColumn.cs
@@ -460,34 +460,42 @@ namespace Microsoft.Data.Analysis
         /// <inheritdoc/>
         public override DataFrame ValueCounts()
         {
-            Dictionary<string, ICollection<long>> groupedValues = GroupColumnValues<string>();
+            Dictionary<string, ICollection<long>> groupedValues = GroupColumnValues<string>(out HashSet<long> _);
             return StringDataFrameColumn.ValueCountsImplementation(groupedValues);
         }
 
         /// <inheritdoc/>
         public override GroupBy GroupBy(int columnIndex, DataFrame parent)
         {
-            Dictionary<string, ICollection<long>> dictionary = GroupColumnValues<string>();
+            Dictionary<string, ICollection<long>> dictionary = GroupColumnValues<string>(out HashSet<long> _);
             return new GroupBy<string>(parent, columnIndex, dictionary);
         }
 
         /// <inheritdoc/>
-        public override Dictionary<TKey, ICollection<long>> GroupColumnValues<TKey>()
+        public override Dictionary<TKey, ICollection<long>> GroupColumnValues<TKey>(out HashSet<long> nullIndices)
         {
             if (typeof(TKey) == typeof(string))
             {
+                nullIndices = new HashSet<long>();
                 Dictionary<string, ICollection<long>> multimap = new Dictionary<string, ICollection<long>>(EqualityComparer<string>.Default);
                 for (long i = 0; i < Length; i++)
                 {
-                    string str = this[i] ?? "__null__";
-                    bool containsKey = multimap.TryGetValue(str, out ICollection<long> values);
-                    if (containsKey)
+                    string str = this[i];
+                    if (str != null)
                     {
-                        values.Add(i);
+                        bool containsKey = multimap.TryGetValue(str, out ICollection<long> values);
+                        if (containsKey)
+                        {
+                            values.Add(i);
+                        }
+                        else
+                        {
+                            multimap.Add(str, new List<long>() { i });
+                        }
                     }
                     else
                     {
-                        multimap.Add(str, new List<long>() { i });
+                        nullIndices.Add(i);
                     }
                 }
                 return multimap as Dictionary<TKey, ICollection<long>>;
@@ -499,7 +507,7 @@ namespace Microsoft.Data.Analysis
         }
 
         /// <inheritdoc/>
-        public ArrowStringDataFrameColumn FillNulls(string value, bool inPlace = false) 
+        public ArrowStringDataFrameColumn FillNulls(string value, bool inPlace = false)
         {
             if (value == null)
             {

--- a/src/Microsoft.Data.Analysis/DataFrame.Join.cs
+++ b/src/Microsoft.Data.Analysis/DataFrame.Join.cs
@@ -345,37 +345,6 @@ namespace Microsoft.Data.Analysis
                         rightRowIndices.Append(otherColumnNullIndex);
                     }
                 }
-
-                //// Now handle the null rows
-                //IEnumerator<long?> thisColumnNullIndicesEnumerator = thisColumnNullIndices.GetEnumerator();
-                //HashSet<long>.Enumerator otherColumnNullIndicesEnumerator = otherColumnNullIndices.GetEnumerator();
-                //while (thisColumnNullIndicesEnumerator.MoveNext() && otherColumnNullIndicesEnumerator.MoveNext())
-                //{
-                //    long? thisColumnNullIndex = thisColumnNullIndicesEnumerator.Current;
-                //    long otherColumnNullIndex = otherColumnNullIndicesEnumerator.Current;
-                //    leftRowIndices.Append(thisColumnNullIndex);
-                //    rightRowIndices.Append(otherColumnNullIndex);
-                //}
-                //while (!otherColumnNullIndicesEnumerator.MoveNext())
-                //{
-                //    long? thisColumnNullIndex = thisColumnNullIndicesEnumerator.Current;
-                //    leftRowIndices.Append(thisColumnNullIndex);
-                //    rightRowIndices.Append(null);
-                //    if (!thisColumnNullIndicesEnumerator.MoveNext())
-                //    {
-                //        break;
-                //    }
-                //}
-                //while (!thisColumnNullIndicesEnumerator.MoveNext())
-                //{
-                //    long otherColumnNullIndex = otherColumnNullIndicesEnumerator.Current;
-                //    leftRowIndices.Append(null);
-                //    rightRowIndices.Append(otherColumnNullIndex);
-                //    if (!otherColumnNullIndicesEnumerator.MoveNext())
-                //    {
-                //        break;
-                //    }
-                //}
             }
             else
                 throw new NotImplementedException(nameof(joinAlgorithm));

--- a/src/Microsoft.Data.Analysis/DataFrameColumn.cs
+++ b/src/Microsoft.Data.Analysis/DataFrameColumn.cs
@@ -203,7 +203,12 @@ namespace Microsoft.Data.Analysis
             return Clone(sortIndices, !ascending, NullCount);
         }
 
-        public virtual Dictionary<TKey, ICollection<long>> GroupColumnValues<TKey>() => throw new NotImplementedException();
+        /// <summary>
+        /// Groups the rows of this column by their value.
+        /// </summary>
+        /// <typeparam name="TKey">The type of data held by this column</typeparam>
+        /// <returns>A mapping of value(<typeparamref name="TKey"/>) to the indices containing this value</returns>
+        public virtual Dictionary<TKey, ICollection<long>> GroupColumnValues<TKey>(out HashSet<long> nullIndices) => throw new NotImplementedException();
 
         /// <summary>
         /// Returns a DataFrame containing counts of unique values

--- a/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.cs
+++ b/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.cs
@@ -313,7 +313,7 @@ namespace Microsoft.Data.Analysis
 
         public override DataFrame ValueCounts()
         {
-            Dictionary<T, ICollection<long>> groupedValues = GroupColumnValues<T>();
+            Dictionary<T, ICollection<long>> groupedValues = GroupColumnValues<T>(out HashSet<long> _);
             PrimitiveDataFrameColumn<T> keys = new PrimitiveDataFrameColumn<T>("Values");
             PrimitiveDataFrameColumn<long> counts = new PrimitiveDataFrameColumn<long>("Counts");
             foreach (KeyValuePair<T, ICollection<long>> keyValuePair in groupedValues)
@@ -520,32 +520,41 @@ namespace Microsoft.Data.Analysis
         /// <inheritdoc/>
         public override GroupBy GroupBy(int columnIndex, DataFrame parent)
         {
-            Dictionary<T, ICollection<long>> dictionary = GroupColumnValues<T>();
+            Dictionary<T, ICollection<long>> dictionary = GroupColumnValues<T>(out HashSet<long> _);
             return new GroupBy<T>(parent, columnIndex, dictionary);
         }
 
-        public override Dictionary<TKey, ICollection<long>> GroupColumnValues<TKey>()
+        public override Dictionary<TKey, ICollection<long>> GroupColumnValues<TKey>(out HashSet<long> nullIndices)
         {
             if (typeof(TKey) == typeof(T))
             {
                 Dictionary<T, ICollection<long>> multimap = new Dictionary<T, ICollection<long>>(EqualityComparer<T>.Default);
+                nullIndices = new HashSet<long>();
                 for (int b = 0; b < _columnContainer.Buffers.Count; b++)
                 {
                     ReadOnlyDataFrameBuffer<T> buffer = _columnContainer.Buffers[b];
                     ReadOnlySpan<T> readOnlySpan = buffer.ReadOnlySpan;
+                    ReadOnlySpan<byte> nullBitMapSpan = _columnContainer.NullBitMapBuffers[b].ReadOnlySpan;
                     long previousLength = b * ReadOnlyDataFrameBuffer<T>.MaxCapacity;
                     for (int i = 0; i < readOnlySpan.Length; i++)
                     {
                         long currentLength = i + previousLength;
-                        bool containsKey = multimap.TryGetValue(readOnlySpan[i], out ICollection<long> values);
-                        if (containsKey)
+                        if (_columnContainer.IsValid(nullBitMapSpan, i))
                         {
-                            values.Add(currentLength);
+                            bool containsKey = multimap.TryGetValue(readOnlySpan[i], out ICollection<long> values);
+                            if (containsKey)
+                            {
+                                values.Add(currentLength);
+                            }
+                            else
+                            {
+                                multimap.Add(readOnlySpan[i], new List<long>() { currentLength });
+                            }
                         }
                         else
                         {
-                            multimap.Add(readOnlySpan[i], new List<long>() { currentLength });
-                        }
+                            nullIndices.Add(currentLength);
+                        }    
                     }
                 }
                 return multimap as Dictionary<TKey, ICollection<long>>;

--- a/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.cs
+++ b/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.cs
@@ -554,7 +554,7 @@ namespace Microsoft.Data.Analysis
                         else
                         {
                             nullIndices.Add(currentLength);
-                        }    
+                        }
                     }
                 }
                 return multimap as Dictionary<TKey, ICollection<long>>;

--- a/src/Microsoft.Data.Analysis/StringDataFrameColumn.cs
+++ b/src/Microsoft.Data.Analysis/StringDataFrameColumn.cs
@@ -419,14 +419,14 @@ namespace Microsoft.Data.Analysis
                     string str = this[i];
                     if (str != null)
                     {
-                        bool containsKey = multimap.TryGetValue(this[i], out ICollection<long> values);
+                        bool containsKey = multimap.TryGetValue(str, out ICollection<long> values);
                         if (containsKey)
                         {
                             values.Add(i);
                         }
                         else
                         {
-                            multimap.Add(this[i] ?? default, new List<long>() { i });
+                            multimap.Add(str, new List<long>() { i });
                         }
                     }
                     else

--- a/test/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
+++ b/test/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
@@ -1700,7 +1700,7 @@ namespace Microsoft.Data.Analysis.Tests
         [Theory]
         [InlineData(10, 5, JoinAlgorithm.Left)]
         [InlineData(5, 10, JoinAlgorithm.Right)]
-        public void TestMergeEdgeCases_Left(int leftLength, int rightLength, JoinAlgorithm joinAlgorithm)
+        public void TestMergeEdgeCases_LeftOrRight(int leftLength, int rightLength, JoinAlgorithm joinAlgorithm)
         {
             DataFrame left = MakeDataFrameWithAllMutableColumnTypes(leftLength);
             if (leftLength > 5)
@@ -1851,6 +1851,21 @@ namespace Microsoft.Data.Analysis.Tests
                 int rightRowIndex = rightRows[i];
                 MatchRowsOnMergedDataFrame(merge, left, right, rowIndex, null, rightRowIndex);
             }
+        }
+
+        [Fact]
+        public void TestMerge_Issue5778()
+        {
+            DataFrame left = MakeDataFrameWithAllMutableColumnTypes(2, false);
+            DataFrame right = MakeDataFrameWithAllMutableColumnTypes(1);
+
+            DataFrame merge = left.Merge<int>(right, "Int", "Int");
+
+            Assert.Equal(2, merge.Rows.Count);
+            Assert.Equal(0, (int)merge.Columns["Int_left"][0]);
+            Assert.Equal(1, (int)merge.Columns["Int_left"][1]);
+            MatchRowsOnMergedDataFrame(merge, left, right, 0, 0, 0);
+            MatchRowsOnMergedDataFrame(merge, left, right, 1, 1, 0);
         }
 
         [Fact]


### PR DESCRIPTION
Currently, we don't differentiate between `null` values and `default` values in columns. As a result, these values are considered equivalent in the `Merge` routine. This PR fixes that by handling them separately. Also added unit tests so we don't regress in the future.

Fixes https://github.com/dotnet/machinelearning/issues/5765 and contributes to https://github.com/dotnet/machinelearning/issues/5691

