### PR TITLE
Ubuntu 18.04 queues

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -36,7 +36,7 @@ jobs:
         _targetFramework: netcoreapp3.1
     innerLoop: true
     pool:
-      name: Hosted Ubuntu 1804
+      vmImage: ubuntu-18.04
     helixQueue: Ubuntu.1804.ArmArch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm32v7-20210531091521-97d8652
 
 - template: /build/ci/job-template.yml
@@ -58,7 +58,7 @@ jobs:
         _targetFramework: netcoreapp3.1
     innerLoop: true
     pool:
-      name: Hosted Ubuntu 1804
+      vmImage: ubuntu-18.04
     helixQueue: Ubuntu.1804.ArmArch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8-20210531091519-97d8652
 
 - template: /build/ci/job-template.yml
@@ -79,7 +79,7 @@ jobs:
         _targetFramework: netcoreapp3.1
     innerLoop: true
     pool:
-      name: Hosted Ubuntu 1804
+      vmImage: ubuntu-18.04
     helixQueue: Ubuntu.1804.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-mlnet-helix-20210528183707-dde38af
 
 - template: /build/ci/job-template.yml
@@ -89,7 +89,7 @@ jobs:
     container: UbuntuContainer
     innerLoop: true
     pool:
-      name: Hosted Ubuntu 1804
+      vmImage: ubuntu-18.04
     helixQueue: Ubuntu.1804.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-mlnet-helix-20210528184647-dde38af
 
 - template: /build/ci/job-template.yml
@@ -98,7 +98,7 @@ jobs:
     buildScript: ./build.sh
     innerLoop: true
     pool:
-      name: Hosted macOS
+      vmImage: macOS-10.15
     helixQueue: OSX.1015.Amd64.Open
 
 - template: /build/ci/job-template.yml
@@ -141,7 +141,7 @@ jobs:
     innerLoop: true
     vsTestConfiguration: "/Framework:.NETCoreApp,Version=v3.0"
     pool:
-      name: Hosted VS2017
+      vmImage: windows-2019
     helixQueue: Windows.10.Amd64.Open
 
 - template: /build/ci/job-template.yml
@@ -151,7 +151,7 @@ jobs:
     innerLoop: true
     vsTestConfiguration: "/Framework:.NETCoreApp,Version=v2.1"
     pool:
-      name: Hosted VS2017
+      vmImage: windows-2019
     helixQueue: Windows.10.Amd64.Open
 
 - template: /build/ci/job-template.yml
@@ -172,7 +172,7 @@ jobs:
     innerLoop: true
     vsTestConfiguration: "/Framework:.NETCoreApp,Version=v4.0"
     pool:
-      name: Hosted VS2017
+      vmImage: windows-2019
     helixQueue: Windows.10.Amd64.Open
 
 - template: /build/ci/job-template.yml
@@ -183,5 +183,5 @@ jobs:
     innerLoop: true
     vsTestConfiguration: "/Framework:.NETCoreApp,Version=v2.1"
     pool:
-      name: Hosted VS2017
+      vmImage: windows-2019
     helixQueue: Windows.10.Amd64.Open

--- a/build/.night-build.yml
+++ b/build/.night-build.yml
@@ -47,7 +47,7 @@ jobs:
         _includeBenchmarkData: true
     nightlyBuild: true
     pool:
-      name:  Hosted Ubuntu 1804
+      vmImage: ubuntu-18.04
 
 - template: /build/ci/job-template.yml
   parameters:
@@ -56,7 +56,7 @@ jobs:
     container: UbuntuContainer
     nightlyBuild: true
     pool:
-      name:  Hosted Ubuntu 1804
+      vmImage: ubuntu-18.04
 
 - template: /build/ci/job-template.yml
   parameters:
@@ -64,7 +64,7 @@ jobs:
     buildScript: ./build.sh
     nightlyBuild: true
     pool:
-      name: Hosted macOS
+      vmImage: macOS-10.15
 
 - template: /build/ci/job-template.yml
   parameters:
@@ -81,7 +81,7 @@ jobs:
         _includeBenchmarkData: true
     nightlyBuild: true
     pool:
-      name: Hosted VS2017
+      vmImage: windows-2019
 
 - template: /build/ci/job-template.yml
   parameters:
@@ -89,7 +89,7 @@ jobs:
     buildScript: build.cmd
     nightlyBuild: true
     pool:
-      name: Hosted VS2017
+      vmImage: windows-2019
 
 - template: /build/ci/job-template.yml
   parameters:
@@ -106,7 +106,7 @@ jobs:
         _includeBenchmarkData: false
     nightlyBuild: true
     pool:
-      name: Hosted VS2017
+      vmImage: windows-2019
 
 - template: /build/ci/job-template.yml
   parameters:
@@ -115,4 +115,4 @@ jobs:
     buildScript: build.cmd
     nightlyBuild: true
     pool:
-      name: Hosted VS2017
+      vmImage: windows-2019

--- a/build/.outer-loop-build.yml
+++ b/build/.outer-loop-build.yml
@@ -45,7 +45,7 @@ jobs:
         _config_short: RI
         _includeBenchmarkData: true
     pool:
-      name:  Hosted Ubuntu 1804
+      vmImage: ubuntu-18.04
 
 - template: /build/ci/job-template.yml
   parameters:
