### PR TITLE
DataFrame: Add DateTime column type

### DIFF
--- a/src/Microsoft.Data.Analysis/DateTimeComputation.cs
+++ b/src/Microsoft.Data.Analysis/DateTimeComputation.cs
@@ -311,4 +311,295 @@ namespace Microsoft.Data.Analysis
         }
 
     }
+
+    internal class DateTimeArithmetic : IPrimitiveDataFrameColumnArithmetic<DateTime>
+    {
+        public void Add(PrimitiveColumnContainer<DateTime> left, PrimitiveColumnContainer<DateTime> right)
+        {
+            throw new NotSupportedException();
+        }
+        public void Add(PrimitiveColumnContainer<DateTime> column, DateTime scalar)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Add(DateTime scalar, PrimitiveColumnContainer<DateTime> column)
+        {
+            throw new NotSupportedException();
+        }
+        public void Subtract(PrimitiveColumnContainer<DateTime> left, PrimitiveColumnContainer<DateTime> right)
+        {
+            throw new NotSupportedException();
+        }
+        public void Subtract(PrimitiveColumnContainer<DateTime> column, DateTime scalar)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Subtract(DateTime scalar, PrimitiveColumnContainer<DateTime> column)
+        {
+            throw new NotSupportedException();
+        }
+        public void Multiply(PrimitiveColumnContainer<DateTime> left, PrimitiveColumnContainer<DateTime> right)
+        {
+            throw new NotSupportedException();
+        }
+        public void Multiply(PrimitiveColumnContainer<DateTime> column, DateTime scalar)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Multiply(DateTime scalar, PrimitiveColumnContainer<DateTime> column)
+        {
+            throw new NotSupportedException();
+        }
+        public void Divide(PrimitiveColumnContainer<DateTime> left, PrimitiveColumnContainer<DateTime> right)
+        {
+            throw new NotSupportedException();
+        }
+        public void Divide(PrimitiveColumnContainer<DateTime> column, DateTime scalar)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Divide(DateTime scalar, PrimitiveColumnContainer<DateTime> column)
+        {
+            throw new NotSupportedException();
+        }
+        public void Modulo(PrimitiveColumnContainer<DateTime> left, PrimitiveColumnContainer<DateTime> right)
+        {
+            throw new NotSupportedException();
+        }
+        public void Modulo(PrimitiveColumnContainer<DateTime> column, DateTime scalar)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Modulo(DateTime scalar, PrimitiveColumnContainer<DateTime> column)
+        {
+            throw new NotSupportedException();
+        }
+        public void And(PrimitiveColumnContainer<DateTime> left, PrimitiveColumnContainer<DateTime> right)
+        {
+            throw new NotSupportedException();
+        }
+        public void And(PrimitiveColumnContainer<DateTime> column, DateTime scalar)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void And(DateTime scalar, PrimitiveColumnContainer<DateTime> column)
+        {
+            throw new NotSupportedException();
+        }
+        public void Or(PrimitiveColumnContainer<DateTime> left, PrimitiveColumnContainer<DateTime> right)
+        {
+            throw new NotSupportedException();
+        }
+        public void Or(PrimitiveColumnContainer<DateTime> column, DateTime scalar)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Or(DateTime scalar, PrimitiveColumnContainer<DateTime> column)
+        {
+            throw new NotSupportedException();
+        }
+        public void Xor(PrimitiveColumnContainer<DateTime> left, PrimitiveColumnContainer<DateTime> right)
+        {
+            throw new NotSupportedException();
+        }
+        public void Xor(PrimitiveColumnContainer<DateTime> column, DateTime scalar)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Xor(DateTime scalar, PrimitiveColumnContainer<DateTime> column)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void LeftShift(PrimitiveColumnContainer<DateTime> column, int value)
+        {
+            throw new NotSupportedException();
+        }
+        public void RightShift(PrimitiveColumnContainer<DateTime> column, int value)
+        {
+            throw new NotSupportedException();
+        }
+        public void ElementwiseEquals(PrimitiveColumnContainer<DateTime> left, PrimitiveColumnContainer<DateTime> right, PrimitiveColumnContainer<bool> ret)
+        {
+            for (int b = 0; b < left.Buffers.Count; b++)
+            {
+                var buffer = left.Buffers[b];
+                var mutableBuffer = DataFrameBuffer<DateTime>.GetMutableBuffer(buffer);
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < span.Length; i++)
+                {
+                    ret[i] = (span[i] == otherSpan[i]);
+                }
+            }
+        }
+        public void ElementwiseEquals(PrimitiveColumnContainer<DateTime> column, DateTime scalar, PrimitiveColumnContainer<bool> ret)
+        {
+            for (int b = 0; b < column.Buffers.Count; b++)
+            {
+                var buffer = column.Buffers[b];
+                var mutableBuffer = DataFrameBuffer<DateTime>.GetMutableBuffer(buffer);
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < span.Length; i++)
+                {
+                    ret[i] = (span[i] == scalar);
+                }
+            }
+        }
+        public void ElementwiseNotEquals(PrimitiveColumnContainer<DateTime> left, PrimitiveColumnContainer<DateTime> right, PrimitiveColumnContainer<bool> ret)
+        {
+            for (int b = 0; b < left.Buffers.Count; b++)
+            {
+                var buffer = left.Buffers[b];
+                var mutableBuffer = DataFrameBuffer<DateTime>.GetMutableBuffer(buffer);
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < span.Length; i++)
+                {
+                    ret[i] = (span[i] != otherSpan[i]);
+                }
+            }
+        }
+        public void ElementwiseNotEquals(PrimitiveColumnContainer<DateTime> column, DateTime scalar, PrimitiveColumnContainer<bool> ret)
+        {
+            for (int b = 0; b < column.Buffers.Count; b++)
+            {
+                var buffer = column.Buffers[b];
+                var mutableBuffer = DataFrameBuffer<DateTime>.GetMutableBuffer(buffer);
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < span.Length; i++)
+                {
+                    ret[i] = (span[i] != scalar);
+                }
+            }
+        }
+        public void ElementwiseGreaterThanOrEqual(PrimitiveColumnContainer<DateTime> left, PrimitiveColumnContainer<DateTime> right, PrimitiveColumnContainer<bool> ret)
+        {
+            for (int b = 0; b < left.Buffers.Count; b++)
+            {
+                var buffer = left.Buffers[b];
+                var mutableBuffer = DataFrameBuffer<DateTime>.GetMutableBuffer(buffer);
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < span.Length; i++)
+                {
+                    ret[i] = (span[i] >= otherSpan[i]);
+                }
+            }
+        }
+        public void ElementwiseGreaterThanOrEqual(PrimitiveColumnContainer<DateTime> column, DateTime scalar, PrimitiveColumnContainer<bool> ret)
+        {
+            for (int b = 0; b < column.Buffers.Count; b++)
+            {
+                var buffer = column.Buffers[b];
+                var mutableBuffer = DataFrameBuffer<DateTime>.GetMutableBuffer(buffer);
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < span.Length; i++)
+                {
+                    ret[i] = (span[i] >= scalar);
+                }
+            }
+        }
+        public void ElementwiseLessThanOrEqual(PrimitiveColumnContainer<DateTime> left, PrimitiveColumnContainer<DateTime> right, PrimitiveColumnContainer<bool> ret)
+        {
+            for (int b = 0; b < left.Buffers.Count; b++)
+            {
+                var buffer = left.Buffers[b];
+                var mutableBuffer = DataFrameBuffer<DateTime>.GetMutableBuffer(buffer);
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < span.Length; i++)
+                {
+                    ret[i] = (span[i] <= otherSpan[i]);
+                }
+            }
+        }
+        public void ElementwiseLessThanOrEqual(PrimitiveColumnContainer<DateTime> column, DateTime scalar, PrimitiveColumnContainer<bool> ret)
+        {
+            for (int b = 0; b < column.Buffers.Count; b++)
+            {
+                var buffer = column.Buffers[b];
+                var mutableBuffer = DataFrameBuffer<DateTime>.GetMutableBuffer(buffer);
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < span.Length; i++)
+                {
+                    ret[i] = (span[i] <= scalar);
+                }
+            }
+        }
+        public void ElementwiseGreaterThan(PrimitiveColumnContainer<DateTime> left, PrimitiveColumnContainer<DateTime> right, PrimitiveColumnContainer<bool> ret)
+        {
+            for (int b = 0; b < left.Buffers.Count; b++)
+            {
+                var buffer = left.Buffers[b];
+                var mutableBuffer = DataFrameBuffer<DateTime>.GetMutableBuffer(buffer);
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < span.Length; i++)
+                {
+                    ret[i] = (span[i] > otherSpan[i]);
+                }
+            }
+        }
+        public void ElementwiseGreaterThan(PrimitiveColumnContainer<DateTime> column, DateTime scalar, PrimitiveColumnContainer<bool> ret)
+        {
+            for (int b = 0; b < column.Buffers.Count; b++)
+            {
+                var buffer = column.Buffers[b];
+                var mutableBuffer = DataFrameBuffer<DateTime>.GetMutableBuffer(buffer);
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < span.Length; i++)
+                {
+                    ret[i] = (span[i] > scalar);
+                }
+            }
+        }
+        public void ElementwiseLessThan(PrimitiveColumnContainer<DateTime> left, PrimitiveColumnContainer<DateTime> right, PrimitiveColumnContainer<bool> ret)
+        {
+            for (int b = 0; b < left.Buffers.Count; b++)
+            {
+                var buffer = left.Buffers[b];
+                var mutableBuffer = DataFrameBuffer<DateTime>.GetMutableBuffer(buffer);
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < span.Length; i++)
+                {
+                    ret[i] = (span[i] < otherSpan[i]);
+                }
+            }
+        }
+        public void ElementwiseLessThan(PrimitiveColumnContainer<DateTime> column, DateTime scalar, PrimitiveColumnContainer<bool> ret)
+        {
+            for (int b = 0; b < column.Buffers.Count; b++)
+            {
+                var buffer = column.Buffers[b];
+                var mutableBuffer = DataFrameBuffer<DateTime>.GetMutableBuffer(buffer);
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < span.Length; i++)
+                {
+                    ret[i] = (span[i] < scalar);
+                }
+            }
+        }
+    }
 }

