### PR TITLE
Regenerate fabricbot config to include several new automation tasks

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -327,7 +327,7 @@
         {
           "name": "addReply",
           "parameters": {
-            "comment": "This issue has been marked `needs-author-action` since it may be missing important information. Please refer to our [contribution guidelines](https://github.com/dotnet/runtime/blob/main/CONTRIBUTING.md#writing-a-good-bug-report) for tips on how to report issues effectively."
+            "comment": "This issue has been marked `needs-author-action` and may be missing some important information."
           }
         }
       ],

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -6,15 +6,42 @@
     "subCapability": "IssuesOnlyResponder",
     "version": "1.0",
     "config": {
-      "taskName": "Add untriaged label to new issues",
+      "taskName": "Add untriaged label to new/reopened issues without a milestone",
+      "actions": [
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": "untriaged"
+          }
+        }
+      ],
+      "eventType": "issue",
+      "eventNames": [
+        "issues"
+      ],
       "conditions": {
         "operator": "and",
         "operands": [
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "opened"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "name": "isAction",
+                "parameters": {
+                  "action": "opened"
+                }
+              },
+              {
+                "name": "isAction",
+                "parameters": {
+                  "action": "reopened"
+                }
+              },
+              {
+                "name": "removedFromMilestone",
+                "parameters": {}
+              }
+            ]
           },
           {
             "name": "isOpen",
@@ -35,16 +62,26 @@
               {
                 "name": "hasLabel",
                 "parameters": {
-                  "label": "needs-author-action"
+                  "label": "untriaged"
                 }
               }
             ]
           }
         ]
-      },
+      }
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "taskName": "Remove untriaged label from issues when closed or added to a milestone",
       "actions": [
         {
-          "name": "addLabel",
+          "name": "removeLabel",
           "parameters": {
             "label": "untriaged"
           }
@@ -52,9 +89,34 @@
       ],
       "eventType": "issue",
       "eventNames": [
-        "issues",
-        "project_card"
-      ]
+        "issues"
+      ],
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "name": "isAction",
+                "parameters": {
+                  "action": "closed"
+                }
+              },
+              {
+                "name": "addedToMilestone",
+                "parameters": {}
+              }
+            ]
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "untriaged"
+            }
+          }
+        ]
+      }
     }
   },
   {
@@ -77,42 +139,6 @@
     "subCapability": "PullRequestResponder",
     "version": "1.0",
     "config": {
-      "conditions": {
-        "operator": "and",
-        "operands": [
-          {
-            "name": "isAction",
-            "parameters": {
-              "action": "opened"
-            }
-          },
-          {
-            "operator": "or",
-            "operands": [
-              {
-                "name": "activitySenderHasPermissions",
-                "parameters": {
-                  "association": "OWNER",
-                  "permissions": "admin"
-                }
-              },
-              {
-                "name": "activitySenderHasPermissions",
-                "parameters": {
-                  "association": "MEMBER",
-                  "permissions": "write"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "eventType": "pull_request",
-      "eventNames": [
-        "pull_request",
-        "issues",
-        "project_card"
-      ],
       "taskName": "Assign Team PRs to author",
       "actions": [
         {
@@ -123,9 +149,34 @@
             }
           }
         }
-      ]
-    },
-    "disabled": false
+      ],
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request"
+      ],
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isAction",
+            "parameters": {
+              "action": "opened"
+            }
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "activitySenderHasPermissions",
+                "parameters": {
+                  "permissions": "read"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
   },
   {
     "taskSource": "fabricbot-config",
@@ -134,6 +185,19 @@
     "subCapability": "PullRequestResponder",
     "version": "1.0",
     "config": {
+      "taskName": "Label community PRs",
+      "actions": [
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": "community-contribution"
+          }
+        }
+      ],
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request"
+      ],
       "conditions": {
         "operator": "and",
         "operands": [
@@ -152,7 +216,6 @@
                   {
                     "name": "activitySenderHasPermissions",
                     "parameters": {
-                      "association": "OWNER",
                       "permissions": "admin"
                     }
                   }
@@ -164,7 +227,17 @@
                   {
                     "name": "activitySenderHasPermissions",
                     "parameters": {
-                      "association": "MEMBER",
+                      "permissions": "maintain"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "activitySenderHasPermissions",
+                    "parameters": {
                       "permissions": "write"
                     }
                   }
@@ -239,24 +312,8 @@
             ]
           }
         ]
-      },
-      "eventType": "pull_request",
-      "eventNames": [
-        "pull_request",
-        "issues",
-        "project_card"
-      ],
-      "taskName": "Label community PRs",
-      "actions": [
-        {
-          "name": "addLabel",
-          "parameters": {
-            "label": "community-contribution"
-          }
-        }
-      ]
-    },
-    "disabled": false
+      }
+    }
   },
   {
     "taskSource": "fabricbot-config",
@@ -265,6 +322,19 @@
     "subCapability": "IssuesOnlyResponder",
     "version": "1.0",
     "config": {
+      "taskName": "Needs-author-action notification",
+      "actions": [
+        {
+          "name": "addReply",
+          "parameters": {
+            "comment": "This issue has been marked `needs-author-action` since it may be missing important information. Please refer to our [contribution guidelines](https://github.com/dotnet/runtime/blob/main/CONTRIBUTING.md#writing-a-good-bug-report) for tips on how to report issues effectively."
+          }
+        }
+      ],
+      "eventType": "issue",
+      "eventNames": [
+        "issues"
+      ],
       "conditions": {
         "operator": "and",
         "operands": [
@@ -275,21 +345,7 @@
             }
           }
         ]
-      },
-      "eventType": "issue",
-      "eventNames": [
-        "issues",
-        "project_card"
-      ],
-      "taskName": "Needs-author-action notification",
-      "actions": [
-        {
-          "name": "addReply",
-          "parameters": {
-            "comment": "This issue has been marked `needs-author-action` since it may be missing important information. Please refer to our [contribution guidelines](https://github.com/dotnet/runtime/blob/main/CONTRIBUTING.md#writing-a-good-bug-report) for tips on how to report issues effectively."
-          }
-        }
-      ]
+      }
     }
   },
   {
@@ -299,15 +355,33 @@
     "subCapability": "PullRequestReviewResponder",
     "version": "1.0",
     "config": {
+      "taskName": "PR reviews with \"changes requested\" applies the needs-author-action label",
+      "actions": [
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": "needs-author-action"
+          }
+        }
+      ],
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request_review"
+      ],
       "conditions": {
         "operator": "and",
         "operands": [
           {
-            "name": "activitySenderHasPermissions",
-            "parameters": {
-              "state": "changes_requested",
-              "permissions": "write"
-            }
+            "operator": "not",
+            "operands": [
+              {
+                "name": "activitySenderHasPermissions",
+                "parameters": {
+                  "state": "changes_requested",
+                  "permissions": "read"
+                }
+              }
+            ]
           },
           {
             "name": "isAction",
@@ -322,20 +396,7 @@
             }
           }
         ]
