### PR TITLE
add image featurizer to AutoFeaturizer

### DIFF
--- a/src/Microsoft.ML.AutoML/CodeGen/dnn_featurizer_image_search_space.json
+++ b/src/Microsoft.ML.AutoML/CodeGen/dnn_featurizer_image_search_space.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "./search-space-schema.json#",
+  "name": "dnn_featurizer_image_option",
+  "search_space": [
+    {
+      "name": "OutputColumnName",
+      "type": "string"
+    },
+    {
+      "name": "InputColumnName",
+      "type": "string"
+    },
+    {
+      "name": "ModelFactory",
+      "type": "dnnModelFactory",
+      "default": "resnet_18",
+      "search_space": [
+        "alexnet", "resnet_101", "resnet_18", "resnet_50"
+      ]
+    }
+  ]
+}

--- a/src/Microsoft.ML.AutoML/CodeGen/estimator-schema.json
+++ b/src/Microsoft.ML.AutoML/CodeGen/estimator-schema.json
@@ -68,6 +68,7 @@
               "ApplyOnnxModel",
               "ResizeImages",
               "ExtractPixels",
+              "DnnFeaturizerImage",
               "Naive",
               "ForecastBySsa"
             ]
@@ -180,22 +181,12 @@
                     "confidenceLowerBoundColumn",
                     "confidenceUpperBoundColumn",
                     "confidenceLevel",
-                    "variableHorizon"
+                    "variableHorizon",
+                    "modelFactory"
                   ]
                 },
                 "argumentType": {
-                  "type": "string",
-                  "enum": [
-                    "integer",
-                    "float",
-                    "double",
-                    "string",
-                    "boolean",
-                    "resizingKind",
-                    "colorBits",
-                    "colorsOrder",
-                    "anchor"
-                  ]
+                  "$ref": "search-space-schema.json#/definitions/option_type"
                 }
               }
             }

--- a/src/Microsoft.ML.AutoML/CodeGen/search-space-schema.json
+++ b/src/Microsoft.ML.AutoML/CodeGen/search-space-schema.json
@@ -2,6 +2,29 @@
   "$schema": "http://json-schema.org/draft-04/schema",
   "title": "Search Space",
   "definitions": {
+    "boolArray": {
+      "type": "array",
+      "items": { "type": "boolean" }
+    },
+    "intArray": {
+      "type": "array",
+      "items": { "type": "integer" }
+    },
+    "dnnModelFactoryArray": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/dnnModelFactoryType"
+      }
+    },
+    "dnnModelFactoryType": {
+      "type": "string",
+      "enum": [
+        "resnet_18",
+        "resnet_50",
+        "resnet_101",
+        "alexnet"
+      ]
+    },
     "range": {
       "type": "object",
       "properties": {
@@ -12,18 +35,17 @@
       "required": [ "min", "max" ]
     },
     "choice": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "oneOf": [
-            { "type": "string" },
-            { "type": "number" },
-            { "type": "integer" },
-            { "type": "boolean" }
-          ]
+      "oneOf": [
+        {
+          "$ref": "#/definitions/intArray"
+        },
+        {
+          "$ref": "#/definitions/dnnModelFactoryArray"
+        },
+        {
+          "$ref": "#/definitions/boolArray"
         }
-      },
-      "required": [ "value" ]
+      ]
     },
     "option": {
       "type": "object",
@@ -86,7 +108,8 @@
         "extract_pixels_option",
         "load_image_option",
         "image_classification_option",
-        "matrix_factorization_option"
+        "matrix_factorization_option",
+        "dnn_featurizer_image_option"
       ]
     },
     "option_name": {
@@ -130,7 +153,8 @@
         "ApproximationRank",
         "NumberOfIterations",
         "Quiet",
-        "OutputAsFloatArray"
+        "OutputAsFloatArray",
+        "ModelFactory"
       ]
     },
     "option_type": {
@@ -145,7 +169,8 @@
         "resizingKind",
         "colorBits",
         "colorsOrder",
-        "anchor"
+        "anchor",
+        "dnnModelFactory"
       ]
     }
   },

