### PR TITLE
Update some test package dependencies

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -39,6 +39,10 @@
       <Uri>https://github.com/dotnet/xharness</Uri>
       <Sha>89cb4b1d368e0f15b4df8e02a176dd1f1c33958b</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="7.0.0-beta.22215.2">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>4000024394df3049886c50e54ad0a2b903221ef0</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="3.8.0-3.20460.2">
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>d57cda76c2b76cff75487a085d289cfadd99150b</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -113,9 +113,7 @@
     <SystemThreadingTasksExtensionVersion>4.5.2</SystemThreadingTasksExtensionVersion>
     <SystemValueTupleVersion>4.4.0</SystemValueTupleVersion>
     <WindowsAzureStorageVersion>8.5.0</WindowsAzureStorageVersion>
-    <XUnitVersion>2.4.0</XUnitVersion>
-    <XUnitAbstractionsVersion>2.0.3</XUnitAbstractionsVersion>
-    <XUnitVSRunnerVersion>2.4.0</XUnitVSRunnerVersion>
+    <XUnitVersion>2.4.2-pre.9</XUnitVersion>
     <MicrosoftDotNetBuildTasksFeedVersion>7.0.0-beta.22215.2</MicrosoftDotNetBuildTasksFeedVersion>
     <MicrosoftDotNetSignToolVersion>7.0.0-beta.22215.2</MicrosoftDotNetSignToolVersion>
     <MicrosoftAzureDocumentDBVersion>1.22.0</MicrosoftAzureDocumentDBVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -58,6 +58,7 @@
     <SystemDataSqlClientVersion>4.6.1</SystemDataSqlClientVersion>
     <XunitCombinatorialVersion>1.2.7</XunitCombinatorialVersion>
     <SystemDataSQLiteCoreVersion>1.0.112.2</SystemDataSQLiteCoreVersion>
+    <MicrosoftDotNetXUnitExtensionsVersion>7.0.0-beta.22215.2</MicrosoftDotNetXUnitExtensionsVersion>
     <!-- Opt-out repo features -->
     <UsingToolXliff>false</UsingToolXliff>
     <UsingToolNetFrameworkReferenceAssemblies Condition="'$(DotNetBuildFromSource)' != 'true'">true</UsingToolNetFrameworkReferenceAssemblies>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -30,8 +30,14 @@
     <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
     <PackageReference Include="Xunit.Combinatorial" Version="$(XunitCombinatorialVersion)" />
-    <PackageReference Include="Microsoft.DotNet.XUnitExtensions" Version="2.4.0-prerelease-63213-02" />
+    <PackageReference Include="Microsoft.DotNet.XUnitExtensions" Version="$(MicrosoftDotNetXUnitExtensionsVersion)" />
     <PackageReference Include="coverlet.collector" Version="$(CoverletCollectorVersion)" />
+
+    <!-- workaround stale references in test packages by 
+         1) updating NETStandard.Library - the newer version brings less references on netstandard2.0 compatible frameworks.
+         2) updating Microsoft.NETCore.Targets - the newer version prevents .NETCore 1.x era runtime.* packages from being referenced. -->
+    <PackageReference Include="NETStandard.Library" Version="2.0.3" />
+    <PackageReference Include="Microsoft.NETCore.Targets" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -7,6 +7,7 @@
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('OSX')) AND '$(TargetArchitecture)' == 'arm64'">net6.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(TestTargetFramework)' != ''">$(TestTargetFramework)</TargetFrameworks>
     <RuntimeIdentifier Condition="'$(TargetFramework)' == 'net461'">win-x64</RuntimeIdentifier>
+    <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GenerateDependencyFile>true</GenerateDependencyFile>


### PR DESCRIPTION
Avoid referencing some 1.x era packages.

Add a subscription for Microsoft.DotNet.XUnitExtensions since that comes from Arcade.

This is just a workaround, best fix would be to have all these packages target newer frameworks.
- https://github.com/microsoft/testfx/issues/1073
- https://github.com/AArnott/Xunit.Combinatorial/commit/309bc69c924401271ec865e0de999294cab2a7f3
- Update to xUnit 3.0

