### PR TITLE
Bug fix: Saving problem with TF2 SavedModel fmt in TensorflowTransform class.

### DIFF
--- a/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
@@ -463,32 +463,32 @@ namespace Microsoft.ML.Transforms
                 }
             }
             else {
-               ctx.SaveBinaryStream("TFSavedModel", w =>
-               {
-                   // only these files need to be saved.
-                   var modelFilePaths = new List<string>
-                   {
-                       Path.Combine(_savedModelPath, DefaultModelFileNames.Graph),
-                       Path.Combine(_savedModelPath, DefaultModelFileNames.VariablesFolder, DefaultModelFileNames.Index)
-                   };
-                   modelFilePaths.AddRange(Directory.GetFiles(Path.Combine(_savedModelPath, DefaultModelFileNames.VariablesFolder), DefaultModelFileNames.Data, SearchOption.TopDirectoryOnly));
+                ctx.SaveBinaryStream("TFSavedModel", w =>
+                {
+                    // only these files need to be saved.
+                    var modelFilePaths = new List<string>
+                    {
+                        Path.Combine(_savedModelPath, DefaultModelFileNames.Graph),
+                        Path.Combine(_savedModelPath, DefaultModelFileNames.VariablesFolder, DefaultModelFileNames.Index)
+                    };
+                    modelFilePaths.AddRange(Directory.GetFiles(Path.Combine(_savedModelPath, DefaultModelFileNames.VariablesFolder), DefaultModelFileNames.Data, SearchOption.TopDirectoryOnly));
 
-                   w.Write(modelFilePaths.Count);
+                    w.Write(modelFilePaths.Count);
 
-                   foreach (var fullPath in modelFilePaths)
-                   {
-                       var relativePath = fullPath.Substring(_savedModelPath.Length + 1);
-                       w.Write(relativePath);
+                    foreach (var fullPath in modelFilePaths)
+                    {
+                        var relativePath = fullPath.Substring(_savedModelPath.Length + 1);
+                        w.Write(relativePath);
 
-                       using (var fs = new FileStream(fullPath, FileMode.Open))
-                       {
-                           long fileLength = fs.Length;
-                           w.Write(fileLength);
-                           long actualWritten = fs.CopyRange(w.BaseStream, fileLength);
-                           Host.Assert(actualWritten == fileLength);
-                       }
-                   }
-               });
+                        using (var fs = new FileStream(fullPath, FileMode.Open))
+                        {
+                            long fileLength = fs.Length;
+                            w.Write(fileLength);
+                            long actualWritten = fs.CopyRange(w.BaseStream, fileLength);
+                            Host.Assert(actualWritten == fileLength);
+                        }
+                    }
+                });
             }
 
             Host.AssertNonEmpty(Inputs);


### PR DESCRIPTION
The SaveModel function of the TensorflowTransform class didn't save the TensorFlow saved_model directory in the zip repo. It was just done for frozen graphs but missing for the SavedModel format.

I followed the schema that you used for the DnnRetrainTransform class to fix it:

https://github.com/dotnet/machinelearning/blob/43c49f6ce4370cf91dcd7bf302d82f30d798420c/src/Microsoft.ML.Vision/DnnRetrainTransform.cs#L68-L75
and https://github.com/dotnet/machinelearning/blob/43c49f6ce4370cf91dcd7bf302d82f30d798420c/src/Microsoft.ML.Vision/DnnRetrainTransform.cs#L701-L726.

The same part was not present in the TensorflowTransform class. Just the frozen graph saving:

https://github.com/dotnet/machinelearning/blob/43c49f6ce4370cf91dcd7bf302d82f30d798420c/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs#L425-L467.

It leads to an incomplete zip repo that cannot be reloaded after.

After this fix the zip repo can be saved and loaded for inference.
![Inference2](https://user-images.githubusercontent.com/9255497/118483542-6b29d800-b716-11eb-8634-9331c2d12756.png)
[saved_model.pb.zip](https://github.com/dotnet/machinelearning/files/6493522/saved_model.pb.zip)