--- a/src/Microsoft.Data.Analysis/DateTimeDataFrameColumn.cs
+++ b/src/Microsoft.Data.Analysis/DateTimeDataFrameColumn.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Data.Analysis
+{
+    public partial class DateTimeDataFrameColumn : PrimitiveDataFrameColumn<DateTime>
+    {
+        public DateTimeDataFrameColumn(string name, IEnumerable<DateTime?> values) : base(name, values) { }
+
+        public DateTimeDataFrameColumn(string name, IEnumerable<DateTime> values) : base(name, values) { }
+
+        public DateTimeDataFrameColumn(string name, long length = 0) : base(name, length) { }
+
+        public DateTimeDataFrameColumn(string name, ReadOnlyMemory<byte> buffer, ReadOnlyMemory<byte> nullBitMap, int length = 0, int nullCount = 0) : base(name, buffer, nullBitMap, length, nullCount) { }
+
+        internal DateTimeDataFrameColumn(string name, PrimitiveColumnContainer<DateTime> values) : base(name, values) { }
+    }
+}

--- a/src/Microsoft.Data.Analysis/IDataView.Extension.cs
+++ b/src/Microsoft.Data.Analysis/IDataView.Extension.cs
@@ -68,6 +68,10 @@ namespace Microsoft.ML
                 {
                     dataFrameColumns.Add(new BooleanDataFrameColumn(dataViewColumn.Name));
                 }
+                else if (type == DateTimeDataViewType.Instance)
+                {
+                    dataFrameColumns.Add(new DateTimeDataFrameColumn(dataViewColumn.Name));
+                }
                 else if (type == NumberDataViewType.Byte)
                 {
                     dataFrameColumns.Add(new ByteDataFrameColumn(dataViewColumn.Name));

--- a/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.BinaryOperations.cs
+++ b/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.BinaryOperations.cs
@@ -380,6 +380,8 @@ namespace Microsoft.Data.Analysis
                     return ElementwiseEqualsImplementation(column as PrimitiveDataFrameColumn<byte>);
                 case PrimitiveDataFrameColumn<char> charColumn:
                     return ElementwiseEqualsImplementation(column as PrimitiveDataFrameColumn<char>);
+                case PrimitiveDataFrameColumn<DateTime> dateTimeColumn:
+                    return ElementwiseEqualsImplementation(column as PrimitiveDataFrameColumn<DateTime>);
                 case PrimitiveDataFrameColumn<decimal> decimalColumn:
                     return ElementwiseEqualsImplementation(column as PrimitiveDataFrameColumn<decimal>);
                 case PrimitiveDataFrameColumn<double> doubleColumn:
@@ -1743,6 +1745,14 @@ namespace Microsoft.Data.Analysis
                     PrimitiveDataFrameColumn<bool> retColumn = CloneAsBooleanColumn();
                     (this as PrimitiveDataFrameColumn<U>)._columnContainer.ElementwiseEquals(column._columnContainer, retColumn._columnContainer);
                     return retColumn;
+                case Type dateTimeType when dateTimeType == typeof(DateTime):
+                    if (typeof(U) != typeof(DateTime))
+                    {
+                        throw new NotSupportedException();
+                    }
+                    PrimitiveDataFrameColumn<bool> newcolumn = CloneAsBooleanColumn();
+                    (this as PrimitiveDataFrameColumn<U>)._columnContainer.ElementwiseEquals(column._columnContainer, newcolumn._columnContainer);
+                    return newcolumn;
                 case Type decimalType when decimalType == typeof(decimal):
                     if (typeof(U) == typeof(bool))
                     {

--- a/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.cs
+++ b/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.cs
@@ -690,7 +690,7 @@ namespace Microsoft.Data.Analysis
             builder.AddColumn(Name, GetDataViewType());
         }
 
-        public static DataViewType GetDataViewType()
+        private static DataViewType GetDataViewType()
         {
             if (typeof(T) == typeof(bool))
             {

--- a/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.cs
+++ b/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.cs
@@ -282,7 +282,7 @@ namespace Microsoft.Data.Analysis
         public override bool IsNumericColumn()
         {
             bool ret = true;
-            if (typeof(T) == typeof(char) || typeof(T) == typeof(bool))
+            if (typeof(T) == typeof(char) || typeof(T) == typeof(bool) || typeof(T) == typeof(DateTime))
                 ret = false;
             return ret;
         }
@@ -325,7 +325,10 @@ namespace Microsoft.Data.Analysis
         }
 
         /// <inheritdoc/>
-        public override bool HasDescription() => IsNumericColumn();
+        public override bool HasDescription()
+        {
+            return this.IsNumericColumn() || typeof(T) == typeof(DateTime);
+        }
 
         /// <summary>
         /// Returns a preview of the column contents as a formatted string.
@@ -687,7 +690,7 @@ namespace Microsoft.Data.Analysis
             builder.AddColumn(Name, GetDataViewType());
         }
 
-        private static DataViewType GetDataViewType()
+        public static DataViewType GetDataViewType()
         {
             if (typeof(T) == typeof(bool))
             {
@@ -700,6 +703,10 @@ namespace Microsoft.Data.Analysis
             else if (typeof(T) == typeof(double))
             {
                 return NumberDataViewType.Double;
+            }
+            else if (typeof(T) == typeof(DateTime))
+            {
+                return DateTimeDataViewType.Instance;
             }
             else if (typeof(T) == typeof(float))
             {
@@ -744,7 +751,7 @@ namespace Microsoft.Data.Analysis
                 return NumberDataViewType.Double;
             }
 
-            throw new NotSupportedException();
+            throw new NotSupportedException("Type is " + typeof(T).Name);
         }
 
         protected internal override Delegate GetDataViewGetter(DataViewRowCursor cursor)

--- a/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumnArithmetic.cs
+++ b/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumnArithmetic.cs
@@ -116,6 +116,10 @@ namespace Microsoft.Data.Analysis
             {
                 return (IPrimitiveDataFrameColumnArithmetic<T>)new UShortArithmetic();
             }
+            else if (typeof(T) == typeof(DateTime))
+            {
+                return (IPrimitiveDataFrameColumnArithmetic<T>)new DateTimeArithmetic();
+            }
             throw new NotSupportedException();
         }
     }
@@ -130,10 +134,10 @@ namespace Microsoft.Data.Analysis
         {
             throw new NotSupportedException();
         }
