### PR TITLE
Using internal TempFilePath

### DIFF
--- a/src/Microsoft.ML.Core/Data/Repository.cs
+++ b/src/Microsoft.ML.Core/Data/Repository.cs
@@ -113,14 +113,19 @@ namespace Microsoft.ML
             PathMap = new ConcurrentDictionary<string, string>();
             _open = new List<Entry>();
             if (needDir)
-                DirTemp = GetShortTempDir();
+                DirTemp = GetShortTempDir(ectx);
             else
                 GC.SuppressFinalize(this);
         }
 
-        private static string GetShortTempDir()
+        private static string GetShortTempDir(IExceptionContext ectx)
         {
-            var path = Path.Combine(Path.GetFullPath(Path.GetTempPath()), "ml_dotnet", Path.GetRandomFileName());
+            string path;
+            if (ectx is IHostEnvironmentInternal iHostInternal)
+                path = Path.Combine(Path.GetFullPath(iHostInternal.TempFilePath), "ml_dotnet", Path.GetRandomFileName());
+            else
+                path = Path.Combine(Path.GetFullPath(Path.GetTempPath()), "ml_dotnet", Path.GetRandomFileName());
+
             Directory.CreateDirectory(path);
             return path;
         }

--- a/src/Microsoft.ML.Core/Data/Repository.cs
+++ b/src/Microsoft.ML.Core/Data/Repository.cs
@@ -120,12 +120,11 @@ namespace Microsoft.ML
 
         private static string GetShortTempDir(IExceptionContext ectx)
         {
-            string path;
-            if (ectx is IHostEnvironmentInternal iHostInternal)
-                path = Path.Combine(Path.GetFullPath(iHostInternal.TempFilePath), "ml_dotnet", Path.GetRandomFileName());
-            else
-                path = Path.Combine(Path.GetFullPath(Path.GetTempPath()), "ml_dotnet", Path.GetRandomFileName());
+            string tempPath = ectx is IHostEnvironmentInternal iHostInternal ?
+                iHostInternal.TempFilePath :
+                Path.GetTempPath();
 
+            string path = Path.Combine(Path.GetFullPath(tempPath), "ml_dotnet", Path.GetRandomFileName());
             Directory.CreateDirectory(path);
             return path;
         }

--- a/src/Microsoft.ML.Data/Commands/DataCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/DataCommand.cs
@@ -398,7 +398,7 @@ namespace Microsoft.ML.Data
         /// <summary>
         /// Saves <paramref name="loader"/> to the specified <paramref name="file"/>.
         /// </summary>
