### PR TITLE
add loss to TrialResult

### DIFF
--- a/src/Microsoft.ML.AutoML/API/AutoMLExperimentExtension.cs
+++ b/src/Microsoft.ML.AutoML/API/AutoMLExperimentExtension.cs
@@ -162,7 +162,6 @@ namespace Microsoft.ML.AutoML
         {
             experiment.ServiceCollection.AddSingleton<IMetricManager>(metricManager);
             experiment.ServiceCollection.AddSingleton<IEvaluateMetricManager>(metricManager);
-            experiment.SetIsMaximize(metricManager.IsMaximize);
 
             return experiment;
         }

--- a/src/Microsoft.ML.AutoML/API/BinaryClassificationExperiment.cs
+++ b/src/Microsoft.ML.AutoML/API/BinaryClassificationExperiment.cs
@@ -382,12 +382,13 @@ namespace Microsoft.ML.AutoML
                         BinaryClassificationMetric.AreaUnderPrecisionRecallCurve => res.Metrics.AreaUnderPrecisionRecallCurve,
                         _ => throw new NotImplementedException($"{metricManager.MetricName} is not supported!"),
                     };
-
+                    var loss = metricManager.IsMaximize ? -metric : metric;
                     stopWatch.Stop();
 
 
                     return new TrialResult<BinaryClassificationMetrics>()
                     {
+                        Loss = loss,
                         Metric = metric,
                         Model = model,
                         TrialSettings = settings,
@@ -415,12 +416,14 @@ namespace Microsoft.ML.AutoML
                         BinaryClassificationMetric.AreaUnderPrecisionRecallCurve => metrics.AreaUnderPrecisionRecallCurve,
                         _ => throw new NotImplementedException($"{metricManager.Metric} is not supported!"),
                     };
+                    var loss = metricManager.IsMaximize ? -metric : metric;
 
                     stopWatch.Stop();
 
 
                     return new TrialResult<BinaryClassificationMetrics>()
                     {
+                        Loss = loss,
                         Metric = metric,
                         Model = model,
                         TrialSettings = settings,

--- a/src/Microsoft.ML.AutoML/API/MulticlassClassificationExperiment.cs
+++ b/src/Microsoft.ML.AutoML/API/MulticlassClassificationExperiment.cs
@@ -379,12 +379,14 @@ namespace Microsoft.ML.AutoML
                         MulticlassClassificationMetric.TopKAccuracy => res.Metrics.TopKAccuracy,
                         _ => throw new NotImplementedException($"{metricManager.MetricName} is not supported!"),
                     };
+                    var loss = metricManager.IsMaximize ? -metric : metric;
 
                     stopWatch.Stop();
 
 
                     return new TrialResult<MulticlassClassificationMetrics>()
                     {
+                        Loss = loss,
                         Metric = metric,
                         Model = model,
                         TrialSettings = settings,
@@ -412,12 +414,14 @@ namespace Microsoft.ML.AutoML
                         MulticlassClassificationMetric.TopKAccuracy => metrics.TopKAccuracy,
                         _ => throw new NotImplementedException($"{metricManager.Metric} is not supported!"),
                     };
+                    var loss = metricManager.IsMaximize ? -metric : metric;
 
                     stopWatch.Stop();
 
 
                     return new TrialResult<MulticlassClassificationMetrics>()
                     {
+                        Loss = loss,
                         Metric = metric,
                         Model = model,
                         TrialSettings = settings,

--- a/src/Microsoft.ML.AutoML/AutoMLExperiment/AutoMLExperiment.cs
+++ b/src/Microsoft.ML.AutoML/AutoMLExperiment/AutoMLExperiment.cs
@@ -20,7 +20,7 @@ namespace Microsoft.ML.AutoML
         internal const string PipelineSearchspaceName = "_pipeline_";
         private readonly AutoMLExperimentSettings _settings;
         private readonly MLContext _context;
-        private double _bestError = double.MaxValue;
+        private double _bestLoss = double.MaxValue;
         private TrialResult _bestTrialResult = null;
         private readonly IServiceCollection _serviceCollection;
         private CancellationTokenSource _globalCancellationTokenSource;
@@ -94,12 +94,6 @@ namespace Microsoft.ML.AutoML
         public AutoMLExperiment SetTrainingTimeInSeconds(uint trainingTimeInSeconds)
         {
             _settings.MaxExperimentTimeInSeconds = trainingTimeInSeconds;
-            return this;
-        }
-
-        public AutoMLExperiment SetIsMaximize(bool isMaximize)
-        {
-            _settings.IsMaximize = isMaximize;
             return this;
         }
 
@@ -290,11 +284,11 @@ namespace Microsoft.ML.AutoML
                         monitor?.ReportCompletedTrial(trialResult);
                         tuner.Update(trialResult);
 
-                        var error = _settings.IsMaximize ? 1 - trialResult.Metric : trialResult.Metric;
-                        if (error < _bestError)
+                        var loss = trialResult.Loss;
+                        if (loss < _bestLoss)
                         {
                             _bestTrialResult = trialResult;
-                            _bestError = error;
+                            _bestLoss = loss;
                             monitor?.ReportBestTrial(trialResult);
                         }
                     }
