### PR TITLE
Add callback for Merge procedure to filter out not suitable rows

### DIFF
--- a/src/Microsoft.Data.Analysis/DataFrame.Join.cs
+++ b/src/Microsoft.Data.Analysis/DataFrame.Join.cs
@@ -188,7 +188,7 @@ namespace Microsoft.Data.Analysis
 
             bool isLeftDataFrameRetained = IsLeftDataFrameRetained(retainedDataFrame, supplementaryDataFrame, joinAlgorithm);
 
-            return PerformMerging(retainedDataFrame, isLeftDataFrameRetained, retainedJoinColumnNames, occurrences, supplementaryJoinColumnsNullIndices,
+            return PerformMerging(retainedDataFrame, retainedJoinColumnNames, isLeftDataFrameRetained, occurrences, supplementaryJoinColumnsNullIndices,
                 out retainedRowIndices, out supplementaryRowIndices, isInner, calculateIntersection, canAcceptRow);
         }
 
@@ -275,8 +275,8 @@ namespace Microsoft.Data.Analysis
             return shrinkedOccurences;
         }
 
-        private static HashSet<long> PerformMerging(DataFrame retainedDataFrame, bool isLeftDataFrameRetained,
-            string[] retainedJoinColumnNames, Dictionary<long, ICollection<long>> occurrences, HashSet<long> supplementaryJoinColumnsNullIndices,
+        private static HashSet<long> PerformMerging(DataFrame retainedDataFrame, string[] retainedJoinColumnNames, bool isLeftDataFrameRetained,
+            Dictionary<long, ICollection<long>> occurrences, HashSet<long> supplementaryJoinColumnsNullIndices,
             out PrimitiveDataFrameColumn<long> retainedRowIndices, out PrimitiveDataFrameColumn<long> supplementaryRowIndices,
             bool isInner, bool calculateIntersection,
             Func<long?, long?, bool> canAcceptRow = null)
@@ -338,7 +338,7 @@ namespace Microsoft.Data.Analysis
                         long? leftDataFrameIndex = isLeftDataFrameRetained ? i : row;
                         long? rightDataFrameIndex = isLeftDataFrameRetained ? row : i;
 
-                        if (canAcceptRow != null || canAcceptRow(leftDataFrameIndex, rightDataFrameIndex))
+                        if (canAcceptRow == null || canAcceptRow(leftDataFrameIndex, rightDataFrameIndex))
                         {
                             retainedRowIndices.Append(i);
                             supplementaryRowIndices.Append(row);


### PR DESCRIPTION
We've experienced the following limitation in DataFrame's Merge procedure:

During the merging of two data frames with output ~20M rows it would be great to filter out not acceptable rows if possible (i.e. to have ability to check that the current row for left data frame (some columns) with the current row for right data frame (same or different columns) - is a incorrect combination and can be removed from the result). We can filter out that rows on the fly - and that's the idea.

Another idea - is apply filtering on the result when the merge is completed, but when count of rows ~20M (and ~100 columns) it requires a lot of time and memory (provide one more data frame with some amount of rows filtered) - is too expensive on big data.

So I proposed to add callback with signature:

bool canAcceptRow (long? leftDataFrameRowIndex, long? rightDataFrameRowIndex);

and on the caller side we can provide some filtration if needed (we have left/right data frames and their indexes). If callback is null then it will be ignored - no affected the current behaviour.

