### PR TITLE
New version of Intel MKL.

### DIFF
--- a/docs/building/MlNetMklDeps/MlNetMklDeps.nuspec
+++ b/docs/building/MlNetMklDeps/MlNetMklDeps.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd">
   <metadata>
     <id>MlNetMklDeps</id>
-    <version>0.0.0.11</version>
+    <version>0.0.0.12</version>
     <title>This NuGet package provides Intel(R) MKL dependencies for ML.NET</title>
     <authors>Intel Corporation</authors>
     <owners>Microsoft</owners>

--- a/docs/building/MlNetMklDeps/MlNetMklDeps.nuspec
+++ b/docs/building/MlNetMklDeps/MlNetMklDeps.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd">
   <metadata>
     <id>MlNetMklDeps</id>
-    <version>0.0.0.10</version>
+    <version>0.0.0.11</version>
     <title>This NuGet package provides Intel(R) MKL dependencies for ML.NET</title>
     <authors>Intel Corporation</authors>
     <owners>Microsoft</owners>

--- a/docs/building/MlNetMklDeps/MlNetMklDeps.nuspec
+++ b/docs/building/MlNetMklDeps/MlNetMklDeps.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd">
   <metadata>
     <id>MlNetMklDeps</id>
-    <version>0.0.0.9</version>
+    <version>0.0.0.10</version>
     <title>This NuGet package provides Intel(R) MKL dependencies for ML.NET</title>
     <authors>Intel Corporation</authors>
     <owners>Microsoft</owners>

--- a/docs/building/MlNetMklDeps/version.md
+++ b/docs/building/MlNetMklDeps/version.md
@@ -14,3 +14,6 @@ mkl 2019 Update 2
 mac:2019.2.187
 linux:2019.2.187
 windows:2019.2.187
+
+#Intel MKl SDK versions used to build the MlNetMklDeps v0.0.0.10
+mkl 2021.3

--- a/docs/building/MlNetMklDeps/version.md
+++ b/docs/building/MlNetMklDeps/version.md
@@ -15,5 +15,5 @@ mac:2019.2.187
 linux:2019.2.187
 windows:2019.2.187
 
-#Intel MKl SDK versions used to build the MlNetMklDeps v0.0.0.10
+#Intel MKl SDK versions used to build the MlNetMklDeps v0.0.0.12
 mkl 2021.3

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -22,7 +22,7 @@
     <LightGBMPackageVersion>2.3.1</LightGBMPackageVersion>
     <MicrosoftExtensionsPackageVersion>2.1.0</MicrosoftExtensionsPackageVersion>
     <MicrosoftMLOnnxRuntimePackageVersion>1.6.0</MicrosoftMLOnnxRuntimePackageVersion>
-    <MlNetMklDepsPackageVersion>0.0.0.11</MlNetMklDepsPackageVersion>
+    <MlNetMklDepsPackageVersion>0.0.0.12</MlNetMklDepsPackageVersion>
     <ParquetDotNetPackageVersion>2.1.3</ParquetDotNetPackageVersion>
     <SystemDrawingCommonPackageVersion>4.5.0</SystemDrawingCommonPackageVersion>
     <SystemIOFileSystemAccessControl>4.5.0</SystemIOFileSystemAccessControl>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -22,7 +22,7 @@
     <LightGBMPackageVersion>2.3.1</LightGBMPackageVersion>
     <MicrosoftExtensionsPackageVersion>2.1.0</MicrosoftExtensionsPackageVersion>
     <MicrosoftMLOnnxRuntimePackageVersion>1.6.0</MicrosoftMLOnnxRuntimePackageVersion>
-    <MlNetMklDepsPackageVersion>0.0.0.10</MlNetMklDepsPackageVersion>
+    <MlNetMklDepsPackageVersion>0.0.0.11</MlNetMklDepsPackageVersion>
     <ParquetDotNetPackageVersion>2.1.3</ParquetDotNetPackageVersion>
     <SystemDrawingCommonPackageVersion>4.5.0</SystemDrawingCommonPackageVersion>
     <SystemIOFileSystemAccessControl>4.5.0</SystemIOFileSystemAccessControl>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -22,7 +22,7 @@
     <LightGBMPackageVersion>2.3.1</LightGBMPackageVersion>
     <MicrosoftExtensionsPackageVersion>2.1.0</MicrosoftExtensionsPackageVersion>
     <MicrosoftMLOnnxRuntimePackageVersion>1.6.0</MicrosoftMLOnnxRuntimePackageVersion>
-    <MlNetMklDepsPackageVersion>0.0.0.9</MlNetMklDepsPackageVersion>
+    <MlNetMklDepsPackageVersion>0.0.0.10</MlNetMklDepsPackageVersion>
     <ParquetDotNetPackageVersion>2.1.3</ParquetDotNetPackageVersion>
     <SystemDrawingCommonPackageVersion>4.5.0</SystemDrawingCommonPackageVersion>
     <SystemIOFileSystemAccessControl>4.5.0</SystemIOFileSystemAccessControl>