@@ -305,7 +299,7 @@ namespace Microsoft.ML.AutoML
                     var result = new TrialResult
                     {
                         TrialSettings = setting,
-                        Metric = _settings.IsMaximize ? double.MinValue : double.MaxValue,
+                        Loss = double.MaxValue,
                     };
 
                     tuner.Update(result);
@@ -351,8 +345,6 @@ namespace Microsoft.ML.AutoML
             public int? Seed { get; set; }
 
             public SearchSpace.SearchSpace SearchSpace { get; set; }
-
-            public bool IsMaximize { get; set; }
         }
     }
 }

--- a/src/Microsoft.ML.AutoML/AutoMLExperiment/Runner/ITrialRunner.cs
+++ b/src/Microsoft.ML.AutoML/AutoMLExperiment/Runner/ITrialRunner.cs
@@ -16,8 +16,6 @@ namespace Microsoft.ML.AutoML
     /// </summary>
     public interface ITrialRunner : IDisposable
     {
-        TrialResult Run(TrialSettings settings);
-
         Task<TrialResult> RunAsync(TrialSettings settings, CancellationToken ct);
     }
 }

--- a/src/Microsoft.ML.AutoML/AutoMLExperiment/Runner/SweepablePipelineRunner.cs
+++ b/src/Microsoft.ML.AutoML/AutoMLExperiment/Runner/SweepablePipelineRunner.cs
@@ -53,12 +53,16 @@ namespace Microsoft.ML.AutoML
 
                 stopWatch.Stop();
 
+                var metric = metrics.Average();
+                var loss = _metricManager.IsMaximize ? -metric : metric;
+
                 return new TrialResult
                 {
-                    Metric = metrics.Average(),
+                    Metric = metric,
                     Model = models.First(),
                     DurationInMilliseconds = stopWatch.ElapsedMilliseconds,
                     TrialSettings = settings,
+                    Loss = loss,
                 };
             }
 
@@ -68,9 +72,11 @@ namespace Microsoft.ML.AutoML
                 var eval = model.Transform(trainTestDatasetManager.TestDataset);
                 var metric = _metricManager.Evaluate(_mLContext, eval);
                 stopWatch.Stop();
+                var loss = _metricManager.IsMaximize ? -metric : metric;
 
                 return new TrialResult
                 {
+                    Loss = loss,
                     Metric = metric,
                     Model = model,
                     DurationInMilliseconds = stopWatch.ElapsedMilliseconds,

--- a/src/Microsoft.ML.AutoML/AutoMLExperiment/TrialResult.cs
+++ b/src/Microsoft.ML.AutoML/AutoMLExperiment/TrialResult.cs
@@ -16,6 +16,14 @@ namespace Microsoft.ML.AutoML
 
         public ITransformer Model { get; set; }
 
+        /// <summary>
+        /// the loss for current trial, which is smaller the better. This value will be used to fit smart tuners in <see cref="AutoMLExperiment"/>.
+        /// </summary>
+        public double Loss { get; set; }
+
+        /// <summary>
+        /// Evaluation result.
+        /// </summary>
         public double Metric { get; set; }
 
         public double DurationInMilliseconds { get; set; }

--- a/src/Microsoft.ML.AutoML/Tuner/EciCfoTuner.cs
+++ b/src/Microsoft.ML.AutoML/Tuner/EciCfoTuner.cs
@@ -44,13 +44,16 @@ namespace Microsoft.ML.AutoML
 
         public void Update(TrialResult result)
         {
+            var originalParameter = result.TrialSettings.Parameter;
             var schema = result.TrialSettings.Parameter[AutoMLExperiment.PipelineSearchspaceName]["_SCHEMA_"].AsType<string>();
+            _pipelineProposer.Update(result, schema);
             if (_tuners.TryGetValue(schema, out var tuner))
             {
+                var parameter = result.TrialSettings.Parameter[AutoMLExperiment.PipelineSearchspaceName];
+                result.TrialSettings.Parameter = parameter;
                 tuner.Update(result);
+                result.TrialSettings.Parameter = originalParameter;
             }
-
-            _pipelineProposer.Update(result, schema);
         }
     }
 }

