### PR TITLE
Speed-up bitmap operations on images. Fixes #5856

### DIFF
--- a/src/Microsoft.ML.ImageAnalytics/VectorToImageTransform.cs
+++ b/src/Microsoft.ML.ImageAnalytics/VectorToImageTransform.cs
@@ -375,7 +375,7 @@ namespace Microsoft.ML.Transforms.Image
                         BitmapData bmpData = null;
                         try
                         {
-                            bmpData = dst.LockBits(new Rectangle(0, 0, dst.Width, dst.Height), ImageLockMode.ReadOnly, dst.PixelFormat);
+                            bmpData = dst.LockBits(new Rectangle(0, 0, dst.Width, dst.Height), ImageLockMode.WriteOnly, dst.PixelFormat);
                             for (int y = 0; y < height; ++y)
                             {
                                 byte[] row = new byte[bmpData.Stride];


### PR DESCRIPTION
Speed-up operations using raw access instead of very slow functions GetPixel and SetPixel.
Associated issue: #5856 

I made this changes to make more fast the operations on the images, as explained in the issue #5856.
My approach is substituting all the very slow GetPixel and SetPixel functions with a raw access to the images data.

My test code is this:
```C#
[TensorFlowFact]
public void TensorFlowTransformObjectDetectionTest()
{
    // Saved model
    var modelLocation = @"D:\ObjectDetection\carp\TensorFlow\exported-model-SSD-MobileNET-v2-320x320\saved_model";
    // Create the estimators pipe
    var pipe = 
        _mlContext.Transforms.LoadImages(
            inputColumnName: "ImagePath",
            outputColumnName: "Image",
            imageFolder: "")
        .Append(_mlContext.Transforms.ResizeImages(
            inputColumnName: "Image",
            outputColumnName: "ResizedImage",
            imageWidth: 300,
            imageHeight: 300,
            resizing: ImageResizingEstimator.ResizingKind.Fill))
        .Append(_mlContext.Transforms.ExtractPixels(
            inputColumnName: "ResizedImage",
            outputColumnName: "serving_default_input_tensor:0",
            interleavePixelColors: true,
            outputAsFloatArray: false))
        .Append(_mlContext.Model.LoadTensorFlowModel(modelLocation).ScoreTensorFlowModel(
            inputColumnNames: new[] { "serving_default_input_tensor:0" },
            outputColumnNames: new[]
            {
                "StatefulPartitionedCall:1" /* detection_boxes */,
                "StatefulPartitionedCall:2" /* detection_classes */,
                "StatefulPartitionedCall:4" /* detection_scores */
            }));

    // Collect all the path of the images in the test directory
    var imagesLocation = @"D:\ObjectDetection\carp\TensorFlow\images\test";
    var images =
        Directory.GetFiles(imagesLocation).Where(file => new[] { ".jpg", ".jfif" }
        .Any(ext => Path.GetExtension(file).ToLower() == ext))
        .Select(file => new { ImagePath = file })
        .ToArray();

    // Create the transformer
    var data = _mlContext.Data.LoadFromEnumerable(images.Take(0));
    var model = pipe.Fit(data);

    // Test n times the inference on the collected images
    for (int i = 0, nImage = 0; i < 1000; i++, nImage = (nImage + 1) % images.Length)
        model.Transform(_mlContext.Data.LoadFromEnumerable(new[] { images[nImage] })).Preview();
}
```

but unluckily I cannot insert in the commit because it access to my local data (model and images).

The result of this changes is the improvement of speed dealing with images as described in my issue #5856.
If they are associated with my other PR #5848 / Issue #5847 they can improve the all the TF object detection system by ~396% (of course, measured on my device; it could be less or more in other devices).

### Without optimizations (current)
![WithoutOptimization](https://user-images.githubusercontent.com/9255497/122921241-8c5b9500-d362-11eb-85ff-81e2e367c561.png)

### With only image raw access optimization (Issue #5856 / PR #5857)
![WithRawAccessOptimization](https://user-images.githubusercontent.com/9255497/122921468-d04e9a00-d362-11eb-930d-d71ff2e73f31.png)

### With TensorFlow and image raw access optimization (Issue #5847 / PR #5848 and Issue #5856 / PR #5857)
![FullOptimization](https://user-images.githubusercontent.com/9255497/122921701-1572cc00-d363-11eb-99ea-753fe771d8dd.png)

