### PR TITLE
Added BufferedStream for reading from DeflateStream - reduces loading…

### DIFF
--- a/src/Microsoft.ML.Data/DataLoadSave/Binary/BinaryLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Binary/BinaryLoader.cs
@@ -617,7 +617,8 @@ namespace Microsoft.ML.Data.IO
                             stream.Seek(BlockOffset, SeekOrigin.Begin);
                             using (var subset = new SubsetStream(stream, BlockSize))
                             using (var decompressed = Compression.DecompressStream(subset))
-                            using (var valueReader = _codec.OpenReader(decompressed, 1))
+                            using (var bufferedStream = new BufferedStream(decompressed))
+                            using (var valueReader = _codec.OpenReader(bufferedStream, 1))
                             {
                                 valueReader.MoveNext();
                                 valueReader.Get(ref Value);


### PR DESCRIPTION
Fixes issue #5913 
Issue from .NET runtime: https://github.com/dotnet/runtime/issues/39233#issuecomment-658879877

Buffered reader around the binary reader will significantly improve loading time of bigger ML models using .NET/.NET Core runtime.
