### PR TITLE
Init _bestMetricValue for Loss metric

### DIFF
--- a/src/Microsoft.ML.Vision/ImageClassificationTrainer.cs
+++ b/src/Microsoft.ML.Vision/ImageClassificationTrainer.cs
@@ -258,7 +258,10 @@ namespace Microsoft.ML.Vision
                 if (metric == EarlyStoppingMetric.Accuracy)
                     CheckIncreasing = true;
                 else if (metric == EarlyStoppingMetric.Loss)
+                {
                     CheckIncreasing = false;
+                    _bestMetricValue = Single.MaxValue;
+                }
             }
 
             /// <summary>


### PR DESCRIPTION
_bestMetricValue must be initialized with Single.MaxValue for Loss metric because is decreasing over training.

Fixes #5938 
