### PR TITLE
Add in VS 2022 support.

### DIFF
--- a/docs/building/windows-instructions.md
+++ b/docs/building/windows-instructions.md
@@ -6,7 +6,7 @@ You can build ML.NET either via the command line or by using Visual Studio.
 ## Required Software
 
 1. **[Visual Studio 2019 Version 16.4+](https://www.visualstudio.com/downloads/) (Community, Professional, Enterprise)** The Community version is completely free. The below build instructions were verified for VS 16.4.
-2. **[CMake](https://cmake.org/)** must be installed from [the CMake download page](https://cmake.org/download/#latest) and added to your path.
+2. **[CMake](https://cmake.org/)** must be installed from [the CMake download page](https://cmake.org/download/#latest) and added to your path. If you want to use Visual Studio 2022, you need to be using at least CMake 3.21.
 
 ### Visual Studio 2019 Installation
 We have successfully verified the below build instructions for Visual Studio version 16.4 and higher.

--- a/src/Native/build.cmd
+++ b/src/Native/build.cmd
@@ -51,7 +51,9 @@ set "VSCMD_START_DIR=%__currentScriptDir%"
 call "%_VSCOMNTOOLS%\VsDevCmd.bat"
 
 :RunVCVars
-if "%VisualStudioVersion%"=="16.0" (
+if "%VisualStudioVersion%"=="17.0" (
+    goto :VS2022
+) else if "%VisualStudioVersion%"=="16.0" (
     goto :VS2019
 ) else if "%VisualStudioVersion%"=="15.0" (
     goto :VS2017
@@ -65,6 +67,14 @@ echo Error: Visual Studio 2015, 2017 or 2019 required
 echo        Please see https://github.com/dotnet/machinelearning/tree/main/Documentation for build instructions.
 exit /b 1
 
+:VS2022
+:: Setup vars for VS2019
+set __PlatformToolset=v143
+set __VSVersion=17 2022
+:: Set the environment for the native build
+call "%VS170COMNTOOLS%..\..\VC\Auxiliary\Build\vcvarsall.bat" %__VCBuildArch%
+
+goto :SetupDirs
 :VS2019
 :: Setup vars for VS2019
 set __PlatformToolset=v142

--- a/src/Native/build.cmd
+++ b/src/Native/build.cmd
@@ -62,13 +62,13 @@ if "%VisualStudioVersion%"=="17.0" (
 )
 
 :MissingVersion
-:: Can't find VS 2015, 2017 or 2019
-echo Error: Visual Studio 2015, 2017 or 2019 required
+:: Can't find VS 2015, 2017, 2019, or 2022
+echo Error: Visual Studio 2015, 2017, 2019, or 2022 required
 echo        Please see https://github.com/dotnet/machinelearning/tree/main/Documentation for build instructions.
 exit /b 1
 
 :VS2022
-:: Setup vars for VS2019
+:: Setup vars for VS2022
 set __PlatformToolset=v143
 set __VSVersion=17 2022
 :: Set the environment for the native build


### PR DESCRIPTION
Added in support for VS 2022 in the native build.

Also added documentation stating the version of CMake needed for 2022.