-      },
-      "eventType": "pull_request",
-      "eventNames": [
-        "pull_request_review"
-      ],
-      "taskName": "PR reviews with \"changes requested\" applies the needs-author-action label",
-      "actions": [
-        {
-          "name": "addLabel",
-          "parameters": {
-            "label": "needs-author-action"
-          }
-        }
-      ]
+      }
     }
   },
   {
@@ -346,35 +407,6 @@
     "version": "1.0",
     "config": {
       "taskName": "Replace `needs-author-action` label with `needs-further-triage` label when the author comments on an issue",
-      "conditions": {
-        "operator": "and",
-        "operands": [
-          {
-            "name": "isAction",
-            "parameters": {
-              "action": "created"
-            }
-          },
-          {
-            "name": "isActivitySender",
-            "parameters": {
-              "user": {
-                "type": "author"
-              }
-            }
-          },
-          {
-            "name": "hasLabel",
-            "parameters": {
-              "label": "needs-author-action"
-            }
-          },
-          {
-            "name": "isOpen",
-            "parameters": {}
-          }
-        ]
-      },
       "actions": [
         {
           "name": "addLabel",
@@ -392,7 +424,36 @@
       "eventType": "issue",
       "eventNames": [
         "issue_comment"
-      ]
+      ],
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isAction",
+            "parameters": {
+              "action": "created"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": {
+                "type": "author"
+              }
+            }
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "needs-author-action"
+            }
+          },
+          {
+            "name": "isOpen",
+            "parameters": {}
+          }
+        ]
+      }
     }
   },
   {
@@ -402,6 +463,19 @@
     "subCapability": "PullRequestResponder",
     "version": "1.0",
     "config": {
+      "taskName": "Pushing changes to PR branch removes the needs-author-action label",
+      "actions": [
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": "needs-author-action"
+          }
+        }
+      ],
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request"
+      ],
       "conditions": {
         "operator": "and",
         "operands": [
@@ -418,22 +492,7 @@
             }
           }
         ]
-      },
-      "eventType": "pull_request",
-      "eventNames": [
-        "pull_request",
-        "issues",
-        "project_card"
-      ],
-      "taskName": "Pushing changes to PR branch removes the needs-author-action label",
-      "actions": [
-        {
-          "name": "removeLabel",
-          "parameters": {
-            "label": "needs-author-action"
-          }
-        }
-      ]
+      }
     }
   },
   {
@@ -443,6 +502,19 @@
     "subCapability": "PullRequestCommentResponder",
     "version": "1.0",
     "config": {
+      "taskName": "Author commenting in PR removes the needs-author-action label",
+      "actions": [
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": "needs-author-action"
+          }
+        }
+      ],
+      "eventType": "pull_request",
+      "eventNames": [
+        "issue_comment"
+      ],
       "conditions": {
         "operator": "and",
         "operands": [
@@ -471,22 +543,8 @@
             "parameters": {}
           }
         ]
