### PR TITLE
Fixed PFI bug with transformer chains

### DIFF
--- a/src/Microsoft.ML.Transforms/PermutationFeatureImportanceExtensions.cs
+++ b/src/Microsoft.ML.Transforms/PermutationFeatureImportanceExtensions.cs
@@ -665,9 +665,9 @@ namespace Microsoft.ML
 
             ISingleFeaturePredictionTransformer lastTransformer = null;
 
-            if (model is TransformerChain<ITransformer> chain)
+            if (model is ITransformerChainAccessor chain)
             {
-                foreach (var transformer in chain.Reverse())
+                foreach (var transformer in chain.Transformers.Reverse())
                 {
                     if (transformer is ISingleFeaturePredictionTransformer singlePredictionTransformer)
                     {


### PR DESCRIPTION
Fixes #6027 

The new pfi APi we added to make it easier for users has an issue with handling Transformer chains incorrectly. This PR fixes that and adds a test using Transformer chains.