### PR TITLE
Fixes #6198 Fix notimplementedexception error message while appending dataframe column

### DIFF
--- a/src/Microsoft.Data.Analysis/DataFrame.Arrow.cs
+++ b/src/Microsoft.Data.Analysis/DataFrame.Arrow.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Data.Analysis
                 case ArrowTypeId.Time32:
                 case ArrowTypeId.Time64:
                 default:
-                    throw new NotImplementedException(nameof(fieldType.Name));
+                    throw new NotImplementedException($"{fieldType.Name}");
             }
 
             if (dataFrameColumn != null)


### PR DESCRIPTION
Fix notimplementedexception error message while appending dataframe column

Change error message of NotImplementedAxception from nameof(fieldType.Name) to fieldType.Name
nameof(fieldType.Name) will always return 'Name' whenever an error occurs independent of the fieldtype name
fieldType.Name will return the name of the field type (e.g. 'timestamp') 

See also issue #6198 

- [x ] There's a descriptive title that will make sense to other developers some time from now. 
- [x ] There's associated issues. All PR's should have issue(s) associated - unless a trivial self-evident change such as fixing a typo. You can use the format `Fixes #nnnn` in your description to cause GitHub to automatically close the issue(s) when your PR is merged.
- [x ] Your change description explains what the change does, why you chose your approach, and anything else that reviewers should know.
- [ x] You have included any necessary tests in the same PR.