-      },
-      "eventType": "pull_request",
-      "eventNames": [
-        "issue_comment"
-      ],
-      "taskName": "Author commenting in PR removes the needs-author-action label",
-      "actions": [
-        {
-          "name": "removeLabel",
-          "parameters": {
-            "label": "needs-author-action"
-          }
-        }
-      ]
-    },
-    "disabled": false
+      }
+    }
   },
   {
     "taskSource": "fabricbot-config",
@@ -496,6 +554,18 @@
     "version": "1.0",
     "config": {
       "taskName": "Author responding to a pull request review comment removes the needs-author-action label",
+      "actions": [
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": "needs-author-action"
+          }
+        }
+      ],
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request_review"
+      ],
       "conditions": {
         "operator": "and",
         "operands": [
@@ -524,19 +594,7 @@
             "parameters": {}
           }
         ]
-      },
-      "actions": [
-        {
-          "name": "removeLabel",
-          "parameters": {
-            "label": "needs-author-action"
-          }
-        }
-      ],
-      "eventType": "pull_request",
-      "eventNames": [
-        "pull_request_review"
-      ]
+      }
     }
   },
   {
@@ -547,6 +605,20 @@
     "version": "1.1",
     "config": {
       "taskName": "Add no-recent-activity label to issues",
+      "actions": [
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": "no-recent-activity"
+          }
+        },
+        {
+          "name": "addReply",
+          "parameters": {
+            "comment": "This issue has been automatically marked `no-recent-activity` because it has not had any activity for 14 days. It will be closed if no further activity occurs within 14 more days. Any new comment (by anyone, not necessarily the author) will remove `no-recent-activity`."
+          }
+        }
+      ],
       "frequency": [
         {
           "weekDay": 0,
@@ -646,7 +718,17 @@
             "label": "no-recent-activity"
           }
         }
-      ],
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "scheduled",
+    "capabilityId": "ScheduledSearch",
+    "subCapability": "ScheduledSearch",
+    "version": "1.1",
+    "config": {
+      "taskName": "Add no-recent-activity label to PRs",
       "actions": [
         {
           "name": "addLabel",
@@ -657,21 +739,10 @@
         {
           "name": "addReply",
           "parameters": {
-            "comment": "This issue has been automatically marked `no-recent-activity` because it has not had any activity for 14 days. It will be closed if no further activity occurs within 14 more days. Any new comment (by anyone, not necessarily the author) will remove `no-recent-activity`."
+            "comment": "This pull request has been automatically marked `no-recent-activity` because it has not had any activity for 14 days. It will be closed if no further activity occurs within 14 more days. Any new comment (by anyone, not necessarily the author) will remove `no-recent-activity`."
           }
         }
-      ]
-    },
-    "disabled": false
-  },
-  {
-    "taskSource": "fabricbot-config",
-    "taskType": "scheduled",
-    "capabilityId": "ScheduledSearch",
-    "subCapability": "ScheduledSearch",
-    "version": "1.1",
-    "config": {
-      "taskName": "Add no-recent-activity label to PRs",
+      ],
       "frequency": [
         {
           "weekDay": 0,
@@ -771,23 +842,8 @@
             "label": "no-recent-activity"
           }
         }
-      ],
-      "actions": [
-        {
-          "name": "addLabel",
-          "parameters": {
-            "label": "no-recent-activity"
-          }
-        },
-        {
-          "name": "addReply",
-          "parameters": {
-            "comment": "This pull request has been automatically marked `no-recent-activity` because it has not had any activity for 14 days. It will be closed if no further activity occurs within 14 more days. Any new comment (by anyone, not necessarily the author) will remove `no-recent-activity`."
-          }
-        }
       ]
-    },
-    "disabled": false
+    }
   },
   {
     "taskSource": "fabricbot-config",
@@ -797,6 +853,18 @@
     "version": "1.0",
     "config": {
       "taskName": "Remove `no-recent-activity` label from issues when issue is modified",
+      "actions": [
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": "no-recent-activity"
+          }
+        }
+      ],
+      "eventType": "issue",
+      "eventNames": [
+        "issues"
+      ],
       "conditions": {
         "operator": "and",
         "operands": [
@@ -829,20 +897,7 @@
             ]
           }
         ]
-      },
-      "actions": [
-        {
-          "name": "removeLabel",
-          "parameters": {
-            "label": "no-recent-activity"
-          }
-        }
-      ],
-      "eventType": "issue",
-      "eventNames": [
-        "issues",
-        "project_card"
-      ]
+      }
     }
   },
   {
@@ -853,17 +908,6 @@
     "version": "1.0",
     "config": {
       "taskName": "Remove `no-recent-activity` label when an issue is commented on",
-      "conditions": {
-        "operator": "and",
-        "operands": [
-          {
-            "name": "hasLabel",
-            "parameters": {
-              "label": "no-recent-activity"
-            }
-          }
-        ]
-      },
       "actions": [
         {
           "name": "removeLabel",
@@ -875,7 +919,18 @@
       "eventType": "issue",
       "eventNames": [
         "issue_comment"
-      ]
+      ],
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "no-recent-activity"
+            }
+          }
+        ]
+      }
     }
   },
   {
@@ -885,6 +940,19 @@
     "subCapability": "PullRequestResponder",
     "version": "1.0",
     "config": {
+      "taskName": "Remove `no-recent-activity` label from PRs when modified",
+      "actions": [
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": "no-recent-activity"
+          }
+        }
+      ],
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request"
+      ],
       "conditions": {
         "operator": "and",
         "operands": [
@@ -910,22 +978,7 @@
             ]
           }
         ]
