### PR TITLE
New PFI API

### DIFF
--- a/src/Microsoft.ML.Data/Prediction/CalibratorCatalog.cs
+++ b/src/Microsoft.ML.Data/Prediction/CalibratorCatalog.cs
@@ -204,7 +204,6 @@ namespace Microsoft.ML.Calibrators
         string ISingleFeaturePredictionTransformer.FeatureColumnName => ((ISingleFeaturePredictionTransformer<TICalibrator>)this).FeatureColumnName;
 
         DataViewType ISingleFeaturePredictionTransformer<TICalibrator>.FeatureColumnType => NumberDataViewType.Single;
-        DataViewType ISingleFeaturePredictionTransformer.FeatureColumnType => ((ISingleFeaturePredictionTransformer<TICalibrator>)this).FeatureColumnType;
 
         TICalibrator IPredictionTransformer<TICalibrator>.Model => _calibrator;
 

--- a/src/Microsoft.ML.Data/Prediction/CalibratorCatalog.cs
+++ b/src/Microsoft.ML.Data/Prediction/CalibratorCatalog.cs
@@ -200,9 +200,11 @@ namespace Microsoft.ML.Calibrators
             }
         }
 
-        public string FeatureColumnName => DefaultColumnNames.Score;
+        string ISingleFeaturePredictionTransformer<TICalibrator>.FeatureColumnName => DefaultColumnNames.Score;
+        string ISingleFeaturePredictionTransformer.FeatureColumnName => ((ISingleFeaturePredictionTransformer<TICalibrator>)this).FeatureColumnName;
 
-        public DataViewType FeatureColumnType => NumberDataViewType.Single;
+        DataViewType ISingleFeaturePredictionTransformer<TICalibrator>.FeatureColumnType => NumberDataViewType.Single;
+        DataViewType ISingleFeaturePredictionTransformer.FeatureColumnType => ((ISingleFeaturePredictionTransformer<TICalibrator>)this).FeatureColumnType;
 
         TICalibrator IPredictionTransformer<TICalibrator>.Model => _calibrator;
 

--- a/src/Microsoft.ML.Data/Prediction/CalibratorCatalog.cs
+++ b/src/Microsoft.ML.Data/Prediction/CalibratorCatalog.cs
@@ -162,7 +162,7 @@ namespace Microsoft.ML.Calibrators
     /// where score can be viewed as a feature while probability is treated as the label.
     /// </summary>
     /// <typeparam name="TICalibrator">The <see cref="ICalibrator"/> used to transform the data.</typeparam>
-    public abstract class CalibratorTransformer<TICalibrator> : RowToRowTransformerBase, ISingleFeaturePredictionTransformer<TICalibrator>
+    public abstract class CalibratorTransformer<TICalibrator> : RowToRowTransformerBase, ISingleFeaturePredictionTransformer<TICalibrator>, ISingleFeaturePredictionTransformer
         where TICalibrator : class, ICalibrator
     {
         private readonly TICalibrator _calibrator;
@@ -200,9 +200,9 @@ namespace Microsoft.ML.Calibrators
             }
         }
 
-        string ISingleFeaturePredictionTransformer<TICalibrator>.FeatureColumnName => DefaultColumnNames.Score;
+        public string FeatureColumnName => DefaultColumnNames.Score;
 
-        DataViewType ISingleFeaturePredictionTransformer<TICalibrator>.FeatureColumnType => NumberDataViewType.Single;
+        public DataViewType FeatureColumnType => NumberDataViewType.Single;
 
         TICalibrator IPredictionTransformer<TICalibrator>.Model => _calibrator;
 

--- a/src/Microsoft.ML.Data/Prediction/IPredictionTransformer.cs
+++ b/src/Microsoft.ML.Data/Prediction/IPredictionTransformer.cs
@@ -34,4 +34,19 @@ namespace Microsoft.ML
         /// <summary>Holds information about the type of the feature column.</summary>
         DataViewType FeatureColumnType { get; }
     }
+
+    /// <summary>
+    /// An ISingleFeaturePredictionTransformer contains the name of the <see cref="FeatureColumnName"/>
+    /// and its type, <see cref="FeatureColumnType"/>. Implementations of this interface, have the ability
+    /// to score the data of an input <see cref="IDataView"/> through the <see cref="ITransformer.Transform(IDataView)"/>
+    /// </summary>
+    [BestFriend]
+    internal interface ISingleFeaturePredictionTransformer : ITransformer
+    {
+        /// <summary>The name of the feature column.</summary>
+        public string FeatureColumnName { get; }
+
+        /// <summary>Holds information about the type of the feature column.</summary>
+        public DataViewType FeatureColumnType { get; }
+    }
 }

