### PR TITLE
upgrade to .NET Interactive 1.0.0-beta.22103.1

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -31,8 +31,8 @@
     <TensorFlowMajorVersion>2</TensorFlowMajorVersion>
     <TensorflowDotNETVersion>0.20.1</TensorflowDotNETVersion>
     <MicrosoftCodeAnalysisCSharpInternalAnalyzerVersion>3.3.1</MicrosoftCodeAnalysisCSharpInternalAnalyzerVersion>
-    <MicrosoftDotNetInteractiveVersion>1.0.0-beta.21155.3</MicrosoftDotNetInteractiveVersion>
-    <MicrosoftDotNetInteractiveFormattingVersion>1.0.0-beta.21155.3</MicrosoftDotNetInteractiveFormattingVersion>
+    <MicrosoftDotNetInteractiveVersion>1.0.0-beta.22103.1</MicrosoftDotNetInteractiveVersion>
+    <MicrosoftDotNetInteractiveFormattingVersion>1.0.0-beta.22103.1</MicrosoftDotNetInteractiveFormattingVersion>
     <ApacheArrowVersion>2.0.0</ApacheArrowVersion>
     <SystemTextEncodingVersion>4.3.0</SystemTextEncodingVersion>
     <MicrosoftCSharpVersion>4.5.0</MicrosoftCSharpVersion>

--- a/test/Microsoft.Data.Analysis.Interactive.Tests/DataFrameInteractiveTests.cs
+++ b/test/Microsoft.Data.Analysis.Interactive.Tests/DataFrameInteractiveTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Linq;
+using System.Text.RegularExpressions;
 using Microsoft.DotNet.Interactive.Formatting;
 using Xunit;
 
@@ -10,7 +11,7 @@ namespace Microsoft.Data.Analysis.Interactive.Tests
 {
     public class DataFrameInteractiveTests
     {
-        private const string ButtonHtmlPart = "button onclick";
+        private Regex _buttonHtmlPart = new Regex(@"<\s*button.*onclick=.*>");
         private const string TableHtmlPart = "<table";
 
         public static DataFrame MakeDataFrameWithTwoColumns(int length, bool withNulls = true)
@@ -36,7 +37,7 @@ namespace Microsoft.Data.Analysis.Interactive.Tests
             var html = dataFrame.ToDisplayString("text/html");
 
             Assert.Contains(TableHtmlPart, html);
-            Assert.DoesNotContain(ButtonHtmlPart, html);
+            Assert.DoesNotMatch(_buttonHtmlPart, html);
         }
 
         [Fact]
@@ -47,7 +48,7 @@ namespace Microsoft.Data.Analysis.Interactive.Tests
             var html = dataFrame.ToDisplayString("text/html");
 
             Assert.Contains(TableHtmlPart, html);
-            Assert.Contains(ButtonHtmlPart, html);
+            Assert.Matches(_buttonHtmlPart, html);
         }
 
         [Fact]
@@ -58,7 +59,7 @@ namespace Microsoft.Data.Analysis.Interactive.Tests
             var html = dataFrame.Info().ToDisplayString("text/html");
 
             Assert.Contains(TableHtmlPart, html);
-            Assert.DoesNotContain(ButtonHtmlPart, html);
+            Assert.DoesNotMatch(_buttonHtmlPart, html);
         }
     }
 }

--- a/test/Microsoft.Data.Analysis.Interactive.Tests/Microsoft.Data.Analysis.Interactive.Tests.csproj
+++ b/test/Microsoft.Data.Analysis.Interactive.Tests/Microsoft.Data.Analysis.Interactive.Tests.csproj
@@ -7,8 +7,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.Data.Analysis.Interactive\Microsoft.Data.Analysis.Interactive.csproj" />
 
-    <!-- work around https://github.com/dotnet/runtime/issues/45560 until System.Text.Json is fixed and Microsoft.DotNet.Interactive updates to the new version -->
-    <PackageReference Include=" System.Text.Encodings.Web" Version="5.0.1" />
+    <PackageReference Include=" System.Text.Encodings.Web" Version="6.0.0" />
   </ItemGroup>
 
   <!-- register for test discovery in Visual Studio -->


### PR DESCRIPTION
Upgrade .NET Interactive dependencies to version 1.0.0-beta.22103.1, the latest available in nuget feed.
Fix workaround in tests by updating test dependency to System.Text.Encodings.Web 6.0.0
