### PR TITLE
Use Equals and = operator for DataViewType comparison

### DIFF
--- a/src/Microsoft.ML.AutoML/Utils/UserInputValidationUtil.cs
+++ b/src/Microsoft.ML.AutoML/Utils/UserInputValidationUtil.cs
@@ -102,7 +102,7 @@ namespace Microsoft.ML.AutoML
             }
         }
 
-        private static void ValidateColumnInformation(IDataView trainData, ColumnInformation columnInformation,  TaskKind task)
+        private static void ValidateColumnInformation(IDataView trainData, ColumnInformation columnInformation, TaskKind task)
         {
             ValidateColumnInformation(columnInformation);
             ValidateTrainDataColumn(trainData, columnInformation.LabelColumnName, LabelColumnPurposeName, GetAllowedLabelTypes(task));
@@ -217,7 +217,7 @@ namespace Microsoft.ML.AutoML
                     throw new ArgumentException($"{schemaMismatchError} Column '{trainCol.Name}' exists in train data, but not in validation data.", nameof(validationData));
                 }
 
-                if (trainCol.Type != validCol.Value.Type)
+                if (trainCol.Type != validCol.Value.Type && !trainCol.Type.Equals(validCol.Value.Type))
                 {
                     throw new ArgumentException($"{schemaMismatchError} Column '{trainCol.Name}' is of type {trainCol.Type} in train data, and type " +
                         $"{validCol.Value.Type} in validation data.", nameof(validationData));
@@ -260,7 +260,7 @@ namespace Microsoft.ML.AutoML
                 throw new ArgumentException(exceptionMessage);
             }
 
-            if(allowedTypes == null)
+            if (allowedTypes == null)
             {
                 return;
             }


### PR DESCRIPTION
This PR expands on the `DataViewType` equals comparison to allow for advanced types to be used. Currently columns of type `Vector<T, NN>` does to work as the comparison will fail. The Equals implementation in `VectorDataViewType` does account for the `PrimitiveDataViewType` and dimension sizes. 

The method chosen simply expands on the current comparsion and adds Equals to it.

The code has not been tested using the existing test suits as I could not get them to run locally.

This PR also contains two style fixes, shown as errors in VS (automatically fixed). 

Fixes #5773
