### PR TITLE
Updating codecov to newer vm

### DIFF
--- a/build/codecoverage-ci.yml
+++ b/build/codecoverage-ci.yml
@@ -15,4 +15,4 @@ jobs:
         _targetFramework: netcoreapp3.1
     codeCoverage: true
     pool:
-      name: Hosted VS2017
+      vmImage: windows-2019


### PR DESCRIPTION
windows 2017 is now supposed to be deprecated. updating codecov build to be on newer vm.
