### PR TITLE
updated official build yml to latest version

### DIFF
--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -13,9 +13,9 @@ resources:
   - container: UbuntuCrossArm64Container
     image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-mlnet-cross-arm64-20210512124625-2e59a5f
 
-phases:
+jobs:
 ################################################################################
-- phase: Linux_x64
+- job: Linux_x64
 ################################################################################
   variables:
     BuildConfig: Release
@@ -23,11 +23,11 @@ phases:
     DOTNET_CLI_TELEMETRY_OPTOUT: 1
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
     DOTNET_MULTILEVEL_LOOKUP: 0
-  queue:
+  pool:
     name: DotNet-Build
     demands:
     - agent.os -equals linux
-    container: CentosContainer
+  container: CentosContainer
   steps:
   - script: ./restore.sh
     displayName: restore all projects
@@ -45,7 +45,7 @@ phases:
       artifactType: container
 
 ################################################################################
-- phase: Linux_arm
+- job: Linux_arm
 ################################################################################
   variables:
     BuildConfig: Release-netcoreapp3_1
@@ -53,11 +53,12 @@ phases:
     DOTNET_CLI_TELEMETRY_OPTOUT: 1
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
     DOTNET_MULTILEVEL_LOOKUP: 0
-  queue:
+    ROOTFS_DIR: '/crossrootfs/arm'
+  pool:
     name: DotNet-Build
     demands:
     - agent.os -equals linux
-    container: UbuntuCrossArmContainer
+  container: UbuntuCrossArmContainer
   steps:
   - script: ./restore.sh
     displayName: restore all projects
@@ -75,7 +76,7 @@ phases:
       artifactType: container
 
 ################################################################################
-- phase: Linux_arm64
+- job: Linux_arm64
 ################################################################################
   variables:
     BuildConfig: Release-netcoreapp3_1
@@ -83,11 +84,12 @@ phases:
     DOTNET_CLI_TELEMETRY_OPTOUT: 1
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
     DOTNET_MULTILEVEL_LOOKUP: 0
-  queue:
+    ROOTFS_DIR: '/crossrootfs/arm64'
+  pool:
     name: DotNet-Build
     demands:
     - agent.os -equals linux
-    container: UbuntuCrossArm64Container
+  container: UbuntuCrossArm64Container
   steps:
   - script: ./restore.sh
     displayName: restore all projects
@@ -105,7 +107,7 @@ phases:
       artifactType: container
 
 ################################################################################
-- phase: MacOS
+- job: MacOS
 ################################################################################
   variables:
     BuildConfig: Release
@@ -113,7 +115,7 @@ phases:
     DOTNET_CLI_TELEMETRY_OPTOUT: 1
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
     DOTNET_MULTILEVEL_LOOKUP: 0
-  queue:
+  pool:
     name: Hosted macOS
   steps:
   # Work around MacOS Homebrew image/environment bug: https://github.com/actions/virtual-environments/issues/2322#issuecomment-749211076
@@ -137,9 +139,9 @@ phases:
       pathToPublish: $(Build.SourcesDirectory)/artifacts/pkgassets
       artifactName: PackageAssets
       artifactType: container
-      
+
 ################################################################################
-- phase: MacOS_Apple_Silicon
+- job: MacOS_Apple_Silicon
 ################################################################################
   variables:
     BuildConfig: Release-netcoreapp3_1
@@ -147,7 +149,7 @@ phases:
     DOTNET_CLI_TELEMETRY_OPTOUT: 1
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
     DOTNET_MULTILEVEL_LOOKUP: 0
-  queue:
+  pool:
     vmImage: macOS-10.15
   steps:
   # Work around MacOS Homebrew image/environment bug: https://github.com/actions/virtual-environments/issues/2322#issuecomment-749211076
@@ -173,7 +175,7 @@ phases:
       artifactType: container
 
 ################################################################################
-- phase: Windows_x86
+- job: Windows_x86
 ################################################################################
   variables:
     BuildConfig: Release
@@ -184,7 +186,7 @@ phases:
     _SignType: real
     _UseEsrpSigning: true
     _TeamName: DotNetCore
-  queue:
+  pool:
     name: DotNetCore-Build
     demands:
       - agent.os -equals Windows_NT
@@ -224,7 +226,7 @@ phases:
     displayName: Dotnet Server Shutdown
 
 ################################################################################
-- phase: Windows_x64
+- job: Windows_x64
 ################################################################################
   variables:
     BuildConfig: Release
@@ -235,7 +237,7 @@ phases:
     _SignType: real
     _UseEsrpSigning: true
     _TeamName: DotNetCore
-  queue:
+  pool:
     name: DotNetCore-Build
     demands:
       - agent.os -equals Windows_NT
@@ -278,7 +280,7 @@ phases:
     displayName: Dotnet Server Shutdown
 
 ################################################################################
-- phase: Package
+- job: Package
 ################################################################################
   dependsOn:
   - Linux_x64
@@ -301,7 +303,7 @@ phases:
     _AzureDevopsFeedUrl: https://pkgs.dev.azure.com/dnceng/public/_packaging/MachineLearning/nuget/v3/index.json
     _SymwebSymbolServerPath: https://microsoft.artifacts.visualstudio.com/DefaultCollection
     _MsdlSymbolServerPath: https://microsoftpublicsymbols.artifacts.visualstudio.com/DefaultCollection
-  queue:
+  pool:
     name: DotNetCore-Build
     demands:
       - agent.os -equals Windows_NT


### PR DESCRIPTION
I forgot that the official build yml isn't validated during the PR process.

With all the new additions and use of new queues, we need to update the yml syntax from version 1 to the current version. I synced with @safern and used this doc, https://github.com/dotnet/arcade/blob/main/Documentation/AzureDevOps/PhaseToJobSchemaChange.md, to update the YAML from using the 'phase' syntax to the new 'job' syntax. This was already done for the CI build a while ago, but it hadn't been done for the official build (probably because it wasn't necessary to use the latest syntax at the time).

Here is a run with these official builds succeeding, https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4980869&view=logs&j=1d2f55de-c984-5e06-0d18-75388f298a89&t=1d2f55de-c984-5e06-0d18-75388f298a89.

I have also verified the nuget packages have the correct native files for linux-arm, linux-arm64, osx-arm64 for the 2 packages that should have them.