--- a/src/Microsoft.ML.AutoML/CodeGen/transformer-estimators.json
+++ b/src/Microsoft.ML.AutoML/CodeGen/transformer-estimators.json
@@ -321,6 +321,27 @@
       "nugetDependencies": [ "Microsoft.ML", "Microsoft.ML.ImageAnalytics" ],
       "usingStatements": [ "Microsoft.ML" ],
       "searchOption": "load_image_option"
+    },
+    {
+      "functionName": "DnnFeaturizerImage",
+      "estimatorTypes": [ "Transforms" ],
+      "arguments": [
+        {
+          "argumentName": "outputColumnName",
+          "argumentType": "string"
+        },
+        {
+          "argumentName": "inputColumnName",
+          "argumentType": "string"
+        },
+        {
+          "argumentName": "modelFactory",
+          "argumentType": "dnnModelFactory"
+        }
+      ],
+      "nugetDependencies": [ "Microsoft.ML.OnnxTransformer", "Microsoft.ML.OnnxRuntime" ],
+      "usingStatements": [ "Microsoft.ML" ],
+      "searchOption": "dnn_featurizer_image_option"
     }
   ]
 }

--- a/src/Microsoft.ML.AutoML/Microsoft.ML.AutoML.csproj
+++ b/src/Microsoft.ML.AutoML/Microsoft.ML.AutoML.csproj
@@ -61,6 +61,7 @@
     <AdditionalFiles Include="CodeGen\*search_space.json" />
     <AdditionalFiles Include="CodeGen\code_gen_flag.json" />
     <AdditionalFiles Include="CodeGen\*-estimators.json" />
+    <None Remove="CodeGen\dnn_featurizer_image_search_space.json" />
     <AdditionalFiles Include="CodeGen\code_gen_flag.json" />
   </ItemGroup>
 

--- a/src/Microsoft.ML.AutoML/Microsoft.ML.AutoML.csproj
+++ b/src/Microsoft.ML.AutoML/Microsoft.ML.AutoML.csproj
@@ -65,7 +65,6 @@
     <AdditionalFiles Include="CodeGen\*search_space.json" />
     <AdditionalFiles Include="CodeGen\code_gen_flag.json" />
     <AdditionalFiles Include="CodeGen\*-estimators.json" />
-    <None Remove="CodeGen\dnn_featurizer_image_search_space.json" />
     <AdditionalFiles Include="CodeGen\code_gen_flag.json" />
   </ItemGroup>
 

--- a/src/Microsoft.ML.AutoML/Microsoft.ML.AutoML.csproj
+++ b/src/Microsoft.ML.AutoML/Microsoft.ML.AutoML.csproj
@@ -35,6 +35,10 @@
       <PrivateAssets>all</PrivateAssets>
     </ProjectReference>
     <ProjectReference Include="..\Microsoft.ML.CpuMath\Microsoft.ML.CpuMath.csproj" />
+    <ProjectReference Include="..\Microsoft.ML.DnnImageFeaturizer.AlexNet\Microsoft.ML.DnnImageFeaturizer.AlexNet.csproj" />
+    <ProjectReference Include="..\Microsoft.ML.DnnImageFeaturizer.ResNet101\Microsoft.ML.DnnImageFeaturizer.ResNet101.csproj" />
+    <ProjectReference Include="..\Microsoft.ML.DnnImageFeaturizer.ResNet18\Microsoft.ML.DnnImageFeaturizer.ResNet18.csproj" />
+    <ProjectReference Include="..\Microsoft.ML.DnnImageFeaturizer.ResNet50\Microsoft.ML.DnnImageFeaturizer.ResNet50.csproj" />
     <ProjectReference Include="..\Microsoft.ML.OnnxTransformer\Microsoft.ML.OnnxTransformer.csproj" />
     <ProjectReference Include="..\Microsoft.ML.SearchSpace\Microsoft.ML.SearchSpace.csproj">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Microsoft.ML.AutoML/SweepableEstimator/Estimators/Images.cs
