### PR TITLE
Fixes Onnx Export for Column Copy Transformer.

### DIFF
--- a/src/Microsoft.ML.Data/Transforms/ColumnCopying.cs
+++ b/src/Microsoft.ML.Data/Transforms/ColumnCopying.cs
@@ -244,9 +244,10 @@ namespace Microsoft.ML.Transforms
 
                 foreach (var column in _columns)
                 {
-                    var srcVariableName = ctx.GetVariableName(column.inputColumnName);
-                    if (!ctx.ContainsColumn(srcVariableName))
+                    if (!ctx.ContainsColumn(column.inputColumnName))
                         continue;
+
+                    var srcVariableName = ctx.GetVariableName(column.inputColumnName);
                     _schema.TryGetColumnIndex(column.inputColumnName, out int colIndex);
                     var dstVariableName = ctx.AddIntermediateVariable(_schema[colIndex].Type, column.outputColumnName);
                     var node = ctx.CreateNode(opType, srcVariableName, dstVariableName, ctx.GetNodeName(opType), "");


### PR DESCRIPTION
Fixes #6237. Column Copy Transformer was checking the wrong thing during the onnx export. It was checking if the intermediate variable exists in the input dataset when it needed to check if the original column name existed in the original dataset.

When Column Copy Transformer is using a column that hasn't been used by another transformer this bug was not encountered. It only shows up when a column (with the same name) is used by a previews transformer. Because this change only affects the internal onnx state, not really a good way to test it automatically.