-      },
-      "eventType": "pull_request",
-      "eventNames": [
-        "pull_request",
-        "issues",
-        "project_card"
-      ],
-      "taskName": "Remove `no-recent-activity` label from PRs when modified",
-      "actions": [
-        {
-          "name": "removeLabel",
-          "parameters": {
-            "label": "no-recent-activity"
-          }
-        }
-      ]
+      }
     }
   },
   {
@@ -935,6 +988,19 @@
     "subCapability": "PullRequestCommentResponder",
     "version": "1.0",
     "config": {
+      "taskName": "Remove `no-recent-activity` label from PRs when commented on",
+      "actions": [
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": "no-recent-activity"
+          }
+        }
+      ],
+      "eventType": "pull_request",
+      "eventNames": [
+        "issue_comment"
+      ],
       "conditions": {
         "operator": "and",
         "operands": [
@@ -949,20 +1015,7 @@
             "parameters": {}
           }
         ]
-      },
-      "eventType": "pull_request",
-      "eventNames": [
-        "issue_comment"
-      ],
-      "taskName": "Remove `no-recent-activity` label from PRs when commented on",
-      "actions": [
-        {
-          "name": "removeLabel",
-          "parameters": {
-            "label": "no-recent-activity"
-          }
-        }
-      ]
+      }
     }
   },
   {
@@ -972,6 +1025,19 @@
     "subCapability": "PullRequestReviewResponder",
     "version": "1.0",
     "config": {
+      "taskName": "Remove `no-recent-activity` label from PRs when new review is added",
+      "actions": [
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": "no-recent-activity"
+          }
+        }
+      ],
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request_review"
+      ],
       "conditions": {
         "operator": "and",
         "operands": [
@@ -986,20 +1052,7 @@
             "parameters": {}
           }
         ]
-      },
-      "eventType": "pull_request",
-      "eventNames": [
-        "pull_request_review"
-      ],
-      "taskName": "Remove `no-recent-activity` label from PRs when new review is added",
-      "actions": [
-        {
-          "name": "removeLabel",
-          "parameters": {
-            "label": "no-recent-activity"
-          }
-        }
-      ]
+      }
     }
   },
   {
@@ -1010,6 +1063,18 @@
     "version": "1.1",
     "config": {
       "taskName": "Close issues with no recent activity",
+      "actions": [
+        {
+          "name": "addReply",
+          "parameters": {
+            "comment": "This issue will now be closed since it had been marked `no-recent-activity` but received no further activity in the past 14 days. It is still possible to reopen or comment on the issue, but please note that the issue will be locked if it remains inactive for another 30 days."
+          }
+        },
+        {
+          "name": "closeIssue",
+          "parameters": {}
+        }
+      ],
       "frequency": [
         {
           "weekDay": 0,
@@ -1103,18 +1168,6 @@
             "days": 14
           }
         }
-      ],
-      "actions": [
-        {
-          "name": "addReply",
-          "parameters": {
-            "comment": "This issue will now be closed since it had been marked `no-recent-activity` but received no further activity in the past 14 days. It is still possible to reopen or comment on the issue, but please note that the issue will be locked if it remains inactive for another 30 days."
-          }
-        },
-        {
-          "name": "closeIssue",
-          "parameters": {}
-        }
       ]
     }
   },
@@ -1126,6 +1179,18 @@
     "version": "1.1",
     "config": {
       "taskName": "Close PRs with no-recent-activity",
+      "actions": [
+        {
+          "name": "addReply",
+          "parameters": {
+            "comment": "This pull request will now be closed since it had been marked `no-recent-activity` but received no further activity in the past 14 days. It is still possible to reopen or comment on the pull request, but please note that it will be locked if it remains inactive for another 30 days."
+          }
+        },
+        {
+          "name": "closeIssue",
+          "parameters": {}
+        }
+      ],
       "frequency": [
         {
           "weekDay": 0,
@@ -1219,18 +1284,6 @@
             "days": 14
           }
         }
-      ],
-      "actions": [
-        {
-          "name": "addReply",
-          "parameters": {
-            "comment": "This pull request will now be closed since it had been marked `no-recent-activity` but received no further activity in the past 14 days. It is still possible to reopen or comment on the pull request, but please note that it will be locked if it remains inactive for another 30 days."
-          }
-        },
-        {
-          "name": "closeIssue",
-          "parameters": {}
-        }
       ]
     }
   },