+++ b/src/Microsoft.ML.AutoML/SweepableEstimator/Estimators/Images.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
+using System;
 namespace Microsoft.ML.AutoML.CodeGen
 {
     internal partial class LoadImages
@@ -42,6 +42,30 @@ namespace Microsoft.ML.AutoML.CodeGen
         {
 
             return context.MulticlassClassification.Trainers.ImageClassification(param.LabelColumnName, param.FeatureColumnName, param.ScoreColumnName);
+        }
+    }
+
+    internal partial class DnnFeaturizerImage
+    {
+        public override IEstimator<ITransformer> BuildFromOption(MLContext context, DnnFeaturizerImageOption param)
+        {
+            switch (param.ModelFactory)
+            {
+                case "resnet_50":
+                    return context.Transforms.DnnFeaturizeImage(param.OutputColumnName,
+                        m => m.ModelSelector.ResNet50(context, param.OutputColumnName, param.InputColumnName), param.InputColumnName);
+                case "resnet_18":
+                    return context.Transforms.DnnFeaturizeImage(param.OutputColumnName,
+                        m => m.ModelSelector.ResNet18(context, param.OutputColumnName, param.InputColumnName), param.InputColumnName);
+                case "resnet_101":
+                    return context.Transforms.DnnFeaturizeImage(param.OutputColumnName,
+                        m => m.ModelSelector.ResNet101(context, param.OutputColumnName, param.InputColumnName), param.InputColumnName);
+                case "alexnet":
+                    return context.Transforms.DnnFeaturizeImage(param.OutputColumnName,
+                        m => m.ModelSelector.AlexNet(context, param.OutputColumnName, param.InputColumnName), param.InputColumnName);
+                default:
+                    throw new NotImplementedException();
+            }
         }
     }
 }

--- a/test/Microsoft.ML.AutoML.Tests/ApprovalTests/AutoFeaturizerTests.AutoFeaturizer_image_test.approved.txt
+++ b/test/Microsoft.ML.AutoML.Tests/ApprovalTests/AutoFeaturizerTests.AutoFeaturizer_image_test.approved.txt
@@ -1,0 +1,50 @@
+{
+  "schema": "e0 * e1 * e2 * e3 * e4",
+  "estimators": {
+    "e0": {
+      "estimatorType": "LoadImages",
+      "parameter": {
+        "OutputColumnName": "ImagePath",
+        "InputColumnName": "ImagePath"
+      }
+    },
+    "e1": {
+      "estimatorType": "ResizeImages",
+      "parameter": {
+        "OutputColumnName": "ImagePath",
+        "InputColumnName": "ImagePath",
+        "ImageHeight": 224,
+        "ImageWidth": 224,
+        "CropAnchor": "Center",
+        "Resizing": "Fill"
+      }
+    },
+    "e2": {
+      "estimatorType": "ExtractPixels",
+      "parameter": {
+        "OutputColumnName": "ImagePath",
+        "InputColumnName": "ImagePath",
+        "ColorsToExtract": "Rgb",
+        "OrderOfExtraction": "ARGB",
+        "OutputAsFloatArray": true
+      }
+    },
+    "e3": {
+      "estimatorType": "DnnFeaturizerImage",
+      "parameter": {
+        "OutputColumnName": "ImagePath",
+        "InputColumnName": "ImagePath",
+        "ModelFactory": "resnet_18"
+      }
+    },
+    "e4": {
+      "estimatorType": "Concatenate",
+      "parameter": {
+        "InputColumnNames": [
+          "ImagePath"
+        ],
+        "OutputColumnName": "Features"
+      }
+    }
+  }
+}