--- a/src/Microsoft.ML.Mkl.Redist/Microsoft.ML.Mkl.Redist.csproj
+++ b/src/Microsoft.ML.Mkl.Redist/Microsoft.ML.Mkl.Redist.csproj
@@ -23,6 +23,8 @@
       <!--Include native PDBs-->
       <BuildOutputInPackage Condition="Exists('$(PackageAssetsPath)$(PackageIdFolderName)\runtimes\win-x86\native\MklProxyNative.pdb')" Include="$(PackageAssetsPath)$(PackageIdFolderName)\runtimes\win-x86\native\MklProxyNative.pdb" TargetPath="..\..\runtimes\win-x86\native"/>
       <BuildOutputInPackage Condition="Exists('$(PackageAssetsPath)$(PackageIdFolderName)\runtimes\win-x64\native\MklProxyNative.pdb')" Include="$(PackageAssetsPath)$(PackageIdFolderName)\runtimes\win-x64\native\MklProxyNative.pdb" TargetPath="..\..\runtimes\win-x64\native"/>
+      <BuildOutputInPackage Condition="Exists('$(PackageAssetsPath)$(PackageIdFolderName)\runtimes\win-x86\native\MklImports.pdb')" Include="$(PackageAssetsPath)$(PackageIdFolderName)\runtimes\win-x86\native\MklImports.pdb" TargetPath="..\..\runtimes\win-x86\native\MklImports.pdb"/>
+      <BuildOutputInPackage Condition="Exists('$(PackageAssetsPath)$(PackageIdFolderName)\runtimes\win-x64\native\MklImports.pdb')" Include="$(PackageAssetsPath)$(PackageIdFolderName)\runtimes\win-x64\native\MklImports.pdb" TargetPath="..\..\runtimes\win-x64\native\MklImports.pdb"/>
     </ItemGroup>
   </Target>
 </Project>

--- a/src/Native/Native.proj
+++ b/src/Native/Native.proj
@@ -86,6 +86,10 @@
           SourceFiles="$(NuGetPackageRoot)mlnetmkldeps\$(MlNetMklDepsPackageVersion)\runtimes\$(PackageRid)\native\$(NativeLibPrefix)MklImports$(NativeLibExtension)"
           DestinationFolder="$(NativeAssetsBuiltPath)" />
 
+    <!-- Copy MklImports pdb over -->
+    <Copy Condition="'$(OS)' == 'Windows_NT' And '$(TargetArchitecture)' != 'arm64' And '$(TargetArchitecture)' != 'arm'" SourceFiles="$(NuGetPackageRoot)mlnetmkldeps\$(MlNetMklDepsPackageVersion)\runtimes\$(PackageRid)\native\MklImports.pdb"
+          DestinationFolder="$(NativeAssetsBuiltPath)" />
+
     <Copy Condition="'$(OS)' == 'Windows_NT' And '$(TargetArchitecture)' != 'arm64' And '$(TargetArchitecture)' != 'arm'" SourceFiles="$(NuGetPackageRoot)mlnetmkldeps\$(MlNetMklDepsPackageVersion)\runtimes\$(PackageRid)\native\libiomp5md$(NativeLibExtension)"
           DestinationFolder="$(NativeAssetsBuiltPath)" />
 
@@ -120,6 +124,9 @@
     <ItemGroup>
       <NativePackageAsset Condition="'$(TargetArchitecture)' != 'arm64' And '$(TargetArchitecture)' != 'arm'"
                           Include="$(NativeAssetsBuiltPath)\$(NativeLibPrefix)MklImports$(NativeLibExtension)"
+                          RelativePath="Microsoft.ML.Mkl.Redist\runtimes\$(PackageRid)\native" />
+      <NativePackageAsset Condition="'$(TargetArchitecture)' != 'arm64' And '$(TargetArchitecture)' != 'arm'"
+                          Include="$(NativeAssetsBuiltPath)\MklImports.pdb"
                           RelativePath="Microsoft.ML.Mkl.Redist\runtimes\$(PackageRid)\native" />
       <NativePackageAsset Condition="'$(OS)' == 'Windows_NT' And '$(TargetArchitecture)' != 'arm64' And '$(TargetArchitecture)' != 'arm'" Include="$(NativeAssetsBuiltPath)\libiomp5md$(NativeLibExtension)"
                           RelativePath="Microsoft.ML.Mkl.Redist\runtimes\$(PackageRid)\native" />

--- a/src/Native/Native.proj
+++ b/src/Native/Native.proj
@@ -125,7 +125,7 @@
       <NativePackageAsset Condition="'$(TargetArchitecture)' != 'arm64' And '$(TargetArchitecture)' != 'arm'"
                           Include="$(NativeAssetsBuiltPath)\$(NativeLibPrefix)MklImports$(NativeLibExtension)"
                           RelativePath="Microsoft.ML.Mkl.Redist\runtimes\$(PackageRid)\native" />