@@ -1241,6 +1294,19 @@
     "subCapability": "ScheduledSearch",
     "version": "1.1",
     "config": {
+      "taskName": "Close inactive Draft PRs",
+      "actions": [
+        {
+          "name": "closeIssue",
+          "parameters": {}
+        },
+        {
+          "name": "addReply",
+          "parameters": {
+            "comment": "Draft Pull Request was automatically closed for 30 days of inactivity. Please [let us know](https://github.com/dotnet/runtime/blob/main/docs/area-owners.md) if you'd like to reopen it."
+          }
+        }
+      ],
       "frequency": [
         {
           "weekDay": 0,
@@ -1330,19 +1396,6 @@
             "days": 30
           }
         }
-      ],
-      "taskName": "Close inactive Draft PRs",
-      "actions": [
-        {
-          "name": "closeIssue",
-          "parameters": {}
-        },
-        {
-          "name": "addReply",
-          "parameters": {
-            "comment": "Draft Pull Request was automatically closed for 30 days of inactivity. Please [let us know](https://github.com/dotnet/runtime/blob/main/docs/area-owners.md) if you'd like to reopen it."
-          }
-        }
       ]
     }
   },
@@ -1353,6 +1406,16 @@
     "subCapability": "ScheduledSearch",
     "version": "1.1",
     "config": {
+      "taskName": "Lock stale issues and PRs",
+      "actions": [
+        {
+          "name": "lockIssue",
+          "parameters": {
+            "reason": "resolved",
+            "label": "will_lock_this"
+          }
+        }
+      ],
       "frequency": [
         {
           "weekDay": 0,
@@ -1440,17 +1503,7 @@
           "name": "isUnlocked",
           "parameters": {}
         }
-      ],
-      "actions": [
-        {
-          "name": "lockIssue",
-          "parameters": {
-            "reason": "resolved",
-            "label": "will_lock_this"
-          }
-        }
-      ],
-      "taskName": "Lock stale issues and PR's"
+      ]
     }
   },
   {
@@ -1460,6 +1513,28 @@
     "subCapability": "IssuesOnlyResponder",
     "version": "1.0",
     "config": {
+      "taskName": "[Area Pod: Drew / Michael / Tanner - Issue Triage] Needs Triage",
+      "actions": [
+        {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
+            "isOrgProject": true
+          }
+        },
+        {
+          "name": "addToProject",
+          "parameters": {
+            "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
+            "columnName": "Needs Triage",
+            "isOrgProject": true
+          }
+        }
+      ],
+      "eventType": "issue",
+      "eventNames": [
+        "issues"
+      ],
       "conditions": {
         "operator": "and",
         "operands": [
@@ -1523,13 +1598,17 @@
             ]
           }
         ]
-      },
-      "eventType": "issue",
-      "eventNames": [
-        "issues",
-        "project_card"
-      ],
-      "taskName": "[Area Pod: Drew / Michael / Tanner - Issue Triage] Needs Triage",
+      }
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssueCommentResponder",
+    "version": "1.0",
+    "config": {
+      "taskName": "[Area Pod: Drew / Michael / Tanner - Issue Triage] Needs Further Triage",
       "actions": [
         {
           "name": "removeFromProject",
@@ -1546,16 +1625,11 @@
             "isOrgProject": true
           }
         }
-      ]
-    }
-  },
-  {
-    "taskSource": "fabricbot-config",
-    "taskType": "trigger",
-    "capabilityId": "IssueResponder",
-    "subCapability": "IssueCommentResponder",
-    "version": "1.0",
-    "config": {
+      ],
+      "eventType": "issue",
+      "eventNames": [
+        "issue_comment"
+      ],
       "conditions": {
         "operator": "and",
         "operands": [
@@ -1569,15 +1643,10 @@
             ]
           },
           {
-            "operator": "not",
-            "operands": [
-              {
-                "name": "activitySenderHasPermissions",
-                "parameters": {
-                  "permissions": "write"
-                }
-              }
-            ]
+            "name": "activitySenderHasPermissions",
+            "parameters": {
+              "permissions": "read"
+            }
           },
           {
             "operator": "or",
@@ -1605,29 +1674,7 @@
             ]
           }
         ]
-      },
-      "eventType": "issue",
-      "eventNames": [
-        "issue_comment"
-      ],
-      "taskName": "[Area Pod: Drew / Michael / Tanner - Issue Triage] Needs Further Triage",
-      "actions": [
-        {
-          "name": "removeFromProject",
-          "parameters": {
-            "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
-            "isOrgProject": true
-          }
-        },
-        {
-          "name": "addToProject",
-          "parameters": {
-            "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
-            "columnName": "Needs Triage",
-            "isOrgProject": true
-          }
-        }
-      ]
+      }
     }
   },
   {
@@ -1637,6 +1684,27 @@
     "subCapability": "IssuesOnlyResponder",
     "version": "1.0",
     "config": {
+      "taskName": "[Area Pod: Drew / Michael / Tanner - Issue Triage] Triaged",
+      "actions": [
+        {
+          "name": "addToProject",
+          "parameters": {
+            "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
+            "columnName": "Triaged",
+            "isOrgProject": true
+          }
+        },
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": "untriaged"
+          }
+        }
+      ],
+      "eventType": "issue",
+      "eventNames": [
+        "issues"
+      ],
       "conditions": {
         "operator": "and",
         "operands": [
@@ -1669,29 +1737,409 @@
             ]
           }
         ]