--- a/test/Microsoft.ML.AutoML.Tests/ApprovalTests/AutoFeaturizerTests.ImagePathFeaturizerTest.approved.txt
+++ b/test/Microsoft.ML.AutoML.Tests/ApprovalTests/AutoFeaturizerTests.ImagePathFeaturizerTest.approved.txt
@@ -1,0 +1,41 @@
+{
+  "schema": "e0 * e1 * e2 * e3",
+  "estimators": {
+    "e0": {
+      "estimatorType": "LoadImages",
+      "parameter": {
+        "OutputColumnName": "imagePath",
+        "InputColumnName": "imagePath"
+      }
+    },
+    "e1": {
+      "estimatorType": "ResizeImages",
+      "parameter": {
+        "OutputColumnName": "imagePath",
+        "InputColumnName": "imagePath",
+        "ImageHeight": 224,
+        "ImageWidth": 224,
+        "CropAnchor": "Center",
+        "Resizing": "Fill"
+      }
+    },
+    "e2": {
+      "estimatorType": "ExtractPixels",
+      "parameter": {
+        "OutputColumnName": "imagePath",
+        "InputColumnName": "imagePath",
+        "ColorsToExtract": "Rgb",
+        "OrderOfExtraction": "ARGB",
+        "OutputAsFloatArray": true
+      }
+    },
+    "e3": {
+      "estimatorType": "DnnFeaturizerImage",
+      "parameter": {
+        "OutputColumnName": "imagePath",
+        "InputColumnName": "imagePath",
+        "ModelFactory": "resnet_18"
+      }
+    }
+  }
+}

--- a/test/Microsoft.ML.AutoML.Tests/AutoFeaturizerTests.cs
+++ b/test/Microsoft.ML.AutoML.Tests/AutoFeaturizerTests.cs
@@ -61,5 +61,32 @@ namespace Microsoft.ML.AutoML.Test
 
             Approvals.Verify(JsonSerializer.Serialize(pipeline, _jsonSerializerOptions));
         }
+
+        [Fact]
+        [UseReporter(typeof(DiffReporter))]
+        [UseApprovalSubdirectory("ApprovalTests")]
+        public void ImagePathFeaturizerTest()
+        {
+            var context = new MLContext(1);
+            var pipeline = context.Auto().ImagePathFeaturizer("imagePath", "imagePath");
+
+            Approvals.Verify(JsonSerializer.Serialize(pipeline, _jsonSerializerOptions));
+        }
+
+
+        [Fact]
+        [UseReporter(typeof(DiffReporter))]
+        [UseApprovalSubdirectory("ApprovalTests")]
+        public void AutoFeaturizer_image_test()
+        {
+            var context = new MLContext(1);
+            var datasetPath = DatasetUtil.GetFlowersDataset();
+            var columnInference = context.Auto().InferColumns(datasetPath, "Label");
+            var textLoader = context.Data.CreateTextLoader(columnInference.TextLoaderOptions);
+            var trainData = textLoader.Load(datasetPath);
+            var pipeline = context.Auto().Featurizer(trainData, columnInference.ColumnInformation);
+
+            Approvals.Verify(JsonSerializer.Serialize(pipeline, _jsonSerializerOptions));
+        }
     }
 }

--- a/tools-local/Microsoft.ML.AutoML.SourceGenerator/SearchSpaceGenerator.cs
+++ b/tools-local/Microsoft.ML.AutoML.SourceGenerator/SearchSpaceGenerator.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Text.Json;
@@ -52,6 +53,7 @@ namespace Microsoft.ML.AutoML.SourceGenerator
                         "anchor" => "Anchor",
                         "colorBits" => "ColorBits",
                         "colorsOrder" => "ColorsOrder",
+                        "dnnModelFactory" => "string",
                         _ => throw new ArgumentException("unknown type"),
                     };
 
@@ -78,42 +80,38 @@ namespace Microsoft.ML.AutoML.SourceGenerator
                         // default option
                         optionAttribution = string.Empty;
                     }