--- a/src/Microsoft.ML.Data/Prediction/IPredictionTransformer.cs
+++ b/src/Microsoft.ML.Data/Prediction/IPredictionTransformer.cs
@@ -45,8 +45,5 @@ namespace Microsoft.ML
     {
         /// <summary>The name of the feature column.</summary>
         string FeatureColumnName { get; }
-
-        /// <summary>Holds information about the type of the feature column.</summary>
-        DataViewType FeatureColumnType { get; }
     }
 }

--- a/src/Microsoft.ML.Data/Prediction/IPredictionTransformer.cs
+++ b/src/Microsoft.ML.Data/Prediction/IPredictionTransformer.cs
@@ -44,9 +44,9 @@ namespace Microsoft.ML
     internal interface ISingleFeaturePredictionTransformer : ITransformer
     {
         /// <summary>The name of the feature column.</summary>
-        public string FeatureColumnName { get; }
+        string FeatureColumnName { get; }
 
         /// <summary>Holds information about the type of the feature column.</summary>
-        public DataViewType FeatureColumnType { get; }
+        DataViewType FeatureColumnType { get; }
     }
 }

--- a/src/Microsoft.ML.Data/Scorers/PredictionTransformer.cs
+++ b/src/Microsoft.ML.Data/Scorers/PredictionTransformer.cs
@@ -204,7 +204,7 @@ namespace Microsoft.ML.Data
     /// Those are all the transformers that work with one feature column.
     /// </summary>
     /// <typeparam name="TModel">The model used to transform the data.</typeparam>
