### PR TITLE
create a data frame from tabular data resource

### DIFF
--- a/src/Microsoft.Data.Analysis.Interactive/TabularDataResourceExtensions.cs
+++ b/src/Microsoft.Data.Analysis.Interactive/TabularDataResourceExtensions.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Linq;
+using Microsoft.Data.Analysis;
+
+
+namespace Microsoft.DotNet.Interactive.Formatting.TabularData
+{
+    public static class TabularDataResourceExtensions
+    {
+        public static DataFrame ToDataFrame(this TabularDataResource tabularDataResource)
+        {
+            if (tabularDataResource == null)
+            {
+                throw new ArgumentNullException(nameof(tabularDataResource));
+            }
+
+            var dataFrame = new DataFrame();
+
+            foreach (var fieldDescriptor in tabularDataResource.Schema.Fields)
+            {
+                switch (fieldDescriptor.Type)
+                {
+                    case TableSchemaFieldType.Number:
+                        dataFrame.Columns.Add(new DoubleDataFrameColumn(fieldDescriptor.Name, tabularDataResource.Data.Select(d => Convert.ToDouble(d[fieldDescriptor.Name]))));
+                        break;
+                    case TableSchemaFieldType.Integer:
+                        dataFrame.Columns.Add(new Int64DataFrameColumn(fieldDescriptor.Name, tabularDataResource.Data.Select(d => Convert.ToInt64(d[fieldDescriptor.Name]))));
+                        break;
+                    case TableSchemaFieldType.Boolean:
+                        dataFrame.Columns.Add(new BooleanDataFrameColumn(fieldDescriptor.Name, tabularDataResource.Data.Select(d => Convert.ToBoolean(d[fieldDescriptor.Name]))));
+                        break;
+                    case TableSchemaFieldType.String:
+                        dataFrame.Columns.Add(new StringDataFrameColumn(fieldDescriptor.Name, tabularDataResource.Data.Select(d => Convert.ToString(d[fieldDescriptor.Name]))));
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+            }
+            return dataFrame;
+        }
+    }
+}

--- a/test/Microsoft.Data.Analysis.Interactive.Tests/DataFrameInteractiveTests.cs
+++ b/test/Microsoft.Data.Analysis.Interactive.Tests/DataFrameInteractiveTests.cs
@@ -2,9 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Microsoft.DotNet.Interactive.Formatting;
+using Microsoft.DotNet.Interactive.Formatting.TabularData;
 using Xunit;
 
 namespace Microsoft.Data.Analysis.Interactive.Tests
@@ -60,6 +63,33 @@ namespace Microsoft.Data.Analysis.Interactive.Tests
 
             Assert.Contains(TableHtmlPart, html);
             Assert.DoesNotMatch(_buttonHtmlPart, html);
+        }
+
+        [Fact]
+        public void LoadFromTabularDataResource()
+        {
+            var schema = new TableSchema();
+            schema.Fields.Add(new TableSchemaFieldDescriptor("TrueOrFalse", TableSchemaFieldType.Boolean));
+            schema.Fields.Add(new TableSchemaFieldDescriptor("Integer", TableSchemaFieldType.Integer));
+            schema.Fields.Add(new TableSchemaFieldDescriptor("Double", TableSchemaFieldType.Number));
+            schema.Fields.Add(new TableSchemaFieldDescriptor("Text", TableSchemaFieldType.String));
+            var data = new List<IDictionary<string, object>>();
+
+            for (var i = 0; i < 5; i++)
+            {
+                data.Add(new Dictionary<string, object>
+                {
+                    ["TrueOrFalse"] = ((i % 2) == 0),
+                    ["Integer"] = i,
+                    ["Double"] = i / 0.5,
+                    ["Text"] = $"hello {i}!"
+                });
+            }
+
+            var tableData = new TabularDataResource(schema, data);
+
+            var dataFrame = tableData.ToDataFrame();
+            Assert.Equal(dataFrame.Columns.Select(c => c.Name).ToArray(), new[] { "TrueOrFalse", "Integer", "Double", "Text" });
         }
     }
 }


### PR DESCRIPTION
Adding api to create DataFrame objects from .NET Interactive tabular data resource.
This enables users to convert KQL and SQL kernel values to dataframe in notebooks