+                    else if (searchSpaceNode is JsonObject searchSpaceObject && searchSpaceObject.ContainsKey("min"))
+                    {
+                        // range option
+                        var minToken = searchSpaceNode["min"];
+                        var minValue = searchSpaceNode["min"].GetValue<double>();
+                        var maxValue = searchSpaceNode["max"].GetValue<double>();
+                        var logBase = searchSpaceObject.ContainsKey("log_base") is false ? "false" : searchSpaceNode["log_base"].GetValue<bool>() ? "true" : "false";
+                        optionAttribution = (optionTypeName, minValue, maxValue, logBase, optionDefaultValue) switch
+                        {
+                            ("int", _, _, _, null) => $"Range((int){Convert.ToInt32(minValue).ToString(CultureInfo.InvariantCulture)}, (int){Convert.ToInt32(maxValue).ToString(CultureInfo.InvariantCulture)}, logBase: {logBase.ToString(CultureInfo.InvariantCulture)})",
+                            ("float", _, _, _, null) => $"Range((float){Convert.ToSingle(minValue).ToString(CultureInfo.InvariantCulture)}, (float){Convert.ToSingle(maxValue).ToString(CultureInfo.InvariantCulture)}, logBase: {logBase.ToString(CultureInfo.InvariantCulture)})",
+                            ("double", _, _, _, null) => $"Range((double){minValue.ToString(CultureInfo.InvariantCulture)}, (double){maxValue.ToString(CultureInfo.InvariantCulture)}, logBase: {logBase.ToString(CultureInfo.InvariantCulture)})",
+                            ("int", _, _, _, _) => $"Range((int){Convert.ToInt32(minValue).ToString(CultureInfo.InvariantCulture)}, (int){Convert.ToInt32(maxValue).ToString(CultureInfo.InvariantCulture)}, init: (int){optionDefaultValue.ToString(CultureInfo.InvariantCulture)}, logBase: {logBase.ToString(CultureInfo.InvariantCulture)})",
+                            ("float", _, _, _, _) => $"Range((float){Convert.ToSingle(minValue).ToString(CultureInfo.InvariantCulture)}, (float){Convert.ToSingle(maxValue).ToString(CultureInfo.InvariantCulture)}, init: (float){optionDefaultValue.ToString(CultureInfo.InvariantCulture)}, logBase: {logBase.ToString(CultureInfo.InvariantCulture)})",
+                            ("double", _, _, _, _) => $"Range((double){minValue.ToString(CultureInfo.InvariantCulture)}, (double){maxValue.ToString(CultureInfo.InvariantCulture)}, init: (double){optionDefaultValue.ToString(CultureInfo.InvariantCulture)}, logBase: {logBase.ToString(CultureInfo.InvariantCulture)})",
+                            _ => throw new NotImplementedException(),
+                        };
+                        optionAttribution = $"[{optionAttribution}]";
+                    }
                     else
                     {
-                        var searchSpaceObject = searchSpaceNode.AsObject();
-                        if (searchSpaceObject.ContainsKey("min"))
+                        // choice option
+                        var values = searchSpaceNode.AsArray().Select(x => x.Deserialize<string>());
+                        var valuesParam = optionTypeName switch
                         {
-                            // range option
-                            var minToken = searchSpaceNode["min"];
-                            var minValue = searchSpaceNode["min"].GetValue<double>();
-                            var maxValue = searchSpaceNode["max"].GetValue<double>();
-                            var logBase = searchSpaceObject.ContainsKey("log_base") is false ? "false" : searchSpaceNode["log_base"].GetValue<bool>() ? "true" : "false";
-                            optionAttribution = (optionTypeName, minValue, maxValue, logBase, optionDefaultValue) switch
-                            {
-                                ("int", _, _, _, null) => $"Range((int){Convert.ToInt32(minValue).ToString(CultureInfo.InvariantCulture)}, (int){Convert.ToInt32(maxValue).ToString(CultureInfo.InvariantCulture)}, logBase: {logBase.ToString(CultureInfo.InvariantCulture)})",
-                                ("float", _, _, _, null) => $"Range((float){Convert.ToSingle(minValue).ToString(CultureInfo.InvariantCulture)}, (float){Convert.ToSingle(maxValue).ToString(CultureInfo.InvariantCulture)}, logBase: {logBase.ToString(CultureInfo.InvariantCulture)})",
-                                ("double", _, _, _, null) => $"Range((double){minValue.ToString(CultureInfo.InvariantCulture)}, (double){maxValue.ToString(CultureInfo.InvariantCulture)}, logBase: {logBase.ToString(CultureInfo.InvariantCulture)})",
-                                ("int", _, _, _, _) => $"Range((int){Convert.ToInt32(minValue).ToString(CultureInfo.InvariantCulture)}, (int){Convert.ToInt32(maxValue).ToString(CultureInfo.InvariantCulture)}, init: (int){optionDefaultValue.ToString(CultureInfo.InvariantCulture)}, logBase: {logBase.ToString(CultureInfo.InvariantCulture)})",
-                                ("float", _, _, _, _) => $"Range((float){Convert.ToSingle(minValue).ToString(CultureInfo.InvariantCulture)}, (float){Convert.ToSingle(maxValue).ToString(CultureInfo.InvariantCulture)}, init: (float){optionDefaultValue.ToString(CultureInfo.InvariantCulture)}, logBase: {logBase.ToString(CultureInfo.InvariantCulture)})",
-                                ("double", _, _, _, _) => $"Range((double){minValue.ToString(CultureInfo.InvariantCulture)}, (double){maxValue.ToString(CultureInfo.InvariantCulture)}, init: (double){optionDefaultValue.ToString(CultureInfo.InvariantCulture)}, logBase: {logBase.ToString(CultureInfo.InvariantCulture)})",
-                                _ => throw new NotImplementedException(),
-                            };
-                            optionAttribution = $"[{optionAttribution}]";
-                        }
-                        else
-                        {
-                            // choice option
-                            var values = searchSpaceNode["value"].GetValue<string[]>();
-                            var valuesParam = optionTypeName switch
-                            {
-                                "int" => $"new object[]{{ {string.Join(",", values)} }}",
-                                "boolean" => $"new object[]{{ {string.Join(",", values)} }}",
-                                "string" => $"new object[]{{ {string.Join(",", values.Select(x => $"\"{x}\""))} }}",
-                                _ => throw new NotImplementedException("only support int|boolean|string"),
-                            };
+                            "int" => $"new object[]{{ {string.Join(",", values)} }}",
+                            "boolean" => $"new object[]{{ {string.Join(",", values)} }}",
+                            "string" => $"new object[]{{ {string.Join(",", values.Select(x => $"\"{x}\""))} }}",
+                            _ => throw new NotImplementedException("only support int|boolean|string"),
+                        };
 