--- a/src/Microsoft.ML.AutoML/Tuner/EciCfoTuner.cs
+++ b/src/Microsoft.ML.AutoML/Tuner/EciCfoTuner.cs
@@ -20,13 +20,11 @@ namespace Microsoft.ML.AutoML
         private readonly PipelineProposer _pipelineProposer;
         // this dictionary records the schema for each trial.
         // the key is trial id, and value is the schema for that trial.
-        private readonly IMetricManager _metricManager;
 
-        public EciCostFrugalTuner(SweepablePipeline sweepablePipeline, IMetricManager metricManager, AutoMLExperiment.AutoMLExperimentSettings settings)
+        public EciCostFrugalTuner(SweepablePipeline sweepablePipeline, AutoMLExperiment.AutoMLExperimentSettings settings)
         {
             _tuners = new Dictionary<string, ITuner>();
-            _pipelineProposer = new PipelineProposer(sweepablePipeline, settings, metricManager);
-            _metricManager = metricManager;
+            _pipelineProposer = new PipelineProposer(sweepablePipeline, settings);
         }
 
         public Parameter Propose(TrialSettings settings)
@@ -34,7 +32,7 @@ namespace Microsoft.ML.AutoML
             (var searchSpace, var schema) = _pipelineProposer.ProposeSearchSpace();
             if (!_tuners.ContainsKey(schema))
             {
-                var t = new CostFrugalTuner(searchSpace, searchSpace.SampleFromFeatureSpace(searchSpace.Default), !_metricManager.IsMaximize);
+                var t = new CostFrugalTuner(searchSpace, searchSpace.SampleFromFeatureSpace(searchSpace.Default));
                 _tuners.Add(schema, t);
             }
 

--- a/test/Microsoft.ML.AutoML.Tests/CostFrugalTunerTests.cs
+++ b/test/Microsoft.ML.AutoML.Tests/CostFrugalTunerTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using FluentAssertions;
@@ -37,7 +38,8 @@ namespace Microsoft.ML.AutoML.Test
                 };
 
                 var param = cfo.Propose(trialSettings);
-                var option = param.AsType<CodeGen.LbfgsOption>();
+                trialSettings.Parameter = param;
+                var option = param.AsType<LbfgsOption>();
 
                 option.L1Regularization.Should().BeInRange(0.03125f, 32768.0f);
                 option.L2Regularization.Should().BeInRange(0.03125f, 32768.0f);
@@ -52,6 +54,58 @@ namespace Microsoft.ML.AutoML.Test
         }
 
         [Fact]
