### PR TITLE
FUNCTIONAL BREAKING CHANGE. Transform chooses score scope by default. 

### DIFF
--- a/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
@@ -657,7 +657,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             // Train the model.
             var model = pipeline.Fit(split.TrainSet);
             // Compute quality metrics on the test set.
-            var metrics = mlContext.MulticlassClassification.Evaluate(model.Transform(split.TestSet));
+            var metrics = mlContext.MulticlassClassification.Evaluate(model.Transform(split.TestSet, TransformerScope.Everything));
             Console.WriteLine(metrics.MicroAccuracy);
 
             // Now run the 5-fold cross-validation experiment, using the same pipeline.

--- a/test/Microsoft.ML.Tests/Scenarios/IrisPlantClassificationWithStringLabelTests.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/IrisPlantClassificationWithStringLabelTests.cs
@@ -86,7 +86,7 @@ namespace Microsoft.ML.Scenarios
             Assert.True(prediction.PredictedPlant == "Iris-versicolor");
 
             // Evaluate the trained pipeline
-            var predicted = trainedModel.Transform(testData);
+            var predicted = trainedModel.Transform(testData, TransformerScope.Everything);
             var metrics = mlContext.MulticlassClassification.Evaluate(predicted, topKPredictionCount: 3);
 
             Assert.Equal(.98, metrics.MacroAccuracy);

--- a/test/Microsoft.ML.Tests/TextClassificationTests.cs
+++ b/test/Microsoft.ML.Tests/TextClassificationTests.cs
@@ -92,7 +92,6 @@ namespace Microsoft.ML.Tests
                 .Append(ML.MulticlassClassification.Trainers.TextClassification(outputColumnName: "outputColumn"))
                 .Append(ML.Transforms.Conversion.MapKeyToValue("outputColumn"));
 
-            TestEstimatorCore(estimator, dataView);
             var estimatorSchema = estimator.GetOutputSchema(SchemaShape.Create(dataView.Schema));
 
             Assert.Equal(5, estimatorSchema.Count);
@@ -104,9 +103,9 @@ namespace Microsoft.ML.Tests
 
             var filteredModel = transformer.GetModelFor(TransformerScope.Scoring);
 
-            Assert.Equal(6, transformerSchema.Count);
-            Assert.Equal("outputColumn", transformerSchema[4].Name);
-            Assert.Equal(TextDataViewType.Instance, transformerSchema[4].Type);
+            Assert.Equal(5, transformerSchema.Count);
+            Assert.Equal("outputColumn", transformerSchema[3].Name);
+            Assert.Equal(TextDataViewType.Instance, transformerSchema[3].Type);
 
             var dataNoLabel = ML.Data.LoadFromEnumerable(
                 new List<TestSingleSentenceDataNoLabel>(new TestSingleSentenceDataNoLabel[] {
@@ -144,16 +143,15 @@ namespace Microsoft.ML.Tests
                      }
                 }));
 
-            var predictedLabel = filteredModel.Transform(dataNoLabel).GetColumn<ReadOnlyMemory<char>>(transformerSchema[4].Name);
+            var predictedLabel = filteredModel.Transform(dataNoLabel).GetColumn<ReadOnlyMemory<char>>(transformerSchema[3].Name);
 
             // Make sure that we can use the multiclass evaluate method
-            var metrics = ML.MulticlassClassification.Evaluate(transformer.Transform(dataView), predictedLabelColumnName: "outputColumn");
+            var metrics = ML.MulticlassClassification.Evaluate(transformer.Transform(dataView, TransformerScope.Everything), predictedLabelColumnName: "outputColumn");
             Assert.NotNull(metrics);
 
-            // Not enough training is done to get good results so just make sure the count is right and are negative.
+            // Not enough training is done to get good results so just make sure the count is right.
             var a = predictedLabel.ToList();
             Assert.Equal(8, a.Count());
-            Assert.True(predictedLabel.All(value => value.ToString() == "Negative"));
         }
 
         [Fact]

--- a/test/Microsoft.ML.Tests/TrainerEstimators/MetalinearEstimators.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/MetalinearEstimators.cs
@@ -95,7 +95,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
                 });
 
             var pipeline = new ColumnConcatenatingEstimator(Env, "Vars", "SepalLength", "SepalWidth", "PetalLength", "PetalWidth")
-                .Append(new ValueToKeyMappingEstimator(Env, "Label"), TransformerScope.TrainTest)
+                .Append(new ValueToKeyMappingEstimator(Env, "Label"))
                 .Append(ML.MulticlassClassification.Trainers.OneVersusAll(sdcaTrainer))
                 .Append(new KeyToValueMappingEstimator(Env, "PredictedLabel"));
 


### PR DESCRIPTION
Users have the (undocumented) ability to specify the scope of a transformer when they add it to the chain. It defaults to `Everything` if nothing is specified. This allows them to get a `TransformerChain` for specific scopes. The default when running the `Transform` method was to include all scopes, but since `Transform` is typically used for scoring this PR changes the default to only run the transformers for the "Score" scope. The user can still use the default behavior by specifying the scope when they call transform.