-      <NativePackageAsset Condition="'$(TargetArchitecture)' != 'arm64' And '$(TargetArchitecture)' != 'arm'"
+      <NativePackageAsset Condition="'$(OS)' == 'Windows_NT' And '$(TargetArchitecture)' != 'arm64' And '$(TargetArchitecture)' != 'arm'"
                           Include="$(NativeAssetsBuiltPath)\MklImports.pdb"
                           RelativePath="Microsoft.ML.Mkl.Redist\runtimes\$(PackageRid)\native" />
       <NativePackageAsset Condition="'$(OS)' == 'Windows_NT' And '$(TargetArchitecture)' != 'arm64' And '$(TargetArchitecture)' != 'arm'" Include="$(NativeAssetsBuiltPath)\libiomp5md$(NativeLibExtension)"

--- a/src/Native/Native.proj
+++ b/src/Native/Native.proj
@@ -35,6 +35,10 @@
     <NativeVersionFile>$(IntermediateOutputPath)_version.h</NativeVersionFile>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
+    <NonArmOnWindows Condition="'$(TargetArchitecture)' != 'arm64' And '$(TargetArchitecture)' != 'arm'">true</NonArmOnWindows>
+  </PropertyGroup>
+
   <PropertyGroup>
     <NativeLibPrefix Condition="'$(OS)' != 'Windows_NT'">lib</NativeLibPrefix>
     <NativeLibExtension Condition="'$(OS)' == 'Windows_NT'">.dll</NativeLibExtension>
@@ -87,10 +91,10 @@
           DestinationFolder="$(NativeAssetsBuiltPath)" />
 
     <!-- Copy MklImports pdb over -->
-    <Copy Condition="'$(OS)' == 'Windows_NT' And '$(TargetArchitecture)' != 'arm64' And '$(TargetArchitecture)' != 'arm'" SourceFiles="$(NuGetPackageRoot)mlnetmkldeps\$(MlNetMklDepsPackageVersion)\runtimes\$(PackageRid)\native\MklImports.pdb"
+    <Copy Condition="'$(NonArmOnWindows)' == 'true'" SourceFiles="$(NuGetPackageRoot)mlnetmkldeps\$(MlNetMklDepsPackageVersion)\runtimes\$(PackageRid)\native\MklImports.pdb"
           DestinationFolder="$(NativeAssetsBuiltPath)" />
 
-    <Copy Condition="'$(OS)' == 'Windows_NT' And '$(TargetArchitecture)' != 'arm64' And '$(TargetArchitecture)' != 'arm'" SourceFiles="$(NuGetPackageRoot)mlnetmkldeps\$(MlNetMklDepsPackageVersion)\runtimes\$(PackageRid)\native\libiomp5md$(NativeLibExtension)"
+    <Copy Condition="'$(NonArmOnWindows)' == 'true'" SourceFiles="$(NuGetPackageRoot)mlnetmkldeps\$(MlNetMklDepsPackageVersion)\runtimes\$(PackageRid)\native\libiomp5md$(NativeLibExtension)"
           DestinationFolder="$(NativeAssetsBuiltPath)" />
 
     <ItemGroup>
@@ -125,10 +129,10 @@
       <NativePackageAsset Condition="'$(TargetArchitecture)' != 'arm64' And '$(TargetArchitecture)' != 'arm'"
                           Include="$(NativeAssetsBuiltPath)\$(NativeLibPrefix)MklImports$(NativeLibExtension)"
                           RelativePath="Microsoft.ML.Mkl.Redist\runtimes\$(PackageRid)\native" />
-      <NativePackageAsset Condition="'$(OS)' == 'Windows_NT' And '$(TargetArchitecture)' != 'arm64' And '$(TargetArchitecture)' != 'arm'"
+      <NativePackageAsset Condition="'$(NonArmOnWindows)' == 'true'"
                           Include="$(NativeAssetsBuiltPath)\MklImports.pdb"
                           RelativePath="Microsoft.ML.Mkl.Redist\runtimes\$(PackageRid)\native" />
-      <NativePackageAsset Condition="'$(OS)' == 'Windows_NT' And '$(TargetArchitecture)' != 'arm64' And '$(TargetArchitecture)' != 'arm'" Include="$(NativeAssetsBuiltPath)\libiomp5md$(NativeLibExtension)"
+      <NativePackageAsset Condition="'$(NonArmOnWindows)' == 'true'" Include="$(NativeAssetsBuiltPath)\libiomp5md$(NativeLibExtension)"
                           RelativePath="Microsoft.ML.Mkl.Redist\runtimes\$(PackageRid)\native" />
 
     </ItemGroup>


### PR DESCRIPTION
Update version of Intel MKL.

The issue of thread contention is still not fixed. According to them:
> We still have this limitation. We don’t have explicit initialization step, so at the very first oneMKL call we do some check for available features and use LoadLibrary to load additional libraries if needed (e.g. to load correct CPU optimizations at runtime for detected HW), but LoadLibrary is not allowed to be used in DLLMain because of potential deadlock. You can use oneMKL in DLLMain but only after initialization, e.g. first cblas call should be done outside of DLLMain.

This is the latest version of Intel MKL and includes the windows .PDB files.