-
+ 
         public void Add(bool scalar, PrimitiveColumnContainer<bool> column)
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException(); 
         }
         public void Subtract(PrimitiveColumnContainer<bool> left, PrimitiveColumnContainer<bool> right)
         {
@@ -143,10 +147,10 @@ namespace Microsoft.Data.Analysis
         {
             throw new NotSupportedException();
         }
-
+ 
         public void Subtract(bool scalar, PrimitiveColumnContainer<bool> column)
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException(); 
         }
         public void Multiply(PrimitiveColumnContainer<bool> left, PrimitiveColumnContainer<bool> right)
         {
@@ -156,10 +160,10 @@ namespace Microsoft.Data.Analysis
         {
             throw new NotSupportedException();
         }
-
+ 
         public void Multiply(bool scalar, PrimitiveColumnContainer<bool> column)
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException(); 
         }
         public void Divide(PrimitiveColumnContainer<bool> left, PrimitiveColumnContainer<bool> right)
         {
@@ -169,10 +173,10 @@ namespace Microsoft.Data.Analysis
         {
             throw new NotSupportedException();
         }
-
+ 
         public void Divide(bool scalar, PrimitiveColumnContainer<bool> column)
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException(); 
         }
         public void Modulo(PrimitiveColumnContainer<bool> left, PrimitiveColumnContainer<bool> right)
         {
@@ -182,10 +186,10 @@ namespace Microsoft.Data.Analysis
         {
             throw new NotSupportedException();
         }
-
+ 
         public void Modulo(bool scalar, PrimitiveColumnContainer<bool> column)
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException(); 
         }
         public void And(PrimitiveColumnContainer<bool> left, PrimitiveColumnContainer<bool> right)
         {
@@ -216,16 +220,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void And(bool scalar, PrimitiveColumnContainer<bool> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<bool>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (bool)(scalar & span[i]);
                 }
@@ -260,16 +264,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Or(bool scalar, PrimitiveColumnContainer<bool> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<bool>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (bool)(scalar | span[i]);
                 }
@@ -304,16 +308,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Xor(bool scalar, PrimitiveColumnContainer<bool> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<bool>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (bool)(scalar ^ span[i]);
                 }
@@ -449,16 +453,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Add(byte scalar, PrimitiveColumnContainer<byte> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (byte)(scalar + span[i]);
                 }
@@ -493,16 +497,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Subtract(byte scalar, PrimitiveColumnContainer<byte> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (byte)(scalar - span[i]);
                 }
@@ -537,16 +541,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Multiply(byte scalar, PrimitiveColumnContainer<byte> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (byte)(scalar * span[i]);
                 }
@@ -581,16 +585,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Divide(byte scalar, PrimitiveColumnContainer<byte> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (byte)(scalar / span[i]);
                 }
@@ -625,16 +629,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Modulo(byte scalar, PrimitiveColumnContainer<byte> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (byte)(scalar % span[i]);
                 }
@@ -669,16 +673,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void And(byte scalar, PrimitiveColumnContainer<byte> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (byte)(scalar & span[i]);
                 }
@@ -713,16 +717,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Or(byte scalar, PrimitiveColumnContainer<byte> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (byte)(scalar | span[i]);
                 }
@@ -757,16 +761,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Xor(byte scalar, PrimitiveColumnContainer<byte> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (byte)(scalar ^ span[i]);
                 }
@@ -1006,16 +1010,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Add(char scalar, PrimitiveColumnContainer<char> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (char)(scalar + span[i]);
                 }
@@ -1050,16 +1054,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Subtract(char scalar, PrimitiveColumnContainer<char> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (char)(scalar - span[i]);
                 }
@@ -1094,16 +1098,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Multiply(char scalar, PrimitiveColumnContainer<char> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (char)(scalar * span[i]);
                 }
@@ -1138,16 +1142,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Divide(char scalar, PrimitiveColumnContainer<char> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (char)(scalar / span[i]);
                 }
@@ -1182,16 +1186,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Modulo(char scalar, PrimitiveColumnContainer<char> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (char)(scalar % span[i]);
                 }
@@ -1226,16 +1230,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void And(char scalar, PrimitiveColumnContainer<char> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (char)(scalar & span[i]);
                 }
@@ -1270,16 +1274,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Or(char scalar, PrimitiveColumnContainer<char> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (char)(scalar | span[i]);
                 }
@@ -1314,16 +1318,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Xor(char scalar, PrimitiveColumnContainer<char> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (char)(scalar ^ span[i]);
                 }
@@ -1563,16 +1567,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Add(decimal scalar, PrimitiveColumnContainer<decimal> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (decimal)(scalar + span[i]);
                 }
@@ -1607,16 +1611,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Subtract(decimal scalar, PrimitiveColumnContainer<decimal> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (decimal)(scalar - span[i]);
                 }
@@ -1651,16 +1655,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Multiply(decimal scalar, PrimitiveColumnContainer<decimal> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (decimal)(scalar * span[i]);
                 }
@@ -1695,16 +1699,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Divide(decimal scalar, PrimitiveColumnContainer<decimal> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (decimal)(scalar / span[i]);
                 }
@@ -1739,16 +1743,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Modulo(decimal scalar, PrimitiveColumnContainer<decimal> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (decimal)(scalar % span[i]);
                 }
@@ -1762,10 +1766,10 @@ namespace Microsoft.Data.Analysis
         {
             throw new NotSupportedException();
         }
-
+ 
         public void And(decimal scalar, PrimitiveColumnContainer<decimal> column)
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException(); 
         }
         public void Or(PrimitiveColumnContainer<decimal> left, PrimitiveColumnContainer<decimal> right)
         {
@@ -1775,10 +1779,10 @@ namespace Microsoft.Data.Analysis
         {
             throw new NotSupportedException();
         }
-
+ 
         public void Or(decimal scalar, PrimitiveColumnContainer<decimal> column)
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException(); 
         }
         public void Xor(PrimitiveColumnContainer<decimal> left, PrimitiveColumnContainer<decimal> right)
         {
@@ -1788,10 +1792,10 @@ namespace Microsoft.Data.Analysis
         {
             throw new NotSupportedException();
         }
-
+ 
         public void Xor(decimal scalar, PrimitiveColumnContainer<decimal> column)
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException(); 
         }
         public void LeftShift(PrimitiveColumnContainer<decimal> column, int value)
         {
@@ -2007,16 +2011,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Add(double scalar, PrimitiveColumnContainer<double> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (double)(scalar + span[i]);
                 }
@@ -2051,16 +2055,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Subtract(double scalar, PrimitiveColumnContainer<double> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (double)(scalar - span[i]);
                 }
@@ -2095,16 +2099,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Multiply(double scalar, PrimitiveColumnContainer<double> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (double)(scalar * span[i]);
                 }
@@ -2139,16 +2143,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Divide(double scalar, PrimitiveColumnContainer<double> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (double)(scalar / span[i]);
                 }
@@ -2183,16 +2187,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Modulo(double scalar, PrimitiveColumnContainer<double> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (double)(scalar % span[i]);
                 }
@@ -2206,10 +2210,10 @@ namespace Microsoft.Data.Analysis
         {
             throw new NotSupportedException();
         }
-
+ 
         public void And(double scalar, PrimitiveColumnContainer<double> column)
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException(); 
         }
         public void Or(PrimitiveColumnContainer<double> left, PrimitiveColumnContainer<double> right)
         {
@@ -2219,10 +2223,10 @@ namespace Microsoft.Data.Analysis
         {
             throw new NotSupportedException();
         }
-
+ 
         public void Or(double scalar, PrimitiveColumnContainer<double> column)
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException(); 
         }
         public void Xor(PrimitiveColumnContainer<double> left, PrimitiveColumnContainer<double> right)
         {
@@ -2232,10 +2236,10 @@ namespace Microsoft.Data.Analysis
         {
             throw new NotSupportedException();
         }
-
+ 
         public void Xor(double scalar, PrimitiveColumnContainer<double> column)
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException(); 
         }
         public void LeftShift(PrimitiveColumnContainer<double> column, int value)
         {
@@ -2451,16 +2455,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Add(float scalar, PrimitiveColumnContainer<float> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (float)(scalar + span[i]);
                 }
@@ -2495,16 +2499,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Subtract(float scalar, PrimitiveColumnContainer<float> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (float)(scalar - span[i]);
                 }
@@ -2539,16 +2543,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Multiply(float scalar, PrimitiveColumnContainer<float> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (float)(scalar * span[i]);
                 }
@@ -2583,16 +2587,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Divide(float scalar, PrimitiveColumnContainer<float> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (float)(scalar / span[i]);
                 }
@@ -2627,16 +2631,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Modulo(float scalar, PrimitiveColumnContainer<float> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (float)(scalar % span[i]);
                 }
@@ -2650,10 +2654,10 @@ namespace Microsoft.Data.Analysis
         {
             throw new NotSupportedException();
         }
-
+ 
         public void And(float scalar, PrimitiveColumnContainer<float> column)
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException(); 
         }
         public void Or(PrimitiveColumnContainer<float> left, PrimitiveColumnContainer<float> right)
         {
@@ -2663,10 +2667,10 @@ namespace Microsoft.Data.Analysis
         {
             throw new NotSupportedException();
         }
-
+ 
         public void Or(float scalar, PrimitiveColumnContainer<float> column)
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException(); 
         }
         public void Xor(PrimitiveColumnContainer<float> left, PrimitiveColumnContainer<float> right)
         {
@@ -2676,10 +2680,10 @@ namespace Microsoft.Data.Analysis
         {
             throw new NotSupportedException();
         }
-
+ 
         public void Xor(float scalar, PrimitiveColumnContainer<float> column)
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException(); 
         }
         public void LeftShift(PrimitiveColumnContainer<float> column, int value)
         {
@@ -2895,16 +2899,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Add(int scalar, PrimitiveColumnContainer<int> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (int)(scalar + span[i]);
                 }
@@ -2939,16 +2943,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Subtract(int scalar, PrimitiveColumnContainer<int> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (int)(scalar - span[i]);
                 }
@@ -2983,16 +2987,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Multiply(int scalar, PrimitiveColumnContainer<int> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (int)(scalar * span[i]);
                 }
@@ -3027,16 +3031,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Divide(int scalar, PrimitiveColumnContainer<int> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (int)(scalar / span[i]);
                 }
@@ -3071,16 +3075,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Modulo(int scalar, PrimitiveColumnContainer<int> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (int)(scalar % span[i]);
                 }
@@ -3115,16 +3119,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void And(int scalar, PrimitiveColumnContainer<int> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (int)(scalar & span[i]);
                 }
@@ -3159,16 +3163,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Or(int scalar, PrimitiveColumnContainer<int> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (int)(scalar | span[i]);
                 }
@@ -3203,16 +3207,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Xor(int scalar, PrimitiveColumnContainer<int> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (int)(scalar ^ span[i]);
                 }
@@ -3452,16 +3456,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Add(long scalar, PrimitiveColumnContainer<long> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (long)(scalar + span[i]);
                 }
@@ -3496,16 +3500,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Subtract(long scalar, PrimitiveColumnContainer<long> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (long)(scalar - span[i]);
                 }
@@ -3540,16 +3544,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Multiply(long scalar, PrimitiveColumnContainer<long> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (long)(scalar * span[i]);
                 }
@@ -3584,16 +3588,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Divide(long scalar, PrimitiveColumnContainer<long> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (long)(scalar / span[i]);
                 }
@@ -3628,16 +3632,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Modulo(long scalar, PrimitiveColumnContainer<long> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (long)(scalar % span[i]);
                 }
@@ -3672,16 +3676,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void And(long scalar, PrimitiveColumnContainer<long> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (long)(scalar & span[i]);
                 }
@@ -3716,16 +3720,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Or(long scalar, PrimitiveColumnContainer<long> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (long)(scalar | span[i]);
                 }
@@ -3760,16 +3764,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Xor(long scalar, PrimitiveColumnContainer<long> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (long)(scalar ^ span[i]);
                 }
@@ -4009,16 +4013,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Add(sbyte scalar, PrimitiveColumnContainer<sbyte> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (sbyte)(scalar + span[i]);
                 }
@@ -4053,16 +4057,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Subtract(sbyte scalar, PrimitiveColumnContainer<sbyte> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (sbyte)(scalar - span[i]);
                 }
@@ -4097,16 +4101,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Multiply(sbyte scalar, PrimitiveColumnContainer<sbyte> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (sbyte)(scalar * span[i]);
                 }
@@ -4141,16 +4145,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Divide(sbyte scalar, PrimitiveColumnContainer<sbyte> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (sbyte)(scalar / span[i]);
                 }
@@ -4185,16 +4189,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Modulo(sbyte scalar, PrimitiveColumnContainer<sbyte> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (sbyte)(scalar % span[i]);
                 }
@@ -4229,16 +4233,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void And(sbyte scalar, PrimitiveColumnContainer<sbyte> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (sbyte)(scalar & span[i]);
                 }
@@ -4273,16 +4277,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Or(sbyte scalar, PrimitiveColumnContainer<sbyte> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (sbyte)(scalar | span[i]);
                 }
@@ -4317,16 +4321,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Xor(sbyte scalar, PrimitiveColumnContainer<sbyte> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (sbyte)(scalar ^ span[i]);
                 }
@@ -4566,16 +4570,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Add(short scalar, PrimitiveColumnContainer<short> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (short)(scalar + span[i]);
                 }
@@ -4610,16 +4614,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Subtract(short scalar, PrimitiveColumnContainer<short> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (short)(scalar - span[i]);
                 }
@@ -4654,16 +4658,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Multiply(short scalar, PrimitiveColumnContainer<short> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (short)(scalar * span[i]);
                 }
@@ -4698,16 +4702,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Divide(short scalar, PrimitiveColumnContainer<short> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (short)(scalar / span[i]);
                 }
@@ -4742,16 +4746,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Modulo(short scalar, PrimitiveColumnContainer<short> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (short)(scalar % span[i]);
                 }
@@ -4786,16 +4790,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void And(short scalar, PrimitiveColumnContainer<short> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (short)(scalar & span[i]);
                 }
@@ -4830,16 +4834,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Or(short scalar, PrimitiveColumnContainer<short> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (short)(scalar | span[i]);
                 }
@@ -4874,16 +4878,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Xor(short scalar, PrimitiveColumnContainer<short> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (short)(scalar ^ span[i]);
                 }
@@ -5123,16 +5127,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Add(uint scalar, PrimitiveColumnContainer<uint> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (uint)(scalar + span[i]);
                 }
@@ -5167,16 +5171,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Subtract(uint scalar, PrimitiveColumnContainer<uint> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (uint)(scalar - span[i]);
                 }
@@ -5211,16 +5215,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Multiply(uint scalar, PrimitiveColumnContainer<uint> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (uint)(scalar * span[i]);
                 }
@@ -5255,16 +5259,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Divide(uint scalar, PrimitiveColumnContainer<uint> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (uint)(scalar / span[i]);
                 }
@@ -5299,16 +5303,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Modulo(uint scalar, PrimitiveColumnContainer<uint> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (uint)(scalar % span[i]);
                 }
@@ -5343,16 +5347,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void And(uint scalar, PrimitiveColumnContainer<uint> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (uint)(scalar & span[i]);
                 }
@@ -5387,16 +5391,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Or(uint scalar, PrimitiveColumnContainer<uint> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (uint)(scalar | span[i]);
                 }
@@ -5431,16 +5435,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Xor(uint scalar, PrimitiveColumnContainer<uint> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (uint)(scalar ^ span[i]);
                 }
@@ -5680,16 +5684,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Add(ulong scalar, PrimitiveColumnContainer<ulong> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (ulong)(scalar + span[i]);
                 }
@@ -5724,16 +5728,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Subtract(ulong scalar, PrimitiveColumnContainer<ulong> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (ulong)(scalar - span[i]);
                 }
@@ -5768,16 +5772,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Multiply(ulong scalar, PrimitiveColumnContainer<ulong> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (ulong)(scalar * span[i]);
                 }
@@ -5812,16 +5816,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Divide(ulong scalar, PrimitiveColumnContainer<ulong> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (ulong)(scalar / span[i]);
                 }
@@ -5856,16 +5860,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Modulo(ulong scalar, PrimitiveColumnContainer<ulong> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (ulong)(scalar % span[i]);
                 }
@@ -5900,16 +5904,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void And(ulong scalar, PrimitiveColumnContainer<ulong> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (ulong)(scalar & span[i]);
                 }
@@ -5944,16 +5948,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Or(ulong scalar, PrimitiveColumnContainer<ulong> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (ulong)(scalar | span[i]);
                 }
@@ -5988,16 +5992,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Xor(ulong scalar, PrimitiveColumnContainer<ulong> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (ulong)(scalar ^ span[i]);
                 }
@@ -6237,16 +6241,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Add(ushort scalar, PrimitiveColumnContainer<ushort> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (ushort)(scalar + span[i]);
                 }
@@ -6281,16 +6285,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Subtract(ushort scalar, PrimitiveColumnContainer<ushort> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (ushort)(scalar - span[i]);
                 }
@@ -6325,16 +6329,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Multiply(ushort scalar, PrimitiveColumnContainer<ushort> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (ushort)(scalar * span[i]);
                 }
@@ -6369,16 +6373,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Divide(ushort scalar, PrimitiveColumnContainer<ushort> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (ushort)(scalar / span[i]);
                 }
@@ -6413,16 +6417,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Modulo(ushort scalar, PrimitiveColumnContainer<ushort> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (ushort)(scalar % span[i]);
                 }
@@ -6457,16 +6461,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void And(ushort scalar, PrimitiveColumnContainer<ushort> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (ushort)(scalar & span[i]);
                 }
@@ -6501,16 +6505,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Or(ushort scalar, PrimitiveColumnContainer<ushort> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (ushort)(scalar | span[i]);
                 }
@@ -6545,16 +6549,16 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
-
+ 
         public void Xor(ushort scalar, PrimitiveColumnContainer<ushort> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
+                var buffer = column.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++)
+                for (int i = 0; i < span.Length; i++) 
                 {
                     span[i] = (ushort)(scalar ^ span[i]);
                 }

--- a/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumnArithmetic.cs
+++ b/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumnArithmetic.cs
@@ -134,10 +134,9 @@ namespace Microsoft.Data.Analysis
         {
             throw new NotSupportedException();
         }
- 
         public void Add(bool scalar, PrimitiveColumnContainer<bool> column)
         {
-            throw new NotSupportedException(); 
+            throw new NotSupportedException();
         }
         public void Subtract(PrimitiveColumnContainer<bool> left, PrimitiveColumnContainer<bool> right)
         {
@@ -147,10 +146,9 @@ namespace Microsoft.Data.Analysis
         {
             throw new NotSupportedException();
         }
- 
         public void Subtract(bool scalar, PrimitiveColumnContainer<bool> column)
         {
-            throw new NotSupportedException(); 
+            throw new NotSupportedException();
         }
         public void Multiply(PrimitiveColumnContainer<bool> left, PrimitiveColumnContainer<bool> right)
         {
@@ -160,10 +158,9 @@ namespace Microsoft.Data.Analysis
         {
             throw new NotSupportedException();
         }
- 
         public void Multiply(bool scalar, PrimitiveColumnContainer<bool> column)
         {
-            throw new NotSupportedException(); 
+            throw new NotSupportedException();
         }
         public void Divide(PrimitiveColumnContainer<bool> left, PrimitiveColumnContainer<bool> right)
         {
@@ -173,10 +170,9 @@ namespace Microsoft.Data.Analysis
         {
             throw new NotSupportedException();
         }
- 
         public void Divide(bool scalar, PrimitiveColumnContainer<bool> column)
         {
-            throw new NotSupportedException(); 
+            throw new NotSupportedException();
         }
         public void Modulo(PrimitiveColumnContainer<bool> left, PrimitiveColumnContainer<bool> right)
         {
@@ -186,10 +182,9 @@ namespace Microsoft.Data.Analysis
         {
             throw new NotSupportedException();
         }
- 
         public void Modulo(bool scalar, PrimitiveColumnContainer<bool> column)
         {
-            throw new NotSupportedException(); 
+            throw new NotSupportedException();
         }
         public void And(PrimitiveColumnContainer<bool> left, PrimitiveColumnContainer<bool> right)
         {
@@ -220,16 +215,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void And(bool scalar, PrimitiveColumnContainer<bool> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<bool>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (bool)(scalar & span[i]);
                 }
@@ -264,16 +258,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Or(bool scalar, PrimitiveColumnContainer<bool> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<bool>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (bool)(scalar | span[i]);
                 }
@@ -308,16 +301,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Xor(bool scalar, PrimitiveColumnContainer<bool> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<bool>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (bool)(scalar ^ span[i]);
                 }
@@ -453,16 +445,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Add(byte scalar, PrimitiveColumnContainer<byte> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (byte)(scalar + span[i]);
                 }
@@ -497,16 +488,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Subtract(byte scalar, PrimitiveColumnContainer<byte> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (byte)(scalar - span[i]);
                 }
@@ -541,16 +531,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Multiply(byte scalar, PrimitiveColumnContainer<byte> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (byte)(scalar * span[i]);
                 }
@@ -585,16 +574,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Divide(byte scalar, PrimitiveColumnContainer<byte> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (byte)(scalar / span[i]);
                 }
@@ -629,16 +617,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Modulo(byte scalar, PrimitiveColumnContainer<byte> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (byte)(scalar % span[i]);
                 }
@@ -673,16 +660,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void And(byte scalar, PrimitiveColumnContainer<byte> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (byte)(scalar & span[i]);
                 }
@@ -717,16 +703,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Or(byte scalar, PrimitiveColumnContainer<byte> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (byte)(scalar | span[i]);
                 }
@@ -761,16 +746,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Xor(byte scalar, PrimitiveColumnContainer<byte> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (byte)(scalar ^ span[i]);
                 }
@@ -1010,16 +994,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Add(char scalar, PrimitiveColumnContainer<char> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (char)(scalar + span[i]);
                 }
@@ -1054,16 +1037,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Subtract(char scalar, PrimitiveColumnContainer<char> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (char)(scalar - span[i]);
                 }
@@ -1098,16 +1080,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Multiply(char scalar, PrimitiveColumnContainer<char> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (char)(scalar * span[i]);
                 }
@@ -1142,16 +1123,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Divide(char scalar, PrimitiveColumnContainer<char> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (char)(scalar / span[i]);
                 }
@@ -1186,16 +1166,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Modulo(char scalar, PrimitiveColumnContainer<char> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (char)(scalar % span[i]);
                 }
@@ -1230,16 +1209,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void And(char scalar, PrimitiveColumnContainer<char> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (char)(scalar & span[i]);
                 }
@@ -1274,16 +1252,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Or(char scalar, PrimitiveColumnContainer<char> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (char)(scalar | span[i]);
                 }
@@ -1318,16 +1295,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Xor(char scalar, PrimitiveColumnContainer<char> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (char)(scalar ^ span[i]);
                 }
@@ -1567,16 +1543,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Add(decimal scalar, PrimitiveColumnContainer<decimal> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (decimal)(scalar + span[i]);
                 }
@@ -1611,16 +1586,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Subtract(decimal scalar, PrimitiveColumnContainer<decimal> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (decimal)(scalar - span[i]);
                 }
@@ -1655,16 +1629,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Multiply(decimal scalar, PrimitiveColumnContainer<decimal> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (decimal)(scalar * span[i]);
                 }
@@ -1699,16 +1672,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Divide(decimal scalar, PrimitiveColumnContainer<decimal> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (decimal)(scalar / span[i]);
                 }
@@ -1743,16 +1715,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Modulo(decimal scalar, PrimitiveColumnContainer<decimal> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (decimal)(scalar % span[i]);
                 }
@@ -1766,10 +1737,9 @@ namespace Microsoft.Data.Analysis
         {
             throw new NotSupportedException();
         }
- 
         public void And(decimal scalar, PrimitiveColumnContainer<decimal> column)
         {
-            throw new NotSupportedException(); 
+            throw new NotSupportedException();
         }
         public void Or(PrimitiveColumnContainer<decimal> left, PrimitiveColumnContainer<decimal> right)
         {
@@ -1779,10 +1749,9 @@ namespace Microsoft.Data.Analysis
         {
             throw new NotSupportedException();
         }
- 
         public void Or(decimal scalar, PrimitiveColumnContainer<decimal> column)
         {
-            throw new NotSupportedException(); 
+            throw new NotSupportedException();
         }
         public void Xor(PrimitiveColumnContainer<decimal> left, PrimitiveColumnContainer<decimal> right)
         {
@@ -1792,10 +1761,9 @@ namespace Microsoft.Data.Analysis
         {
             throw new NotSupportedException();
         }
- 
         public void Xor(decimal scalar, PrimitiveColumnContainer<decimal> column)
         {
-            throw new NotSupportedException(); 
+            throw new NotSupportedException();
         }
         public void LeftShift(PrimitiveColumnContainer<decimal> column, int value)
         {
@@ -2011,16 +1979,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Add(double scalar, PrimitiveColumnContainer<double> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (double)(scalar + span[i]);
                 }
@@ -2055,16 +2022,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Subtract(double scalar, PrimitiveColumnContainer<double> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (double)(scalar - span[i]);
                 }
@@ -2099,16 +2065,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Multiply(double scalar, PrimitiveColumnContainer<double> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (double)(scalar * span[i]);
                 }
@@ -2143,16 +2108,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Divide(double scalar, PrimitiveColumnContainer<double> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (double)(scalar / span[i]);
                 }
@@ -2187,16 +2151,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Modulo(double scalar, PrimitiveColumnContainer<double> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (double)(scalar % span[i]);
                 }
@@ -2210,10 +2173,9 @@ namespace Microsoft.Data.Analysis
         {
             throw new NotSupportedException();
         }
- 
         public void And(double scalar, PrimitiveColumnContainer<double> column)
         {
-            throw new NotSupportedException(); 
+            throw new NotSupportedException();
         }
         public void Or(PrimitiveColumnContainer<double> left, PrimitiveColumnContainer<double> right)
         {
@@ -2223,10 +2185,9 @@ namespace Microsoft.Data.Analysis
         {
             throw new NotSupportedException();
         }
- 
         public void Or(double scalar, PrimitiveColumnContainer<double> column)
         {
-            throw new NotSupportedException(); 
+            throw new NotSupportedException();
         }
         public void Xor(PrimitiveColumnContainer<double> left, PrimitiveColumnContainer<double> right)
         {
@@ -2236,10 +2197,9 @@ namespace Microsoft.Data.Analysis
         {
             throw new NotSupportedException();
         }
- 
         public void Xor(double scalar, PrimitiveColumnContainer<double> column)
         {
-            throw new NotSupportedException(); 
+            throw new NotSupportedException();
         }
         public void LeftShift(PrimitiveColumnContainer<double> column, int value)
         {
@@ -2455,16 +2415,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Add(float scalar, PrimitiveColumnContainer<float> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (float)(scalar + span[i]);
                 }
@@ -2499,16 +2458,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Subtract(float scalar, PrimitiveColumnContainer<float> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (float)(scalar - span[i]);
                 }
@@ -2543,16 +2501,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Multiply(float scalar, PrimitiveColumnContainer<float> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (float)(scalar * span[i]);
                 }
@@ -2587,16 +2544,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Divide(float scalar, PrimitiveColumnContainer<float> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (float)(scalar / span[i]);
                 }
@@ -2631,16 +2587,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Modulo(float scalar, PrimitiveColumnContainer<float> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (float)(scalar % span[i]);
                 }
@@ -2654,10 +2609,9 @@ namespace Microsoft.Data.Analysis
         {
             throw new NotSupportedException();
         }
- 
         public void And(float scalar, PrimitiveColumnContainer<float> column)
         {
-            throw new NotSupportedException(); 
+            throw new NotSupportedException();
         }
         public void Or(PrimitiveColumnContainer<float> left, PrimitiveColumnContainer<float> right)
         {
@@ -2667,10 +2621,9 @@ namespace Microsoft.Data.Analysis
         {
             throw new NotSupportedException();
         }
- 
         public void Or(float scalar, PrimitiveColumnContainer<float> column)
         {
-            throw new NotSupportedException(); 
+            throw new NotSupportedException();
         }
         public void Xor(PrimitiveColumnContainer<float> left, PrimitiveColumnContainer<float> right)
         {
@@ -2680,10 +2633,9 @@ namespace Microsoft.Data.Analysis
         {
             throw new NotSupportedException();
         }
- 
         public void Xor(float scalar, PrimitiveColumnContainer<float> column)
         {
-            throw new NotSupportedException(); 
+            throw new NotSupportedException();
         }
         public void LeftShift(PrimitiveColumnContainer<float> column, int value)
         {
@@ -2899,16 +2851,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Add(int scalar, PrimitiveColumnContainer<int> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (int)(scalar + span[i]);
                 }
@@ -2943,16 +2894,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Subtract(int scalar, PrimitiveColumnContainer<int> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (int)(scalar - span[i]);
                 }
@@ -2987,16 +2937,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Multiply(int scalar, PrimitiveColumnContainer<int> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (int)(scalar * span[i]);
                 }
@@ -3031,16 +2980,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Divide(int scalar, PrimitiveColumnContainer<int> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (int)(scalar / span[i]);
                 }
@@ -3075,16 +3023,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Modulo(int scalar, PrimitiveColumnContainer<int> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (int)(scalar % span[i]);
                 }
@@ -3119,16 +3066,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void And(int scalar, PrimitiveColumnContainer<int> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (int)(scalar & span[i]);
                 }
@@ -3163,16 +3109,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Or(int scalar, PrimitiveColumnContainer<int> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (int)(scalar | span[i]);
                 }
@@ -3207,16 +3152,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Xor(int scalar, PrimitiveColumnContainer<int> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (int)(scalar ^ span[i]);
                 }
@@ -3456,16 +3400,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Add(long scalar, PrimitiveColumnContainer<long> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (long)(scalar + span[i]);
                 }
@@ -3500,16 +3443,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Subtract(long scalar, PrimitiveColumnContainer<long> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (long)(scalar - span[i]);
                 }
@@ -3544,16 +3486,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Multiply(long scalar, PrimitiveColumnContainer<long> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (long)(scalar * span[i]);
                 }
@@ -3588,16 +3529,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Divide(long scalar, PrimitiveColumnContainer<long> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (long)(scalar / span[i]);
                 }
@@ -3632,16 +3572,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Modulo(long scalar, PrimitiveColumnContainer<long> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (long)(scalar % span[i]);
                 }
@@ -3676,16 +3615,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void And(long scalar, PrimitiveColumnContainer<long> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (long)(scalar & span[i]);
                 }
@@ -3720,16 +3658,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Or(long scalar, PrimitiveColumnContainer<long> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (long)(scalar | span[i]);
                 }
@@ -3764,16 +3701,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Xor(long scalar, PrimitiveColumnContainer<long> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (long)(scalar ^ span[i]);
                 }
@@ -4013,16 +3949,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Add(sbyte scalar, PrimitiveColumnContainer<sbyte> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (sbyte)(scalar + span[i]);
                 }
@@ -4057,16 +3992,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Subtract(sbyte scalar, PrimitiveColumnContainer<sbyte> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (sbyte)(scalar - span[i]);
                 }
@@ -4101,16 +4035,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Multiply(sbyte scalar, PrimitiveColumnContainer<sbyte> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (sbyte)(scalar * span[i]);
                 }
@@ -4145,16 +4078,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Divide(sbyte scalar, PrimitiveColumnContainer<sbyte> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (sbyte)(scalar / span[i]);
                 }
@@ -4189,16 +4121,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Modulo(sbyte scalar, PrimitiveColumnContainer<sbyte> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (sbyte)(scalar % span[i]);
                 }
@@ -4233,16 +4164,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void And(sbyte scalar, PrimitiveColumnContainer<sbyte> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (sbyte)(scalar & span[i]);
                 }
@@ -4277,16 +4207,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Or(sbyte scalar, PrimitiveColumnContainer<sbyte> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (sbyte)(scalar | span[i]);
                 }
@@ -4321,16 +4250,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Xor(sbyte scalar, PrimitiveColumnContainer<sbyte> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (sbyte)(scalar ^ span[i]);
                 }
@@ -4570,16 +4498,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Add(short scalar, PrimitiveColumnContainer<short> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (short)(scalar + span[i]);
                 }
@@ -4614,16 +4541,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Subtract(short scalar, PrimitiveColumnContainer<short> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (short)(scalar - span[i]);
                 }
@@ -4658,16 +4584,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Multiply(short scalar, PrimitiveColumnContainer<short> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (short)(scalar * span[i]);
                 }
@@ -4702,16 +4627,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Divide(short scalar, PrimitiveColumnContainer<short> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (short)(scalar / span[i]);
                 }
@@ -4746,16 +4670,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Modulo(short scalar, PrimitiveColumnContainer<short> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (short)(scalar % span[i]);
                 }
@@ -4790,16 +4713,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void And(short scalar, PrimitiveColumnContainer<short> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (short)(scalar & span[i]);
                 }
@@ -4834,16 +4756,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Or(short scalar, PrimitiveColumnContainer<short> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (short)(scalar | span[i]);
                 }
@@ -4878,16 +4799,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Xor(short scalar, PrimitiveColumnContainer<short> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (short)(scalar ^ span[i]);
                 }
@@ -5127,16 +5047,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Add(uint scalar, PrimitiveColumnContainer<uint> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (uint)(scalar + span[i]);
                 }
@@ -5171,16 +5090,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Subtract(uint scalar, PrimitiveColumnContainer<uint> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (uint)(scalar - span[i]);
                 }
@@ -5215,16 +5133,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Multiply(uint scalar, PrimitiveColumnContainer<uint> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (uint)(scalar * span[i]);
                 }
@@ -5259,16 +5176,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Divide(uint scalar, PrimitiveColumnContainer<uint> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (uint)(scalar / span[i]);
                 }
@@ -5303,16 +5219,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Modulo(uint scalar, PrimitiveColumnContainer<uint> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (uint)(scalar % span[i]);
                 }
@@ -5347,16 +5262,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void And(uint scalar, PrimitiveColumnContainer<uint> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (uint)(scalar & span[i]);
                 }
@@ -5391,16 +5305,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Or(uint scalar, PrimitiveColumnContainer<uint> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (uint)(scalar | span[i]);
                 }
@@ -5435,16 +5348,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Xor(uint scalar, PrimitiveColumnContainer<uint> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (uint)(scalar ^ span[i]);
                 }
@@ -5684,16 +5596,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Add(ulong scalar, PrimitiveColumnContainer<ulong> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ulong)(scalar + span[i]);
                 }
@@ -5728,16 +5639,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Subtract(ulong scalar, PrimitiveColumnContainer<ulong> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ulong)(scalar - span[i]);
                 }
@@ -5772,16 +5682,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Multiply(ulong scalar, PrimitiveColumnContainer<ulong> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ulong)(scalar * span[i]);
                 }
@@ -5816,16 +5725,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Divide(ulong scalar, PrimitiveColumnContainer<ulong> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ulong)(scalar / span[i]);
                 }
@@ -5860,16 +5768,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Modulo(ulong scalar, PrimitiveColumnContainer<ulong> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ulong)(scalar % span[i]);
                 }
@@ -5904,16 +5811,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void And(ulong scalar, PrimitiveColumnContainer<ulong> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ulong)(scalar & span[i]);
                 }
@@ -5948,16 +5854,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Or(ulong scalar, PrimitiveColumnContainer<ulong> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ulong)(scalar | span[i]);
                 }
@@ -5992,16 +5897,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Xor(ulong scalar, PrimitiveColumnContainer<ulong> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ulong)(scalar ^ span[i]);
                 }
@@ -6241,16 +6145,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Add(ushort scalar, PrimitiveColumnContainer<ushort> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ushort)(scalar + span[i]);
                 }
@@ -6285,16 +6188,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Subtract(ushort scalar, PrimitiveColumnContainer<ushort> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ushort)(scalar - span[i]);
                 }
@@ -6329,16 +6231,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Multiply(ushort scalar, PrimitiveColumnContainer<ushort> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ushort)(scalar * span[i]);
                 }
@@ -6373,16 +6274,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Divide(ushort scalar, PrimitiveColumnContainer<ushort> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ushort)(scalar / span[i]);
                 }
@@ -6417,16 +6317,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Modulo(ushort scalar, PrimitiveColumnContainer<ushort> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ushort)(scalar % span[i]);
                 }
@@ -6461,16 +6360,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void And(ushort scalar, PrimitiveColumnContainer<ushort> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ushort)(scalar & span[i]);
                 }
@@ -6505,16 +6403,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Or(ushort scalar, PrimitiveColumnContainer<ushort> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ushort)(scalar | span[i]);
                 }
