### PR TITLE
Use LightGBM default seed if not set explicitly

### DIFF
--- a/src/Microsoft.ML.LightGbm/LightGbmTrainerBase.cs
+++ b/src/Microsoft.ML.LightGbm/LightGbmTrainerBase.cs
@@ -261,10 +261,12 @@ namespace Microsoft.ML.Trainers.LightGbm
                 res["boosting_type"] = boosterParams.BoosterName;
 
                 res["verbose"] = Silent ? "-1" : "1";
+
                 if (NumberOfThreads.HasValue)
                     res["nthread"] = NumberOfThreads.Value;
 
-                res["seed"] = (Seed.HasValue) ? Seed : host.Rand.Next();
+                if (Seed.HasValue)
+                    res["seed"] = Seed;
 
                 res[GetOptionName(nameof(MaximumBinCountPerFeature))] = MaximumBinCountPerFeature;
                 res[GetOptionName(nameof(HandleMissingValue))] = HandleMissingValue;


### PR DESCRIPTION

 - Fixes #6062 
 
LightGBM has a default value for seeds. If we set random_seed, then more specific seeds will get overridden. ML.NET interface does not provide option to set the other seeds explicitly. This makes it impossible to train LightGBM with default values. Further, if we a new random seed is set from MLContext it may change for each call. This will affect models which use feature_fraction or other features which use randomity

This PR updates LightGBM to not set seed from .NET unless it has been explicitly set.

Links:
https://lightgbm.readthedocs.io/en/latest/Parameters.html#seed