-                            optionAttribution = optionDefaultValue == null ? $"[Choice({valuesParam})]" : $"[Choice({valuesParam}, {optionDefaultValue})]";
-                        }
+                        optionAttribution = optionDefaultValue == null ? $"[Choice({valuesParam})]" : $"[Choice({valuesParam}, {optionDefaultValue})]";
                     }
 
                     return (optionTypeName, optionName, optionAttribution, optionDefaultValue);


### PR DESCRIPTION
We are excited to review your PR.

So we can do the best job, please check:

- [x] There's a descriptive title that will make sense to other developers some time from now. 
- [x] There's associated issues. All PR's should have issue(s) associated - unless a trivial self-evident change such as fixing a typo. You can use the format `Fixes #nnnn` in your description to cause GitHub to automatically close the issue(s) when your PR is merged.
- [x] Your change description explains what the change does, why you chose your approach, and anything else that reviewers should know.
- [x] You have included any necessary tests in the same PR.

This PR adds featurizer for image path. When there's a column, or multiple columns that are referred as image path, a set of estimators with search space will be added for those columns which featurizes image using one of DNN featurizers (ResNet18, ResNet50, AlexNet...)

The initial idea comes from @justinormont, which is a great cross-platform solution to leverage automl in image classification, and can be a more efficient way compared with deep learning, especially on small datasets. 

The estimators that use to featurize images are
```
LoadImage -> ResizeImage(224, 224) -> ExtractPixels -> DnnFeaturizer(one of resnet18, resnet50, alexnet, resnet 101)
```
which transfers an image into a numeric feature array for classifiers to learn and transform.

And while training, the search space from those estimators will be added to the global search space and will be optimized by the selected tuner