+        public void CFO_should_propose_decent_parameter_if_history_provided()
+        {
+            // this test verify that cfo can be recovered by replaying history.
+            var searchSpace = new SearchSpace<LbfgsOption>();
+            var initValues = searchSpace.SampleFromFeatureSpace(searchSpace.Default);
+            var cfo = new CostFrugalTuner(searchSpace, Parameter.FromObject(initValues));
+            var history = new List<TrialResult>();
+            for (int i = 0; i != 100; ++i)
+            {
+                var settings = new TrialSettings()
+                {
+                    TrialId = i,
+                };
+
+                var param = cfo.Propose(settings);
+                settings.Parameter = param;
+                var lseParam = param.AsType<LSE3DSearchSpace>();
+                var x = lseParam.X;
+                var y = lseParam.Y;
+                var z = lseParam.Z;
+                var loss = -LSE3D(x, y, z);
+                if (x == 10 && y == 10 && z == 10)
+                {
+                    break;
+                }
+
+                var result = new TrialResult()
+                {
+                    Loss = loss,
+                    DurationInMilliseconds = 1 * 1000,
+                    TrialSettings = settings,
+                };
+                cfo.Update(result);
+                history.Add(result);
+            }
+
+            var newCfo = new CostFrugalTuner(searchSpace, Parameter.FromObject(initValues));
+            foreach (var result in history.Take(99))
+            {
+                newCfo.Update(result);
+            }
+
+            var lastResult = history.Last();
+            var trialSettings = lastResult.TrialSettings;
+
+            var nextParameterFromNewCfo = newCfo.Propose(trialSettings);
+            var lseParameterFromNewCfo = nextParameterFromNewCfo.AsType<LSE3DSearchSpace>();
+            var lossFromNewCfo = -LSE3D(lseParameterFromNewCfo.X, lseParameterFromNewCfo.Y, lseParameterFromNewCfo.Z);
+            lossFromNewCfo.Should().BeApproximately(lastResult.Loss, 0.1);
+        }
+
+        [Fact]
         public void CFO_should_start_from_init_point_if_provided()
         {
             var trialSettings = new TrialSettings()
@@ -60,7 +114,7 @@ namespace Microsoft.ML.AutoML.Test
             };
             var searchSpace = new SearchSpace<LSE3DSearchSpace>();
             var initValues = searchSpace.SampleFromFeatureSpace(searchSpace.Default);
-            var cfo = new CostFrugalTuner(searchSpace, Parameter.FromObject(initValues), true);
+            var cfo = new CostFrugalTuner(searchSpace, Parameter.FromObject(initValues));
             var param = cfo.Propose(trialSettings).AsType<LSE3DSearchSpace>();
             var x = param.X;
             var y = param.Y;
