### PR TITLE
Update ApacheArrow from 2.0.0 to 3.0.0

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -30,7 +30,7 @@
     <SystemTextJsonVersion>6.0.1</SystemTextJsonVersion>
     <SystemThreadingChannelsVersion>4.7.1</SystemThreadingChannelsVersion>
     <!-- Other product dependencies -->
-    <ApacheArrowVersion>2.0.0</ApacheArrowVersion>
+    <ApacheArrowVersion>3.0.0</ApacheArrowVersion>
     <GoogleProtobufVersion>3.19.4</GoogleProtobufVersion>
     <LightGBMVersion>2.3.1</LightGBMVersion>
     <MicrosoftCodeAnalysisAnalyzersVersion>3.3.0</MicrosoftCodeAnalysisAnalyzersVersion>


### PR DESCRIPTION
Updated ApacheArrow package from 2.0.0 to 3.0.0

## ApacheArrow 3.0.0
- [Release Notes](https://arrow.apache.org/release/3.0.0.html)
- [Download and Install](https://www.apache.org/dyn/closer.lua/arrow/arrow-3.0.0/)


## ApacheArrow 2.0.0
- [Release Notes](https://arrow.apache.org/release/2.0.0.html)
- [Download and Install](https://www.apache.org/dyn/closer.lua/arrow/arrow-2.0.0/)