-      },
-      "eventType": "issue",
-      "eventNames": [
-        "issues",
-        "project_card"
-      ],
-      "taskName": "[Area Pod: Drew / Michael / Tanner - Issue Triage] Triaged",
+      }
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "taskName": "[Area Pod: Drew / Michael / Tanner - Issue Triage] Drew Updated Issue",
       "actions": [
         {
-          "name": "addToProject",
+          "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
-            "columnName": "Triaged",
+            "columnName": "Triage: Drew",
             "isOrgProject": true
           }
-        },
+        }
+      ],
+      "eventType": "issue",
+      "eventNames": [
+        "issues"
+      ],
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "dakersnar"
+            }
+          },
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isInMilestone",
+                "parameters": {}
+              }
+            ]
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "needs-author-action"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssueCommentResponder",
+    "version": "1.0",
+    "config": {
+      "taskName": "[Area Pod: Drew / Michael / Tanner - Issue Triage] Drew Commented",
+      "actions": [
         {
-          "name": "removeLabel",
+          "name": "moveToProjectColumn",
           "parameters": {
-            "label": "untriaged"
+            "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
+            "columnName": "Triage: Drew",
+            "isOrgProject": true
           }
         }
-      ]
+      ],
+      "eventType": "issue",
+      "eventNames": [
+        "issue_comment"
+      ],
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "dakersnar"
+            }
+          },
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isInMilestone",
+                "parameters": {}
+              }
+            ]
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "needs-author-action"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "taskName": "[Area Pod: Drew / Michael / Tanner - Issue Triage] Michael Updated Issue",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
+            "columnName": "Triage: Michael",
+            "isOrgProject": true
+          }
+        }
+      ],
+      "eventType": "issue",
+      "eventNames": [
+        "issues"
+      ],
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "michaelgsharp"
+            }
+          },
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isInMilestone",
+                "parameters": {}
+              }
+            ]
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "needs-author-action"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssueCommentResponder",
+    "version": "1.0",
+    "config": {
+      "taskName": "[Area Pod: Drew / Michael / Tanner - Issue Triage] Michael Commented",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
+            "columnName": "Triage: Michael",
+            "isOrgProject": true
+          }
+        }
+      ],
+      "eventType": "issue",
+      "eventNames": [
+        "issue_comment"
+      ],
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "michaelgsharp"
+            }
+          },
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isInMilestone",
+                "parameters": {}
+              }
+            ]
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "needs-author-action"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "taskName": "[Area Pod: Drew / Michael / Tanner - Issue Triage] Tanner Updated Issue",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
+            "columnName": "Triage: Tanner",
+            "isOrgProject": true
+          }
+        }
+      ],
+      "eventType": "issue",
+      "eventNames": [
+        "issues"
+      ],
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "tannergooding"
+            }
+          },
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isInMilestone",
+                "parameters": {}
+              }
+            ]
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "needs-author-action"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssueCommentResponder",
+    "version": "1.0",
+    "config": {
+      "taskName": "[Area Pod: Drew / Michael / Tanner - Issue Triage] Tanner Commented",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
+            "columnName": "Triage: Tanner",
+            "isOrgProject": true
+          }
+        }
+      ],
+      "eventType": "issue",
+      "eventNames": [
+        "issue_comment"
+      ],
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "tannergooding"
+            }
+          },
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isInMilestone",
+                "parameters": {}
+              }
+            ]
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "needs-author-action"
+                }
+              }
+            ]
+          }
+        ]
+      }
     }
   },
   {
@@ -1701,31 +2149,78 @@
     "subCapability": "PullRequestResponder",
     "version": "1.0",
     "config": {
+      "taskName": "[Area Pod: Drew / Michael / Tanner - PRs] Closed, Merged, or Moved",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Drew / Michael / Tanner - PRs",
+            "columnName": "Done",
+            "isOrgProject": true
+          }
+        }
+      ],
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request"
+      ],
       "conditions": {
         "operator": "and",
         "operands": [
           {
+            "name": "isInProject",
+            "parameters": {
+              "projectName": "Area Pod: Drew / Michael / Tanner - PRs",
+              "isOrgProject": true
+            }
+          },
+          {
             "operator": "not",
             "operands": [
               {
-                "name": "isInProject",
+                "name": "isInProjectColumn",
                 "parameters": {
                   "projectName": "Area Pod: Drew / Michael / Tanner - PRs",
+                  "columnName": "Done",
                   "isOrgProject": true
                 }
               }
             ]
+          },
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isOpen",
+                    "parameters": {}
+                  }
+                ]
+              }
+            ]
           }
         ]
-      },
-      "eventType": "pull_request",
-      "eventNames": [
-        "pull_request",
-        "issues",
-        "project_card"
-      ],
+      }
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
       "taskName": "[Area Pod: Drew / Michael / Tanner - PRs] Needs Champion",
       "actions": [
+        {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Drew / Michael / Tanner - PRs",
+            "isOrgProject": true
+          }
+        },
         {
           "name": "addToProject",
           "parameters": {
@@ -1734,7 +2229,320 @@
             "isOrgProject": true
           }
         }
