### PR TITLE
Codecov yml token addition

### DIFF
--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -43,6 +43,7 @@ jobs:
         testTargetFramework: ''
       ${{ if ne(parameters.testTargetFramework, '') }}:
         testTargetFramework: '/p:TestTargetFramework=${{ parameters.testTargetFramework }}'
+      CODECOV_TOKEN: 03031e35-fe75-4e4c-87ee-e919ae601748
     strategy:
       matrix:
         ${{ if eq(parameters.customMatrixes, '') }}:

--- a/codecov.yml
+++ b/codecov.yml
@@ -20,3 +20,6 @@ flags:
   test:
     paths:
       - test/
+
+codecov:
+  token: 03031e35-fe75-4e4c-87ee-e919ae601748

--- a/codecov.yml
+++ b/codecov.yml
@@ -22,4 +22,4 @@ flags:
       - test/
 
 codecov:
-  token: 03031e35-fe75-4e4c-87ee-e919ae601748
+  token: "03031e35-fe75-4e4c-87ee-e919ae601748"

--- a/codecov.yml
+++ b/codecov.yml
@@ -20,6 +20,3 @@ flags:
   test:
     paths:
       - test/
-
-codecov:
-  token: "03031e35-fe75-4e4c-87ee-e919ae601748"

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -39,7 +39,7 @@
     <SystemCompositionVersion>1.2.0</SystemCompositionVersion>
     <!-- Build/infrastructure Dependencies -->
     <PublishSymbolsPackageVersion>1.0.0-beta-62824-02</PublishSymbolsPackageVersion>
-    <CodecovVersion>1.9.0</CodecovVersion>
+    <CodecovVersion>1.12.4</CodecovVersion>
     <CoverletCollectorVersion>1.2.1</CoverletCollectorVersion>
     <ReportGeneratorVersion>4.3.6</ReportGeneratorVersion>
     <MicrosoftDotNetApiCompatPackageVersion>1.0.0-beta.19225.5</MicrosoftDotNetApiCompatPackageVersion>


### PR DESCRIPTION
Due to the issue of codecov not being able to find the pipeline for some reason, adding in the codecov yml token so it knows where to upload the code coverage stats to.

Also updating the nuget for the codecov uploader.