-        public static void SaveLoader(ILegacyDataLoader loader, IFileHandle file, IExceptionContext ectx)
+        public static void SaveLoader(ILegacyDataLoader loader, IFileHandle file, IHostEnvironment host)
         {
             Contracts.CheckValue(loader, nameof(loader));
             Contracts.CheckValue(file, nameof(file));
@@ -413,7 +413,7 @@ namespace Microsoft.ML.Data
         /// <summary>
         /// Saves <paramref name="loader"/> to the specified <paramref name="stream"/>.
         /// </summary>
-        public static void SaveLoader(ILegacyDataLoader loader, Stream stream, IExceptionContext ectx)
+        public static void SaveLoader(ILegacyDataLoader loader, Stream stream, IHostEnvironment host)
         {
             Contracts.CheckValue(loader, nameof(loader));
             Contracts.CheckValue(stream, nameof(stream));

--- a/src/Microsoft.ML.Data/Commands/DataCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/DataCommand.cs
@@ -209,7 +209,7 @@ namespace Microsoft.ML.Data
             protected void SaveLoader(ILegacyDataLoader loader, string path)
             {
                 using (var file = Host.CreateOutputFile(path))
-                    LoaderUtils.SaveLoader(loader, file);
+                    LoaderUtils.SaveLoader(loader, file, Host);
             }
 
             protected ILegacyDataLoader CreateAndSaveLoader(Func<IHostEnvironment, IMultiStreamSource, ILegacyDataLoader> defaultLoaderFactory = null)
@@ -218,7 +218,7 @@ namespace Microsoft.ML.Data
                 if (!string.IsNullOrWhiteSpace(ImplOptions.OutputModelFile))
                 {
                     using (var file = Host.CreateOutputFile(ImplOptions.OutputModelFile))
-                        LoaderUtils.SaveLoader(loader, file);
+                        LoaderUtils.SaveLoader(loader, file, Host);
                 }
                 return loader;
             }
@@ -398,7 +398,7 @@ namespace Microsoft.ML.Data
         /// <summary>
         /// Saves <paramref name="loader"/> to the specified <paramref name="file"/>.
         /// </summary>
-        public static void SaveLoader(ILegacyDataLoader loader, IFileHandle file)
+        public static void SaveLoader(ILegacyDataLoader loader, IFileHandle file, IExceptionContext ectx)
         {
             Contracts.CheckValue(loader, nameof(loader));
             Contracts.CheckValue(file, nameof(file));
@@ -406,20 +406,20 @@ namespace Microsoft.ML.Data
 
             using (var stream = file.CreateWriteStream())
             {
-                SaveLoader(loader, stream);
+                SaveLoader(loader, stream, ectx);
             }
         }
 
         /// <summary>
         /// Saves <paramref name="loader"/> to the specified <paramref name="stream"/>.
         /// </summary>
-        public static void SaveLoader(ILegacyDataLoader loader, Stream stream)
+        public static void SaveLoader(ILegacyDataLoader loader, Stream stream, IExceptionContext ectx)
         {
             Contracts.CheckValue(loader, nameof(loader));
             Contracts.CheckValue(stream, nameof(stream));
             Contracts.CheckParam(stream.CanWrite, nameof(stream), "Must be writable");
 
-            using (var rep = RepositoryWriter.CreateNew(stream))
+            using (var rep = RepositoryWriter.CreateNew(stream, ectx))
             {
                 ModelSaveContext.SaveModel(rep, loader, ModelFileUtils.DirDataLoaderModel);
                 rep.Commit();

--- a/src/Microsoft.ML.Data/Commands/DataCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/DataCommand.cs
@@ -406,7 +406,7 @@ namespace Microsoft.ML.Data
 
             using (var stream = file.CreateWriteStream())
             {
-                SaveLoader(loader, stream, ectx);
+                SaveLoader(loader, stream, host);
             }
         }
 
@@ -419,7 +419,7 @@ namespace Microsoft.ML.Data
             Contracts.CheckValue(stream, nameof(stream));
             Contracts.CheckParam(stream.CanWrite, nameof(stream), "Must be writable");
 
-            using (var rep = RepositoryWriter.CreateNew(stream, ectx))
+            using (var rep = RepositoryWriter.CreateNew(stream, host))
             {
                 ModelSaveContext.SaveModel(rep, loader, ModelFileUtils.DirDataLoaderModel);
                 rep.Commit();

--- a/src/Microsoft.ML.Data/Model/ModelOperationsCatalog.cs
+++ b/src/Microsoft.ML.Data/Model/ModelOperationsCatalog.cs
@@ -47,7 +47,7 @@ namespace Microsoft.ML
             var chainedModel = model == null ? null : new TransformerChain<ITransformer>(model);
             var compositeLoader = new CompositeDataLoader<TSource, ITransformer>(loader, chainedModel);
 
-            using (var rep = RepositoryWriter.CreateNew(stream))
+            using (var rep = RepositoryWriter.CreateNew(stream, _env))
             {
                 ModelSaveContext.SaveModel(rep, compositeLoader, null);
                 rep.Commit();
@@ -86,7 +86,7 @@ namespace Microsoft.ML
             _env.CheckValueOrNull(inputSchema);
             _env.CheckValue(stream, nameof(stream));
 
-            using (var rep = RepositoryWriter.CreateNew(stream))
+            using (var rep = RepositoryWriter.CreateNew(stream, _env))
             {
                 ModelSaveContext.SaveModel(rep, model, CompositeDataLoader<object, ITransformer>.TransformerDirectory);
                 SaveInputSchema(inputSchema, rep);

--- a/src/Microsoft.ML.Parquet/PartitionedFileLoader.cs
+++ b/src/Microsoft.ML.Parquet/PartitionedFileLoader.cs
@@ -345,7 +345,7 @@ namespace Microsoft.ML.Data
 
             using (var stream = new MemoryStream())
             {
-                LoaderUtils.SaveLoader(loader, stream);
+                LoaderUtils.SaveLoader(loader, stream, _host);
                 return stream.GetBuffer();
             }
         }


### PR DESCRIPTION
Using `IHostInternal.TempFilePath` when possible when using the `RepositoryWriter`. This will use the location set by the user when possible. Fixes #6170