-    public abstract class SingleFeaturePredictionTransformerBase<TModel> : PredictionTransformerBase<TModel>, ISingleFeaturePredictionTransformer<TModel>
+    public abstract class SingleFeaturePredictionTransformerBase<TModel> : PredictionTransformerBase<TModel>, ISingleFeaturePredictionTransformer<TModel>, ISingleFeaturePredictionTransformer
         where TModel : class
     {
         /// <summary>

--- a/src/Microsoft.ML.Transforms/PermutationFeatureImportanceExtensions.cs
+++ b/src/Microsoft.ML.Transforms/PermutationFeatureImportanceExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -123,7 +123,7 @@ namespace Microsoft.ML
         /// <param name="useFeatureWeightFilter">Use features weight to pre-filter features.</param>
         /// <param name="numberOfExamplesToUse">Limit the number of examples to evaluate on. <cref langword="null"/> means up to ~2 bln examples from <paramref param="data"/> will be used.</param>
         /// <param name="permutationCount">The number of permutations to perform.</param>
-        /// <returns>Array of per-feature 'contributions' to the score.</returns>
+        /// <returns>Dictionary mapping each feature to its per-feature 'contributions' to the score.</returns>
         public static ImmutableDictionary<string, RegressionMetricsStatistics>
             PermutationFeatureImportance(
                 this RegressionCatalog catalog,
@@ -275,7 +275,7 @@ namespace Microsoft.ML
         /// <param name="permutationCount">The number of permutations to perform.</param>
         /// <returns>Dictionary mapping each feature to its per-feature 'contributions' to the score.</returns>
         public static ImmutableDictionary<string, BinaryClassificationMetricsStatistics>
-            PermutationFeatureImportance(
+            PermutationFeatureImportanceNonCalibrated(
                 this BinaryClassificationCatalog catalog,
                 ITransformer model,
                 IDataView data,
@@ -427,7 +427,7 @@ namespace Microsoft.ML
         /// <param name="useFeatureWeightFilter">Use features weight to pre-filter features.</param>
         /// <param name="numberOfExamplesToUse">Limit the number of examples to evaluate on. <cref langword="null"/> means up to ~2 bln examples from <paramref param="data"/> will be used.</param>
         /// <param name="permutationCount">The number of permutations to perform.</param>
-        /// <returns>Array of per-feature 'contributions' to the score.</returns>
+        /// <returns>Dictionary mapping each feature to its per-feature 'contributions' to the score.</returns>
         public static ImmutableDictionary<string, MulticlassClassificationMetricsStatistics>
             PermutationFeatureImportance(
                 this MulticlassClassificationCatalog catalog,
@@ -476,7 +476,7 @@ namespace Microsoft.ML
                 logLoss: a.LogLoss - b.LogLoss,
                 logLossReduction: a.LogLossReduction - b.LogLossReduction,
                 topKPredictionCount: a.TopKPredictionCount,
-                topKAccuracies: a?.TopKAccuracyForAllK?.Zip(b.TopKAccuracyForAllK, (a,b)=>a-b)?.ToArray(),
+                topKAccuracies: a?.TopKAccuracyForAllK?.Zip(b.TopKAccuracyForAllK, (a, b) => a - b)?.ToArray(),
                 perClassLogLoss: perClassLogLoss
                 );
         }
@@ -589,7 +589,7 @@ namespace Microsoft.ML
         /// <param name="useFeatureWeightFilter">Use features weight to pre-filter features.</param>
         /// <param name="numberOfExamplesToUse">Limit the number of examples to evaluate on. <cref langword="null"/> means up to ~2 bln examples from <paramref param="data"/> will be used.</param>
         /// <param name="permutationCount">The number of permutations to perform.</param>
-        /// <returns>Array of per-feature 'contributions' to the score.</returns>
+        /// <returns>Dictionary mapping each feature to its per-feature 'contributions' to the score.</returns>
         public static ImmutableDictionary<string, RankingMetricsStatistics>
             PermutationFeatureImportance(
                 this RankingCatalog catalog,
@@ -715,7 +715,14 @@ namespace Microsoft.ML
             var output = new Dictionary<string, TResult>();
             for (int i = 0; i < permutationFeatureImportance.Length; i++)
             {
-                output.Add(featureColumnNames[i].ToString(), permutationFeatureImportance[i]);
+                var name = featureColumnNames[i].ToString();
+
+                // If the slot wasn't given a name, default to just the slot number.
+                if (string.IsNullOrEmpty(name))
+                {
+                    name = $"Slot {i}";
+                }
+                output.Add(name, permutationFeatureImportance[i]);
             }
 
             return output.ToImmutableDictionary();

--- a/src/Microsoft.ML.Transforms/PermutationFeatureImportanceExtensions.cs
+++ b/src/Microsoft.ML.Transforms/PermutationFeatureImportanceExtensions.cs
@@ -669,9 +669,9 @@ namespace Microsoft.ML
             {
                 foreach (var transformer in chain.Reverse())
                 {
-                    if (transformer is ISingleFeaturePredictionTransformer)
+                    if (transformer is ISingleFeaturePredictionTransformer singlePredictionTransformer)
                     {
-                        lastTransformer = transformer as ISingleFeaturePredictionTransformer;
+                        lastTransformer = singlePredictionTransformer;
                         break;
                     }
                 }
@@ -692,7 +692,7 @@ namespace Microsoft.ML
                 resultInitializer,
                 evaluationFunc,
                 deltaFunc,
-                lastTransformer.FeatureColumnName,
+                featureColumnName,
                 permutationCount,
                 useFeatureWeightFilter,
                 numberOfExamplesToUse

--- a/src/Microsoft.ML.Transforms/PermutationFeatureImportanceExtensions.cs
+++ b/src/Microsoft.ML.Transforms/PermutationFeatureImportanceExtensions.cs
@@ -670,7 +670,10 @@ namespace Microsoft.ML
                 foreach (var transformer in chain.Reverse())
                 {
                     if (transformer is ISingleFeaturePredictionTransformer)
+                    {
                         lastTransformer = transformer;
+                        break;
+                    }
                 }
             }
             else lastTransformer = model as ISingleFeaturePredictionTransformer;

--- a/src/Microsoft.ML.Transforms/PermutationFeatureImportanceExtensions.cs
+++ b/src/Microsoft.ML.Transforms/PermutationFeatureImportanceExtensions.cs
@@ -731,7 +731,7 @@ namespace Microsoft.ML
                 }
             }
 
-            throw new ArgumentException($"Type IPredictionTransformer not implemented by provided type", nameof(type));
+            throw new ArgumentException($"Type IPredictionTransformer not implemented by provided type, {type}", nameof(type));
         }
 
         #endregion

--- a/src/Microsoft.ML.Transforms/PermutationFeatureImportanceExtensions.cs
+++ b/src/Microsoft.ML.Transforms/PermutationFeatureImportanceExtensions.cs
@@ -681,7 +681,7 @@ namespace Microsoft.ML
             env.CheckValue(lastTransformer, nameof(lastTransformer), "The model provided does not have a compatible predictor");
 
             string featureColumnName = lastTransformer.FeatureColumnName;
-            TryGetImplementedIPredictionTransformer(lastTransformer.GetType(), out var predictionTransformerGenericType);
+            var predictionTransformerGenericType = GetImplementedIPredictionTransformer(lastTransformer.GetType());
 
             Type[] types = { predictionTransformerGenericType.GenericTypeArguments[0], typeof(TMetric), typeof(TResult) };
             Type pfiGenericType = typeof(PermutationFeatureImportance<,,>).MakeGenericType(types);
@@ -721,19 +721,17 @@ namespace Microsoft.ML
             return output.ToImmutableDictionary();
         }
 
