### PR TITLE
LightGBM parameter changes to match Python implementation results

### DIFF
--- a/src/Microsoft.ML.LightGbm/LightGbmBinaryTrainer.cs
+++ b/src/Microsoft.ML.LightGbm/LightGbmBinaryTrainer.cs
@@ -155,7 +155,7 @@ namespace Microsoft.ML.Trainers.LightGbm
             /// </summary>
             [Argument(ArgumentType.AtMostOnce, HelpText = "Parameter for the sigmoid function.", ShortName = "sigmoid")]
             [TGUI(Label = "Sigmoid", SuggestedSweeps = "0.5,1")]
-            public double Sigmoid = 0.5;
+            public double Sigmoid = 1;
 
             /// <summary>
             /// Determines what evaluation metric to use.

--- a/src/Microsoft.ML.LightGbm/LightGbmBinaryTrainer.cs
+++ b/src/Microsoft.ML.LightGbm/LightGbmBinaryTrainer.cs
@@ -163,7 +163,7 @@ namespace Microsoft.ML.Trainers.LightGbm
             [Argument(ArgumentType.AtMostOnce,
                 HelpText = "Evaluation metrics.",
                 ShortName = "em")]
-            public EvaluateMetricType EvaluationMetric = EvaluateMetricType.Logloss;
+            public EvaluateMetricType EvaluationMetric = EvaluateMetricType.None;
 
             static Options()
             {

--- a/src/Microsoft.ML.LightGbm/LightGbmTrainerBase.cs
+++ b/src/Microsoft.ML.LightGbm/LightGbmTrainerBase.cs
@@ -57,7 +57,7 @@ namespace Microsoft.ML.Trainers.LightGbm
                {nameof(CategoricalSmoothing),                 "cat_smooth" },
                {nameof(L2CategoricalRegularization),          "cat_l2" },
                {nameof(HandleMissingValue),                   "use_missing" },
-               {nameof(UseZeroAsMissingValue),                "zero_as_missing" }
+               {nameof(UseZeroAsMissingValue),                "zero_as_missing" },
                {nameof(NumberOfIterations),                   "num_trees" }
             };
 

--- a/src/Microsoft.ML.LightGbm/LightGbmTrainerBase.cs
+++ b/src/Microsoft.ML.LightGbm/LightGbmTrainerBase.cs
@@ -277,6 +277,8 @@ namespace Microsoft.ML.Trainers.LightGbm
                 res[GetOptionName(nameof(CategoricalSmoothing))] = CategoricalSmoothing;
                 res[GetOptionName(nameof(L2CategoricalRegularization))] = L2CategoricalRegularization;
                 res[GetOptionName(nameof(NumberOfIterations))] = NumberOfIterations;
+                res[GetOptionName(nameof(LearningRate))] = LearningRate;
+                res[GetOptionName(nameof(MinimumExampleCountPerLeaf))] = MinimumExampleCountPerLeaf;
 
                 return res;
             }

--- a/src/Microsoft.ML.LightGbm/LightGbmTrainerBase.cs
+++ b/src/Microsoft.ML.LightGbm/LightGbmTrainerBase.cs
@@ -276,6 +276,7 @@ namespace Microsoft.ML.Trainers.LightGbm
                 res[GetOptionName(nameof(MaximumCategoricalSplitPointCount))] = MaximumCategoricalSplitPointCount;
                 res[GetOptionName(nameof(CategoricalSmoothing))] = CategoricalSmoothing;
                 res[GetOptionName(nameof(L2CategoricalRegularization))] = L2CategoricalRegularization;
+                res[GetOptionName(nameof(NumberOfIterations))] = NumberOfIterations;
 
                 return res;
             }

--- a/src/Microsoft.ML.LightGbm/LightGbmTrainerBase.cs
+++ b/src/Microsoft.ML.LightGbm/LightGbmTrainerBase.cs
@@ -58,6 +58,7 @@ namespace Microsoft.ML.Trainers.LightGbm
                {nameof(L2CategoricalRegularization),          "cat_l2" },
                {nameof(HandleMissingValue),                   "use_missing" },
                {nameof(UseZeroAsMissingValue),                "zero_as_missing" }
+               {nameof(NumberOfIterations),                   "num_trees" }
             };
 
             private protected string GetOptionName(string name)