@@ -74,7 +128,7 @@ namespace Microsoft.ML.AutoML.Test
         {
             var searchSpace = new SearchSpace<LSE3DSearchSpace>();
             var initValues = searchSpace.SampleFromFeatureSpace(searchSpace.Default);
-            var cfo = new CostFrugalTuner(searchSpace, Parameter.FromObject(initValues), false);
+            var cfo = new CostFrugalTuner(searchSpace, Parameter.FromObject(initValues));
             double bestMetric = 0;
             for (int i = 0; i != 100; ++i)
             {
@@ -83,10 +137,12 @@ namespace Microsoft.ML.AutoML.Test
                     TrialId = 0,
                 };
 
-                var param = cfo.Propose(trialSettings).AsType<LSE3DSearchSpace>();
-                var x = param.X;
-                var y = param.Y;
-                var z = param.Z;
+                var param = cfo.Propose(trialSettings);
+                trialSettings.Parameter = param;
+                var lseParam = param.AsType<LSE3DSearchSpace>();
+                var x = lseParam.X;
+                var y = lseParam.Y;
+                var z = lseParam.Z;
                 var metric = LSE3D(x, y, z);
                 bestMetric = Math.Max(bestMetric, metric);
                 Output.WriteLine($"{i} x: {x} y: {y} z: {z}");
@@ -96,6 +152,7 @@ namespace Microsoft.ML.AutoML.Test
                 }
                 cfo.Update(new TrialResult()
                 {
+                    Loss = -metric,
                     DurationInMilliseconds = 1 * 1000,
                     Metric = metric,
                     TrialSettings = trialSettings,
@@ -110,7 +167,7 @@ namespace Microsoft.ML.AutoML.Test
         {
             var searchSpace = new SearchSpace<LSE3DSearchSpace>();
             var initValues = searchSpace.SampleFromFeatureSpace(searchSpace.Default);
-            var cfo = new CostFrugalTuner(searchSpace, Parameter.FromObject(initValues), true);
+            var cfo = new CostFrugalTuner(searchSpace, Parameter.FromObject(initValues));
             double loss = 0;
             for (int i = 0; i != 100; ++i)
             {
@@ -119,10 +176,12 @@ namespace Microsoft.ML.AutoML.Test
                     TrialId = i,
                 };
 
-                var param = cfo.Propose(trialSettings).AsType<LSE3DSearchSpace>();
-                var x = param.X;
-                var y = param.Y;
-                var z = param.Z;
+                var param = cfo.Propose(trialSettings);
+                trialSettings.Parameter = param;
+                var lseParam = param.AsType<LSE3DSearchSpace>();
+                var x = lseParam.X;
+                var y = lseParam.Y;
+                var z = lseParam.Z;
                 loss = LSE3D(x, y, z);
                 Output.WriteLine(loss.ToString());
                 Output.WriteLine($"{i} x: {x} y: {y} z: {z}");
@@ -134,6 +193,7 @@ namespace Microsoft.ML.AutoML.Test
 
                 cfo.Update(new TrialResult()
                 {
+                    Loss = loss,
                     DurationInMilliseconds = 1000,
                     Metric = loss,
                     TrialSettings = trialSettings,
@@ -148,7 +208,7 @@ namespace Microsoft.ML.AutoML.Test
         {
             var searchSpace = new SearchSpace<LSE3DSearchSpace>();
             var initValues = searchSpace.SampleFromFeatureSpace(searchSpace.Default);
-            var cfo = new CostFrugalTuner(searchSpace, Parameter.FromObject(initValues), true);
+            var cfo = new CostFrugalTuner(searchSpace, Parameter.FromObject(initValues));
             double bestMetric = 0;
             for (int i = 0; i != 1000; ++i)
             {
@@ -156,10 +216,12 @@ namespace Microsoft.ML.AutoML.Test
                 {
                     TrialId = i,
                 };
-                var param = cfo.Propose(trialSettings).AsType<LSE3DSearchSpace>();
-                var x = param.X;
-                var y = param.Y;
-                var z = param.Z;
+                var param = cfo.Propose(trialSettings);
+                trialSettings.Parameter = param;
+                var lseParam = param.AsType<LSE3DSearchSpace>();
+                var x = lseParam.X;
+                var y = lseParam.Y;
+                var z = lseParam.Z;
                 var metric = F1(x, y, z);
                 bestMetric = Math.Min(bestMetric, metric);
                 Output.WriteLine($"{i} x: {x} y: {y} z: {z}");
@@ -185,7 +247,7 @@ namespace Microsoft.ML.AutoML.Test
         {
             var searchSpace = new SearchSpace<LSE3DSearchSpace>();
             var initValues = searchSpace.SampleFromFeatureSpace(searchSpace.Default);
-            var cfo = new CostFrugalTuner(searchSpace, Parameter.FromObject(initValues), true);
+            var cfo = new CostFrugalTuner(searchSpace, Parameter.FromObject(initValues));
             var originalCuture = Thread.CurrentThread.CurrentCulture;
             var usCulture = new CultureInfo("en-US", false);
             Thread.CurrentThread.CurrentCulture = usCulture;

--- a/test/Microsoft.ML.AutoML.Tests/CostFrugalTunerTests.cs
+++ b/test/Microsoft.ML.AutoML.Tests/CostFrugalTunerTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.ML.AutoML.Test
         }
 
         [Fact]
-        public void CFO_should_propose_decent_parameter_if_history_provided()
+        public void CFO_should_be_recoverd_if_history_provided()
         {
             // this test verify that cfo can be recovered by replaying history.
             var searchSpace = new SearchSpace<LbfgsOption>();


### PR DESCRIPTION
We are excited to review your PR.

So we can do the best job, please check:

- [x] There's a descriptive title that will make sense to other developers some time from now. 
- [ ] There's associated issues. All PR's should have issue(s) associated - unless a trivial self-evident change such as fixing a typo. You can use the format `Fixes #nnnn` in your description to cause GitHub to automatically close the issue(s) when your PR is merged.
- [x] Your change description explains what the change does, why you chose your approach, and anything else that reviewers should know.
- [x] You have included any necessary tests in the same PR.


This PR adds a new property `Loss` in `TrialResult` class and remove `AutoMLExperimentSettings.IsMaximize`. The `Loss` is always smaller the better and will be used to optimize tuners.

This PR also adds a replay test to `CFO` tuners, which verifies that the status of cfo can be recovered from previous training history.

This PR also removes `ITrialRunner.Run` method as this method has been replaced by `ITrialRunner.RunAsync`
