### PR TITLE
Fixes for ssh cert

### DIFF
--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -116,7 +116,7 @@ jobs:
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
     DOTNET_MULTILEVEL_LOOKUP: 0
   pool:
-    name: Hosted macOS
+    vmImage: macOS-10.15
   steps:
   # Work around MacOS Homebrew image/environment bug: https://github.com/actions/virtual-environments/issues/2322#issuecomment-749211076
   - script: |


### PR DESCRIPTION
`Hosted MacOs` pool, the old way of specifying your vm image, is having issues with SSH certs. Our CI build had switched entirely to the new way to specify vm image, but the official build hadn't. This PR switches to the new format so that we can fix the SSH issue.

Hosted MacOs is using 10.14, which went out of service about a week ago which is why the cert is expiring now. Switching to 10.15, which is still in support fixes this.