--- a/src/Microsoft.ML.LightGbm/LightGbmTrainerBase.cs
+++ b/src/Microsoft.ML.LightGbm/LightGbmTrainerBase.cs
@@ -58,7 +58,7 @@ namespace Microsoft.ML.Trainers.LightGbm
                {nameof(L2CategoricalRegularization),          "cat_l2" },
                {nameof(HandleMissingValue),                   "use_missing" },
                {nameof(UseZeroAsMissingValue),                "zero_as_missing" },
-               {nameof(NumberOfIterations),                   "num_trees" }
+               {nameof(NumberOfIterations),                   "num_iterations" }
             };
 
             private protected string GetOptionName(string name)

--- a/src/Microsoft.ML.LightGbm/LightGbmTrainerBase.cs
+++ b/src/Microsoft.ML.LightGbm/LightGbmTrainerBase.cs
@@ -265,11 +265,9 @@ namespace Microsoft.ML.Trainers.LightGbm
                 if (NumberOfThreads.HasValue)
                     res["nthread"] = NumberOfThreads.Value;
 
-                // keep lightgbm default seed if it has not been specified in Seed
+                // keep lightgbm default seed if it has not been specified in Seed property
                 if (Seed.HasValue)
-                {
                     res["seed"] = Seed;
-                }
 
                 res[GetOptionName(nameof(MaximumBinCountPerFeature))] = MaximumBinCountPerFeature;
                 res[GetOptionName(nameof(HandleMissingValue))] = HandleMissingValue;

--- a/src/Microsoft.ML.LightGbm/LightGbmTrainerBase.cs
+++ b/src/Microsoft.ML.LightGbm/LightGbmTrainerBase.cs
@@ -264,7 +264,11 @@ namespace Microsoft.ML.Trainers.LightGbm
                 if (NumberOfThreads.HasValue)
                     res["nthread"] = NumberOfThreads.Value;
 
-                res["seed"] = (Seed.HasValue) ? Seed : host.Rand.Next();
+                // keep lightgbm default seed if it has not been specified in Seed
+                if (Seed.HasValue)
+                {
+                    res["seed"] = Seed;
+                }
 
                 res[GetOptionName(nameof(MaximumBinCountPerFeature))] = MaximumBinCountPerFeature;
                 res[GetOptionName(nameof(HandleMissingValue))] = HandleMissingValue;

--- a/src/Microsoft.ML.LightGbm/LightGbmTrainerBase.cs
+++ b/src/Microsoft.ML.LightGbm/LightGbmTrainerBase.cs
@@ -277,8 +277,6 @@ namespace Microsoft.ML.Trainers.LightGbm
                 res[GetOptionName(nameof(CategoricalSmoothing))] = CategoricalSmoothing;
                 res[GetOptionName(nameof(L2CategoricalRegularization))] = L2CategoricalRegularization;
                 res[GetOptionName(nameof(NumberOfIterations))] = NumberOfIterations;
-                res[GetOptionName(nameof(LearningRate))] = LearningRate;
-                res[GetOptionName(nameof(MinimumExampleCountPerLeaf))] = MinimumExampleCountPerLeaf;
 
                 return res;
             }


### PR DESCRIPTION
Suggested changes for LightGBM results through ML.NET similar as through Python:
* keep LightGBM default seed if seed has not been set
* add mapping from NumberOfIterations to num_iterations
* add NumberOfIterations to parameters array for LightGBM
* change sigmoid default value to match LightGBM
* Default Evaluation Metric to None per LightGBM default

Project that can be used for comparison between LightGBM in Python and Microsoft.ML.LightGBM and also compare ModelBuilder with python-FLAML: https://github.com/torronen/lightgbm-comparison

Rationale: https://github.com/microsoft/FLAML/discussions/409#discussioncomment-2058431
Reasons for changes explained in the issues:
* fixes #6063 
* fixes #6062 
* fixes #654

I suggest the results should be equal through Python and ML.NET so that developers can discuss and share best practices about hyperparameters. Also, it enables to use tuning from Python. 

Sigmoid value change has been propose before but was not implemented.
It may need more consideration:  https://github.com/dotnet/machinelearning/pull/667

PR is for comments and discussions for now. Results are not yet equal through ML.Net and Python.