@@ -6549,16 +6446,15 @@ namespace Microsoft.Data.Analysis
                 }
             }
         }
- 
         public void Xor(ushort scalar, PrimitiveColumnContainer<ushort> column)
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b]; 
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ushort)(scalar ^ span[i]);
                 }
@@ -6767,8 +6663,4 @@ namespace Microsoft.Data.Analysis
             }
         }
     }
-
-
-
-
 }

--- a/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumnArithmetic.tt
+++ b/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumnArithmetic.tt
@@ -21,9 +21,9 @@ namespace Microsoft.Data.Analysis
         where T : struct
     {
 <# foreach (MethodConfiguration method in methodConfiguration) { #>
-       <#= method.GetMethodSignature("PrimitiveColumnContainer", "T")#>;
+        <#= method.GetMethodSignature("PrimitiveColumnContainer", "T")#>;
 <# if (method.MethodType == MethodType.BinaryScalar) { #>
-       <#= method.GetInvertedMethodSignatureForBinaryScalarsOps("PrimitiveColumnContainer", "T")#>;
+        <#= method.GetInvertedMethodSignatureForBinaryScalarsOps("PrimitiveColumnContainer", "T")#>;
 <# } #>
 <# } #>
     }
@@ -45,6 +45,10 @@ namespace Microsoft.Data.Analysis
                 return (IPrimitiveDataFrameColumnArithmetic<T>)new <#=type.ClassPrefix#>Arithmetic();
             }
 <# } #>