-      ]
+      ],
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request"
+      ],
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "operator": "and",
+            "operands": [
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "dakersnar"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "michaelgsharp"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "tannergooding"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isInProject",
+                    "parameters": {
+                      "projectName": "Area Pod: Drew / Michael / Tanner - PRs",
+                      "isOrgProject": true
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "isInProjectColumn",
+                "parameters": {
+                  "projectName": "Area Pod: Drew / Michael / Tanner - PRs",
+                  "columnName": "Done",
+                  "isOrgProject": true
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "taskName": "[Area Pod: Drew / Michael / Tanner - PRs] Drew Assigned as Champion",
+      "actions": [
+        {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Drew / Michael / Tanner - PRs",
+            "isOrgProject": true
+          }
+        },
+        {
+          "name": "addToProject",
+          "parameters": {
+            "projectName": "Area Pod: Drew / Michael / Tanner - PRs",
+            "columnName": "Champion: Drew",
+            "isOrgProject": true
+          }
+        }
+      ],
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request"
+      ],
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "name": "isAssignedToUser",
+            "parameters": {
+              "user": "dakersnar"
+            }
+          },
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isInProject",
+                    "parameters": {
+                      "projectName": "Area Pod: Drew / Michael / Tanner - PRs",
+                      "isOrgProject": true
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "isInProjectColumn",
+                "parameters": {
+                  "projectName": "Area Pod: Drew / Michael / Tanner - PRs",
+                  "columnName": "Needs Champion",
+                  "isOrgProject": true
+                }
+              },
+              {
+                "name": "isInProjectColumn",
+                "parameters": {
+                  "projectName": "Area Pod: Drew / Michael / Tanner - PRs",
+                  "columnName": "Done",
+                  "isOrgProject": true
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "taskName": "[Area Pod: Drew / Michael / Tanner - PRs] Michael Assigned as Champion",
+      "actions": [
+        {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Drew / Michael / Tanner - PRs",
+            "isOrgProject": true
+          }
+        },
+        {
+          "name": "addToProject",
+          "parameters": {
+            "projectName": "Area Pod: Drew / Michael / Tanner - PRs",
+            "columnName": "Champion: Michael",
+            "isOrgProject": true
+          }
+        }
+      ],
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request"
+      ],
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "name": "isAssignedToUser",
+            "parameters": {
+              "user": "michaelgsharp"
+            }
+          },
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isInProject",
+                    "parameters": {
+                      "projectName": "Area Pod: Drew / Michael / Tanner - PRs",
+                      "isOrgProject": true
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "isInProjectColumn",
+                "parameters": {
+                  "projectName": "Area Pod: Drew / Michael / Tanner - PRs",
+                  "columnName": "Needs Champion",
+                  "isOrgProject": true
+                }
+              },
+              {
+                "name": "isInProjectColumn",
+                "parameters": {
+                  "projectName": "Area Pod: Drew / Michael / Tanner - PRs",
+                  "columnName": "Done",
+                  "isOrgProject": true
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "taskName": "[Area Pod: Drew / Michael / Tanner - PRs] Tanner Assigned as Champion",
+      "actions": [
+        {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Drew / Michael / Tanner - PRs",
+            "isOrgProject": true
+          }
+        },
+        {
+          "name": "addToProject",
+          "parameters": {
+            "projectName": "Area Pod: Drew / Michael / Tanner - PRs",
+            "columnName": "Champion: Tanner",
+            "isOrgProject": true
+          }
+        }
+      ],
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request"
+      ],
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "name": "isAssignedToUser",
+            "parameters": {
+              "user": "tannergooding"
+            }
+          },
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isInProject",
+                    "parameters": {
+                      "projectName": "Area Pod: Drew / Michael / Tanner - PRs",
+                      "isOrgProject": true
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "isInProjectColumn",
+                "parameters": {
+                  "projectName": "Area Pod: Drew / Michael / Tanner - PRs",
+                  "columnName": "Needs Champion",
+                  "isOrgProject": true
+                }
+              },
+              {
+                "name": "isInProjectColumn",
+                "parameters": {
+                  "projectName": "Area Pod: Drew / Michael / Tanner - PRs",
+                  "columnName": "Done",
+                  "isOrgProject": true
+                }
+              }
+            ]
+          }
+        ]
+      }
     }
   }
 ]


### PR DESCRIPTION
The `fabricbot.json` config file is generated from https://github.com/dotnet/fabricbot-config. Here are the configuration tasks that are included for this repository:

1. [trackUntriaged](https://github.com/dotnet/fabricbot-config/blob/main/src/issueAndPullRequestTasks/trackUntriaged.js)
    1. Add `untriaged` label to new/reopened issues without a milestone (or when the milestone is removed)
    1. Remove `untriaged` label from issues when closed or added to a milestone
1. [addInPrLabel](https://github.com/dotnet/fabricbot-config/blob/main/src/issueAndPullRequestTasks/addInPrLabel.js)
    1. Add `in-pr` label on the issue when a pull request is opened to target it
1. [assignTeamAuthor](https://github.com/dotnet/fabricbot-config/blob/main/src/issueAndPullRequestTasks/assignTeamAuthor.js)
    1. Assign Team PRs to author when the PR is opened
1. [addCommunityContributionLabel](https://github.com/dotnet/fabricbot-config/blob/main/src/issueAndPullRequestTasks/addCommunityContributionLabel.js)
    1. Add `community-contribution` label to pull requests created by users that don't have admin, maintain, or write permissions (and the common bot accounts are excluded too)
1. [trackNeedsAuthorAction](https://github.com/dotnet/fabricbot-config/blob/main/src/issueAndPullRequestTasks/trackNeedsAuthorAction.js)
    1. Add a reply when the `needs-author-action` label is applied
    1. Apply the `needs-author-action` label when changes are requested on a PR (by a triager or team member)
    1. Replace `needs-author-action` with `needs-further-triage` when the author comments on an issue
    1. Remove the `needs-author-action` label when changes are pushed to the PR 
    1. Remove the `needs-author-action` label when the author comments on the PR
    1. Remove the `needs-author-action` label when the author response to a review comment
1. [trackNoRecentActivity](https://github.com/dotnet/fabricbot-config/blob/main/src/issueAndPullRequestTasks/trackNoRecentActivity.js)
    1. Add `no-recent-activity` label to issues with `needs-author-action` and no activity for 14 days (via a scheduled search)
    1. Add `no-recent-activity` label to PRs with `needs-author-action` and no activity for 14 days (via a scheduled search)
    1. Remove `no-recent-activity` label from issues when the issue is modified
    1. Remove `no-recent-activity` label from issues when the issue is commented on
    1. Remove `no-recent-activity` label from PRs when the PR is modified
    1. Remove `no-recent-activity` label from PRs when the PR is commented on
    1. Remove `no-recent-activity` label from PRs when the PR has a new review added
    1. Close issues that go an additional 14 days with no activity after having `no-recent-activity` added
    1. Close PRs that go an additional 14 days with no activity after having `no-recent-activity` added
1. [trackInactiveDrafts](https://github.com/dotnet/fabricbot-config/blob/main/src/issueAndPullRequestTasks/trackInactiveDrafts.js)
    1. Close inactive Draft PRs after 30 days of inactivity (via a scheduled search)
1. [trackStaleIssuesAndPullRequests](https://github.com/dotnet/fabricbot-config/blob/main/src/issueAndPullRequestTasks/trackStaleIssuesAndPullRequests.js)
    1. Lock issues and PRs after being closed and going 30 days with no activity (via a scheduled search)
1. Area Pod issue triage project board automation
    1. [issueNeedsTriage](https://github.com/dotnet/fabricbot-config/blob/main/src/projectBoardTasks/issueNeedsTriage.js)
        * Add issues to the "Needs Triage" column when opened/reopened, no milestone is set, the area is included in the pod, and the issue isn't already on the board, or the issue was previously moved to "Triaged"
    1. [issueTriageStarted](https://github.com/dotnet/fabricbot-config/blob/main/src/projectBoardTasks/issueTriageStarted.js)
        * Move issues from "Needs Triage" into a pod member's column when that pod member edits or comments on an issue
    1. [issueTriaged](https://github.com/dotnet/fabricbot-config/blob/main/src/projectBoardTasks/issueTriaged.js)
        * Move issues into "Triaged" when a milestone is applied, the issue is closed, or when the `needs-author-action` label is added
    1. [issueMovedToAnotherArea](https://github.com/dotnet/fabricbot-config/blob/main/src/projectBoardTasks/issueMovedToAnotherArea.js)
        * Move issues into "Triaged" when the area label is changed to another pod's area
    1. [issueNeedsFurtherTriage](https://github.com/dotnet/fabricbot-config/blob/main/src/projectBoardTasks/issueNeedsFurtherTriage.js)
        * Move issues from "Triaged" to "Needs Triage" when a community member (without triage permission) comments on the issue
1. Area Pod PR project board automation
    1. [pullRequestNeedsChampion](https://github.com/dotnet/fabricbot-config/blob/main/src/projectBoardTasks/pullRequestNeedsChampion.js)
        * Add PRs to the "Needs Champion" column when opened/reopened, no pod member is assigned, the area is included in the pod, and the PR isn't already on the board, or the PR was previously moved to "Done"
    1. [pullRequestChampionAssigned](https://github.com/dotnet/fabricbot-config/blob/main/src/projectBoardTasks/pullRequestChampionAssigned.js)
        * Move PRs from "Needs Champion" into a pod member's column when that pod member is assigned, or if the pod member themselves submitted the PR (bypassing the "Needs Champion" column), and the PR has one of the pod's area labels
    1. [pullRequestDone](https://github.com/dotnet/fabricbot-config/blob/main/src/projectBoardTasks/pullRequestDone.js)
        * Move PRs to the "Done" column when merged, closed without merge, or it was moved to another pod's area
