### PR TITLE
Update versioning to 1.7.1 / 0.19.1

### DIFF
--- a/eng/BranchInfo.props
+++ b/eng/BranchInfo.props
@@ -30,11 +30,11 @@
   <PropertyGroup Condition="'$(IsStableProject)' == 'true'">
     <MajorVersion>1</MajorVersion>
     <MinorVersion>7</MinorVersion>
-    <PatchVersion>0</PatchVersion>
+    <PatchVersion>1</PatchVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(IsStableProject)' != 'true'">
     <MajorVersion>0</MajorVersion>
     <MinorVersion>19</MinorVersion>
-    <PatchVersion>0</PatchVersion>
+    <PatchVersion>1</PatchVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
I missed this in the initial branding change.  In other repos we only define this in Versions.props.  Probably we should consolidate this moving forward.