+            else if (typeof(T) == typeof(DateTime))
+            {
+                return (IPrimitiveDataFrameColumnArithmetic<T>)new DateTimeArithmetic();
+            }
             throw new NotSupportedException();
         }
     }
@@ -58,7 +62,7 @@ namespace Microsoft.Data.Analysis
 <# if ((method.IsNumeric && !type.SupportsNumeric) || (method.IsBitwise && !type.SupportsBitwise) || (type.UnsupportedMethods.Contains(method.MethodName))) { #>
             throw new NotSupportedException();
 <# } else if (method.Operator != null) { #>
-            for (int b = 0 ; b < <#= method.Op1Name #>.Buffers.Count; b++)
+            for (int b = 0; b < <#= method.Op1Name #>.Buffers.Count; b++)
             {
                 var buffer = <#= method.Op1Name #>.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<<#=type.TypeName#>>.GetMutableBuffer(buffer);
@@ -90,7 +94,7 @@ namespace Microsoft.Data.Analysis
 <# if ((method.IsNumeric && !type.SupportsNumeric) || (method.IsBitwise && !type.SupportsBitwise) || (type.UnsupportedMethods.Contains(method.MethodName))) { #>
             throw new NotSupportedException(); 
 <# } else if (method.Operator != null) { #>
-            for (int b = 0 ; b < <#= method.Op1Name #>.Buffers.Count; b++)
+            for (int b = 0; b < <#= method.Op1Name #>.Buffers.Count; b++)
             {
                 var buffer = <#= method.Op1Name #>.Buffers[b]; 
                 var mutableBuffer = DataFrameBuffer<<#=type.TypeName#>>.GetMutableBuffer(buffer);

--- a/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumnArithmetic.tt
+++ b/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumnArithmetic.tt
@@ -88,22 +88,22 @@ namespace Microsoft.Data.Analysis
             }
 <# } #>
         }
-<# if (method.MethodType == MethodType.BinaryScalar) { #> 
+<# if (method.MethodType == MethodType.BinaryScalar) { #>
         public <#= method.GetInvertedMethodSignatureForBinaryScalarsOps("PrimitiveColumnContainer", type.TypeName) #>
         {
 <# if ((method.IsNumeric && !type.SupportsNumeric) || (method.IsBitwise && !type.SupportsBitwise) || (type.UnsupportedMethods.Contains(method.MethodName))) { #>
-            throw new NotSupportedException(); 
+            throw new NotSupportedException();
 <# } else if (method.Operator != null) { #>
             for (int b = 0; b < <#= method.Op1Name #>.Buffers.Count; b++)
             {
-                var buffer = <#= method.Op1Name #>.Buffers[b]; 
+                var buffer = <#= method.Op1Name #>.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<<#=type.TypeName#>>.GetMutableBuffer(buffer);
                 <#= method.Op1Name #>.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
 <# if (method.MethodType == MethodType.Binary || method.MethodType == MethodType.Comparison) { #>
                 var otherSpan = <#=method.Op2Name#>.Buffers[b].ReadOnlySpan;
 <# } #>
-                for (int i = 0; i < span.Length; i++) 
+                for (int i = 0; i < span.Length; i++)
                 {
 <# if (method.MethodType == MethodType.BinaryScalar || method.MethodType == MethodType.BinaryInt) { #>
                     span[i] = (<#=type.TypeName#>)(<#= method.Op2Name #> <#= method.Operator #> span[i]);
@@ -116,8 +116,4 @@ namespace Microsoft.Data.Analysis
 <# } #>
     }
 <# } #>
-
-
-
-
 }

--- a/test/Microsoft.Data.Analysis.Tests/ArrowIntegrationTests.cs
+++ b/test/Microsoft.Data.Analysis.Tests/ArrowIntegrationTests.cs
@@ -156,6 +156,29 @@ namespace Microsoft.Data.Analysis.Tests
         }
 
         [Fact]
+        public void TestDateTimeType()
+        {
+            var dataFrame = new DataFrame(
+    new List<DataFrameColumn>(){
+        new SingleDataFrameColumn("Temp", new List<float>(){.22F}),
+        new DateTimeDataFrameColumn("Dteday", new List<DateTime>() {new DateTime(2022, 6, 2)}),
+    }
+);
+
+            var col1 = new DateTimeDataFrameColumn("Dteday", new List<DateTime>() { new DateTime(2022, 6, 2) });
+            var col2 = new DateTimeDataFrameColumn("Dteday2", new List<DateTime>() { new DateTime(2022, 6, 2) });
+
+            // var res21 = col1.Add(col2);
+
+            var stringCol = new StringDataFrameColumn("test1", new List<string>() { "Hello" });
+            var stringCol2 = new StringDataFrameColumn("test2", new List<string>() { "Hello" });
+
+            var res2 = stringCol.Add(stringCol2);
+
+            var res = DateTimeDataFrameColumn.GetDataViewType();
+        }
+
+        [Fact]
         public void TestMutationOnArrowColumn()
         {
             RecordBatch originalBatch = new RecordBatch.Builder()

--- a/test/Microsoft.Data.Analysis.Tests/ArrowIntegrationTests.cs
+++ b/test/Microsoft.Data.Analysis.Tests/ArrowIntegrationTests.cs
@@ -156,29 +156,6 @@ namespace Microsoft.Data.Analysis.Tests
         }
 
         [Fact]
-        public void TestDateTimeType()
-        {
-            var dataFrame = new DataFrame(
-    new List<DataFrameColumn>(){
-        new SingleDataFrameColumn("Temp", new List<float>(){.22F}),
-        new DateTimeDataFrameColumn("Dteday", new List<DateTime>() {new DateTime(2022, 6, 2)}),
-    }
-);
-
-            var col1 = new DateTimeDataFrameColumn("Dteday", new List<DateTime>() { new DateTime(2022, 6, 2) });
-            var col2 = new DateTimeDataFrameColumn("Dteday2", new List<DateTime>() { new DateTime(2022, 6, 2) });
-
-            // var res21 = col1.Add(col2);
-
-            var stringCol = new StringDataFrameColumn("test1", new List<string>() { "Hello" });
-            var stringCol2 = new StringDataFrameColumn("test2", new List<string>() { "Hello" });
-
-            var res2 = stringCol.Add(stringCol2);
-
-            var res = DateTimeDataFrameColumn.GetDataViewType();
-        }
-
-        [Fact]
         public void TestMutationOnArrowColumn()
         {
             RecordBatch originalBatch = new RecordBatch.Builder()

--- a/test/Microsoft.Data.Analysis.Tests/DataFrameColumn.BinaryOperationTests.cs
+++ b/test/Microsoft.Data.Analysis.Tests/DataFrameColumn.BinaryOperationTests.cs
@@ -170,6 +170,7 @@ namespace Microsoft.Data.Analysis.Tests
             Assert.Equal(columnResult.Length, verify.Count());
             Assert.True(columnResult.ElementwiseEquals(verifyColumn).All());
         }
+
         [Fact]
         public void AddDecimalToByteDataFrameColumn()
         {

--- a/test/Microsoft.Data.Analysis.Tests/DataFrameIDataViewTests.cs
+++ b/test/Microsoft.Data.Analysis.Tests/DataFrameIDataViewTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Data.Analysis.Tests
 
             DataDebuggerPreview preview = dataView.Preview();
             Assert.Equal(10, preview.RowView.Length);
-            Assert.Equal(15, preview.ColumnView.Length);
+            Assert.Equal(16, preview.ColumnView.Length);
 
             Assert.Equal("Byte", preview.ColumnView[0].Column.Name);
             Assert.Equal((byte)0, preview.ColumnView[0].Values[0]);
@@ -73,13 +73,17 @@ namespace Microsoft.Data.Analysis.Tests
             Assert.Equal((ushort)65, preview.ColumnView[12].Values[0]);
             Assert.Equal((ushort)66, preview.ColumnView[12].Values[1]);
 
-            Assert.Equal("Bool", preview.ColumnView[13].Column.Name);
-            Assert.Equal(true, preview.ColumnView[13].Values[0]);
-            Assert.Equal(false, preview.ColumnView[13].Values[1]);
+            Assert.Equal("DateTime", preview.ColumnView[13].Column.Name);
+            Assert.Equal(new DateTime(2021, 06, 04), preview.ColumnView[13].Values[0]);
+            Assert.Equal(new DateTime(2021, 06, 05), preview.ColumnView[13].Values[1]);
 
-            Assert.Equal("ArrowString", preview.ColumnView[14].Column.Name);
-            Assert.Equal("foo".ToString(), preview.ColumnView[14].Values[0].ToString());
-            Assert.Equal("foo".ToString(), preview.ColumnView[14].Values[1].ToString());
+            Assert.Equal("Bool", preview.ColumnView[14].Column.Name);
+            Assert.Equal(true, preview.ColumnView[14].Values[0]);
+            Assert.Equal(false, preview.ColumnView[14].Values[1]);
+
+            Assert.Equal("ArrowString", preview.ColumnView[15].Column.Name);
+            Assert.Equal("foo".ToString(), preview.ColumnView[15].Values[0].ToString());
+            Assert.Equal("foo".ToString(), preview.ColumnView[15].Values[1].ToString());
         }
 
         [Fact]
@@ -90,16 +94,16 @@ namespace Microsoft.Data.Analysis.Tests
             IDataView dataView = df;
 
             DataViewSchema schema = dataView.Schema;
-            Assert.Equal(14, schema.Count);
+            Assert.Equal(15, schema.Count);
 
             df.Columns.Remove("Bool");
             schema = dataView.Schema;
-            Assert.Equal(13, schema.Count);
+            Assert.Equal(14, schema.Count);
 
             DataFrameColumn boolColumn = new PrimitiveDataFrameColumn<bool>("Bool", Enumerable.Range(0, (int)df.Rows.Count).Select(x => x % 2 == 1));
             df.Columns.Insert(0, boolColumn);
             schema = dataView.Schema;
-            Assert.Equal(14, schema.Count);
+            Assert.Equal(15, schema.Count);
             Assert.Equal("Bool", schema[0].Name);
 
             DataFrameColumn boolClone = boolColumn.Clone();
@@ -117,7 +121,7 @@ namespace Microsoft.Data.Analysis.Tests
 
             DataDebuggerPreview preview = dataView.Preview();
             Assert.Equal(length, preview.RowView.Length);
-            Assert.Equal(15, preview.ColumnView.Length);
+            Assert.Equal(16, preview.ColumnView.Length);
 
             Assert.Equal("Byte", preview.ColumnView[0].Column.Name);
             Assert.Equal((byte)0, preview.ColumnView[0].Values[0]);
@@ -210,19 +214,26 @@ namespace Microsoft.Data.Analysis.Tests
             Assert.Equal((ushort)0, preview.ColumnView[12].Values[5]); // null row
             Assert.Equal((ushort)71, preview.ColumnView[12].Values[6]);
 
-            Assert.Equal("Bool", preview.ColumnView[13].Column.Name);
-            Assert.Equal(true, preview.ColumnView[13].Values[0]);
-            Assert.Equal(false, preview.ColumnView[13].Values[1]);
-            Assert.Equal(true, preview.ColumnView[13].Values[4]);
-            Assert.Equal(false, preview.ColumnView[13].Values[5]); // null row
-            Assert.Equal(true, preview.ColumnView[13].Values[6]);
+            Assert.Equal("DateTime", preview.ColumnView[13].Column.Name);
+            Assert.Equal(new DateTime(2021, 06, 04), preview.ColumnView[13].Values[0]);
+            Assert.Equal(new DateTime(2021, 06, 05), preview.ColumnView[13].Values[1]);
+            Assert.Equal(new DateTime(2021, 06, 08), preview.ColumnView[13].Values[4]);
+            Assert.Equal(new DateTime(), preview.ColumnView[13].Values[5]); // null row
+            Assert.Equal(new DateTime(2021, 06, 10), preview.ColumnView[13].Values[6]);
 
-            Assert.Equal("ArrowString", preview.ColumnView[14].Column.Name);
-            Assert.Equal("foo", preview.ColumnView[14].Values[0].ToString());
-            Assert.Equal("foo", preview.ColumnView[14].Values[1].ToString());
-            Assert.Equal("foo", preview.ColumnView[14].Values[4].ToString());
-            Assert.Equal("", preview.ColumnView[14].Values[5].ToString()); // null row
-            Assert.Equal("foo", preview.ColumnView[14].Values[6].ToString());
+            Assert.Equal("Bool", preview.ColumnView[14].Column.Name);
+            Assert.Equal(true, preview.ColumnView[14].Values[0]);
+            Assert.Equal(false, preview.ColumnView[14].Values[1]);
+            Assert.Equal(true, preview.ColumnView[14].Values[4]);
+            Assert.Equal(false, preview.ColumnView[14].Values[5]); // null row
+            Assert.Equal(true, preview.ColumnView[14].Values[6]);
+
+            Assert.Equal("ArrowString", preview.ColumnView[15].Column.Name);
+            Assert.Equal("foo", preview.ColumnView[15].Values[0].ToString());
+            Assert.Equal("foo", preview.ColumnView[15].Values[1].ToString());
+            Assert.Equal("foo", preview.ColumnView[15].Values[4].ToString());
+            Assert.Equal("", preview.ColumnView[15].Values[5].ToString()); // null row
+            Assert.Equal("foo", preview.ColumnView[15].Values[6].ToString());
         }
 
         [Fact]

--- a/test/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
+++ b/test/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Data.Analysis.Tests
 
         public static DataFrame MakeDataFrameWithAllMutableColumnTypes(int length, bool withNulls = true)
         {
-            DataFrame df = MakeDataFrameWithNumericAndStringColumns(length, withNulls);
+            DataFrame df = MakeDataFrameWithNumericStringAndDateTimeColumns(length, withNulls);
             DataFrameColumn boolColumn = new BooleanDataFrameColumn("Bool", Enumerable.Range(0, length).Select(x => x % 2 == 0));
             df.Columns.Insert(df.Columns.Count, boolColumn);
             if (withNulls)
@@ -130,7 +130,7 @@ namespace Microsoft.Data.Analysis.Tests
         {
             DataFrame df = MakeDataFrameWithNumericAndStringColumns(length, withNulls);
 
-            DataFrameColumn dateTimeColumn = new PrimitiveDataFrameColumn<DateTime>("DateTime", Enumerable.Range(0, length).Select(x => SampleDateTime.AddDays(x)));
+            DataFrameColumn dateTimeColumn = new DateTimeDataFrameColumn("DateTime", Enumerable.Range(0, length).Select(x => SampleDateTime.AddDays(x)));
             df.Columns.Insert(df.Columns.Count, dateTimeColumn);
             if (withNulls)
             {
@@ -701,6 +701,8 @@ namespace Microsoft.Data.Analysis.Tests
             Assert.Throws<NotSupportedException>(() => df.Columns["Byte"].Any());
             Assert.Throws<NotSupportedException>(() => df.Columns["Char"].All());
             Assert.Throws<NotSupportedException>(() => df.Columns["Char"].Any());
+            Assert.Throws<NotSupportedException>(() => df.Columns["DateTime"].All());
+            Assert.Throws<NotSupportedException>(() => df.Columns["DateTime"].Any());
             Assert.Throws<NotSupportedException>(() => df.Columns["Decimal"].All());
             Assert.Throws<NotSupportedException>(() => df.Columns["Decimal"].Any());
             Assert.Throws<NotSupportedException>(() => df.Columns["Double"].All());
@@ -819,6 +821,20 @@ namespace Microsoft.Data.Analysis.Tests
                     Assert.Throws<NotImplementedException>(() => column.Sum());
                     continue;
                 }
+                else if (column.DataType == typeof(DateTime))
+                {
+                    column.CumulativeMax();
+                    column.CumulativeMin();
+                    column.Max();
+                    column.Min();
+
+                    Assert.Throws<NotSupportedException>(() => column.CumulativeProduct());
+                    Assert.Throws<NotSupportedException>(() => column.CumulativeSum());
+                    Assert.Throws<NotSupportedException>(() => column.Product());
+                    Assert.Throws<NotSupportedException>(() => column.Sum());
+                    continue;
+                }
+
                 column.CumulativeMax();
                 column.CumulativeMin();
                 column.CumulativeProduct();
@@ -1791,7 +1807,7 @@ namespace Microsoft.Data.Analysis.Tests
             for (int i = 0; i < boolColumnFiltered.Columns.Count; i++)
             {
                 DataFrameColumn column = boolColumnFiltered.Columns[i];
-                if (column.Name == "Char" || column.Name == "Bool" || column.Name == "String")
+                if (column.Name == "Char" || column.Name == "Bool" || column.Name == "String" || column.Name == "DateTime")
                     continue;
                 for (int j = 0; j < column.Length; j++)
                 {
@@ -2587,14 +2603,6 @@ namespace Microsoft.Data.Analysis.Tests
         {
             DataFrame df = MakeDataFrameWithAllMutableColumnTypes(10);
 
-            // Add a column manually here until we fix https://github.com/dotnet/corefxlab/issues/2784
-            PrimitiveDataFrameColumn<DateTime> dateTimes = new PrimitiveDataFrameColumn<DateTime>("DateTimes");
-            for (int i = 0; i < 10; i++)
-            {
-                dateTimes.Append(DateTime.Parse("2019/01/01"));
-            }
-            df.Columns.Add(dateTimes);
-
             DataFrame description = df.Description();
             DataFrameColumn descriptionColumn = description.Columns[0];
             Assert.Equal("Description", descriptionColumn.Name);
@@ -2615,9 +2623,9 @@ namespace Microsoft.Data.Analysis.Tests
 
             // Explicitly check the dateTimes column
             DataFrameColumn dateTimeColumn = description.Columns[description.Columns.Count - 1];
-            Assert.Equal(dateTimeColumn.Name, dateTimes.Name);
+            Assert.Equal("DateTime", dateTimeColumn.Name);
             Assert.Equal(4, dateTimeColumn.Length);
-            Assert.Equal((float)10, dateTimeColumn[0]);
+            Assert.Equal((float)9, dateTimeColumn[0]);
             Assert.Null(dateTimeColumn[1]);
             Assert.Null(dateTimeColumn[2]);
             Assert.Null(dateTimeColumn[3]);


### PR DESCRIPTION
Fixes #6213, #5698, #5676

Add the DateTime type as a PrimitiveDataFrameColumn. This will better allow conversion between IDataView and the DataFrame. 

Some DateTime code exists already, like the DateTime computations. However, the partial implementation left bugs, particularly when trying to convert between IDataView and DataFrame. 

I tried to follow the existing patterns but if this shouldn't be bucketed in with the PrimitiveDataFrameColumns I can make changes. 