@@ -53,14 +53,14 @@ jobs:
     buildScript: ./build.sh
     container: UbuntuContainer
     pool:
-      name:  Hosted Ubuntu 1804
+      vmImage: ubuntu-18.04
 
 - template: /build/ci/job-template.yml
   parameters:
     name: MacOS_x64_NetCoreApp21
     buildScript: ./build.sh
     pool:
-      name: Hosted macOS
+      vmImage: macOS-10.15
 
 - template: /build/ci/job-template.yml
   parameters:
@@ -76,14 +76,14 @@ jobs:
         _config_short: RI
         _includeBenchmarkData: true
     pool:
-      name: Hosted VS2017
+      vmImage: windows-2019
 
 - template: /build/ci/job-template.yml
   parameters:
     name: Windows_x64_NetCoreApp21
     buildScript: build.cmd
     pool:
-      name: Hosted VS2017
+      vmImage: windows-2019
 
 - template: /build/ci/job-template.yml
   parameters:
@@ -99,7 +99,7 @@ jobs:
         _config_short: RFX
         _includeBenchmarkData: false
     pool:
-      name: Hosted VS2017
+      vmImage: windows-2019
 
 - template: /build/ci/job-template.yml
   parameters:
@@ -107,4 +107,4 @@ jobs:
     architecture: x86
     buildScript: build.cmd
     pool:
-      name: Hosted VS2017
+      vmImage: windows-2019

--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -37,7 +37,7 @@ jobs:
         spaceValue: ' '
       ${{ if eq(parameters.buildScript, './build.sh') }}:
         spaceValue: '%20'
-      ${{ if and(eq(parameters.pool.name, 'Hosted Ubuntu 1804'), contains(parameters.name, 'cross')) }}:
+      ${{ if and(eq(parameters.pool.vmImage, 'ubuntu-18.04'), contains(parameters.name, 'cross')) }}:
         ROOTFS_DIR: '/crossrootfs/${{ parameters.architecture }}'
       ${{ if eq(parameters.testTargetFramework, '') }}:
         testTargetFramework: ''
@@ -66,31 +66,31 @@ jobs:
 
     steps:
     # Work around MacOS Homebrew image/environment bug: https://github.com/actions/virtual-environments/issues/2322#issuecomment-749211076
-    - ${{ if eq(parameters.pool.name, 'Hosted macOS') }}:
+    - ${{ if eq(parameters.pool.vmImage, 'macOS-10.15') }}:
       - script: |
           rm -rf /usr/local/bin/2to3
         displayName: MacOS Homebrew bug Workaround
         continueOnError: true
     # Extra MacOS step required to install OS-specific dependencies
-    - ${{ if and(eq(parameters.pool.name, 'Hosted macOS'), not(contains(parameters.name, 'cross')))  }}:
+    - ${{ if and(eq(parameters.pool.vmImage, 'macOS-10.15'), not(contains(parameters.name, 'cross')))  }}:
       - script: brew update && brew install mono-libgdiplus && brew install $(Build.SourcesDirectory)/build/libomp.rb --build-from-source --formula && brew link libomp --force
         displayName: Install MacOS build dependencies
     # Extra Apple MacOS step required to install OS-specific dependencies
     - ${{ if and(contains(parameters.pool.vmImage, 'macOS'), contains(parameters.name, 'cross'))  }}:
       - script: brew update && brew install mono-libgdiplus && brew install libomp && brew link libomp --force
         displayName: Install MacOS ARM build dependencies
-    - ${{ if and( eq(parameters.nightlyBuild, 'true'), eq(parameters.pool.name, 'Hosted Ubuntu 1804')) }}:
+    - ${{ if and( eq(parameters.nightlyBuild, 'true'), eq(parameters.pool.vmImage, 'ubuntu-18.04')) }}:
       - bash: echo "##vso[task.setvariable variable=LD_LIBRARY_PATH]$(nightlyBuildRunPath):$LD_LIBRARY_PATH"
         displayName: Set LD_LIBRARY_PATH for Ubuntu and CentOS to locate Native shared library in current running path
     - script: ${{ parameters.buildScript }} -configuration $(_configuration) /p:TargetArchitecture=${{ parameters.architecture }} /p:TestArchitectures=${{ parameters.architecture }} /p:Coverage=${{ parameters.codeCoverage }} $(testTargetFramework)
       displayName: Build
-    - ${{ if eq(parameters.pool.name, 'Hosted macOS') }}:
+    - ${{ if eq(parameters.pool.vmImage, 'macOS-10.15') }}:
       - task: Bash@3
         inputs:
           targetType: inline
           script: cd packages;find . -type d -path "*/runtimes/linux-*"  -exec rm -rv {} +;find . -type d -path "*/runtimes/win-*"  -exec rm -rv {} +;cd ..
         displayName: Clean up non-MacOS runtime folders of NuGet Packages to save disk space
-    - ${{ if eq(parameters.pool.name, 'Hosted Ubuntu 1804') }}:
+    - ${{ if eq(parameters.pool.vmImage, 'ubuntu-18.04') }}:
       - task: Bash@3
         inputs:
           targetType: inline


### PR DESCRIPTION
With Ubuntu 16.04 queues no longer being supported in Azure devops https://github.com/actions/virtual-environments/issues/3287, this PR switches all the Ubuntu queues (not the docker images yet) from 16.04 to 18.04.