-        private static bool TryGetImplementedIPredictionTransformer(Type type, out Type interfaceType)
+        private static Type GetImplementedIPredictionTransformer(Type type)
         {
             foreach (Type iType in type.GetInterfaces())
             {
                 if (iType.IsGenericType && iType.GetGenericTypeDefinition() == typeof(IPredictionTransformer<>))
                 {
-                    interfaceType = iType;
-                    return true;
+                    return iType;
                 }
             }
 
-            interfaceType = null;
-            return false;
+            throw new ArgumentException($"Type IPredictionTransformer not implemented by provided type", nameof(type));
         }
 
         #endregion

--- a/test/Microsoft.ML.TestFramework/BaseTestBaseline.cs
+++ b/test/Microsoft.ML.TestFramework/BaseTestBaseline.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -127,9 +127,9 @@ namespace Microsoft.ML.RunTests
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                if (RuntimeInformation.ProcessArchitecture == Architecture.X64)
+                if(RuntimeInformation.ProcessArchitecture == Architecture.X64)
                     configurationDirs.Add("osx-x64");
-                else if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
+                else if(RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
                     configurationDirs.Add("osx-arm64");
             }
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
@@ -609,7 +609,7 @@ namespace Microsoft.ML.RunTests
             return true;
         }
 
-        public bool CompareNumbersWithTolerance(double expected, double actual, int? iterationOnCollection = null,
+        public bool CompareNumbersWithTolerance(double expected, double actual, int? iterationOnCollection = null, 
             int digitsOfPrecision = DigitsOfPrecision, bool logFailure = true)
         {
             if (double.IsNaN(expected) && double.IsNaN(actual))
@@ -642,7 +642,7 @@ namespace Microsoft.ML.RunTests
             {
                 var message = iterationOnCollection != null ? "" : $"Output and baseline mismatch at line {iterationOnCollection}." + Environment.NewLine;
 
-                if (logFailure)
+                if(logFailure)
                     Fail(message +
                             $"Values to compare are {expected} and {actual}" + Environment.NewLine +
                             $"\t AllowedVariance: {allowedVariance}" + Environment.NewLine +

--- a/test/Microsoft.ML.TestFramework/BaseTestBaseline.cs
+++ b/test/Microsoft.ML.TestFramework/BaseTestBaseline.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -127,9 +127,9 @@ namespace Microsoft.ML.RunTests
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                if(RuntimeInformation.ProcessArchitecture == Architecture.X64)
+                if (RuntimeInformation.ProcessArchitecture == Architecture.X64)
                     configurationDirs.Add("osx-x64");
-                else if(RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
+                else if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
                     configurationDirs.Add("osx-arm64");
             }
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
@@ -609,7 +609,7 @@ namespace Microsoft.ML.RunTests
             return true;
         }
 
-        public bool CompareNumbersWithTolerance(double expected, double actual, int? iterationOnCollection = null, 
+        public bool CompareNumbersWithTolerance(double expected, double actual, int? iterationOnCollection = null,
             int digitsOfPrecision = DigitsOfPrecision, bool logFailure = true)
         {
             if (double.IsNaN(expected) && double.IsNaN(actual))
@@ -642,7 +642,7 @@ namespace Microsoft.ML.RunTests
             {
                 var message = iterationOnCollection != null ? "" : $"Output and baseline mismatch at line {iterationOnCollection}." + Environment.NewLine;
 
-                if(logFailure)
+                if (logFailure)
                     Fail(message +
                             $"Values to compare are {expected} and {actual}" + Environment.NewLine +
                             $"\t AllowedVariance: {allowedVariance}" + Environment.NewLine +


### PR DESCRIPTION
Based on the feedback we received (thanks @houghj16 for all your work on that study!), our PFI API was too complex (and lets be honest, getting past the initial cast stops everyone...).

This PR fixes #5625 by adding a new PFI API that is much more user friendly in both how to call it, and how the results are returned. The added tests also make sure the output from the original API and the new API are identical if you match up the features correctly.

@JakeRadMSFT @briacht