### PR TITLE
Update name of DataFrame.WriteCsv to SaveCsv

### DIFF
--- a/src/Microsoft.Data.Analysis/DataFrame.IO.cs
+++ b/src/Microsoft.Data.Analysis/DataFrame.IO.cs
@@ -396,7 +396,6 @@ namespace Microsoft.Data.Analysis
             return ReadCsvLinesIntoDataFrame(wrappedStreamReaderOrStringReader, separator, header, columnNames, dataTypes, numberOfRowsToRead, guessRows, addIndexColumn);
         }
 
-
         /// <summary>
         /// Writes a DataFrame into a CSV.
         /// </summary>

--- a/src/Microsoft.Data.Analysis/DataFrame.IO.cs
+++ b/src/Microsoft.Data.Analysis/DataFrame.IO.cs
@@ -405,7 +405,7 @@ namespace Microsoft.Data.Analysis
         /// <param name="header">has a header or not</param>
         /// <param name="encoding">The character encoding. Defaults to UTF8 if not specified</param>
         /// <param name="cultureInfo">culture info for formatting values</param>
-        [Obsolete("Use SaveCsv")]
+        [Obsolete("WriteCsv is obsolete and will be removed in a future version. Use SaveCsv instead.")]
         public static void WriteCsv(DataFrame dataFrame, string path,
                                    char separator = ',', bool header = true,
                                    Encoding encoding = null, CultureInfo cultureInfo = null)
@@ -443,7 +443,7 @@ namespace Microsoft.Data.Analysis
         /// <param name="header">has a header or not</param>
         /// <param name="encoding">the character encoding. Defaults to UTF8 if not specified</param>
         /// <param name="cultureInfo">culture info for formatting values</param>
-        [Obsolete("Use SaveCsv")]
+        [Obsolete("WriteCsv is obsolete and will be removed in a future version. Use SaveCsv instead.")]
         public static void WriteCsv(DataFrame dataFrame, Stream csvStream,
                            char separator = ',', bool header = true,
                            Encoding encoding = null, CultureInfo cultureInfo = null)

--- a/src/Microsoft.Data.Analysis/DataFrame.IO.cs
+++ b/src/Microsoft.Data.Analysis/DataFrame.IO.cs
@@ -434,7 +434,6 @@ namespace Microsoft.Data.Analysis
             }
         }
 
-
         /// <summary>
         /// Saves a DataFrame into a CSV.
         /// </summary>

--- a/src/Microsoft.Data.Analysis/DataFrame.IO.cs
+++ b/src/Microsoft.Data.Analysis/DataFrame.IO.cs
@@ -397,7 +397,7 @@ namespace Microsoft.Data.Analysis
         }
 
         /// <summary>
-        /// Writes a DataFrame into a CSV.
+        /// Saves a DataFrame into a CSV.
         /// </summary>
         /// <param name="dataFrame"><see cref="DataFrame"/></param>
         /// <param name="path">CSV file path</param>
@@ -405,20 +405,20 @@ namespace Microsoft.Data.Analysis
         /// <param name="header">has a header or not</param>
         /// <param name="encoding">The character encoding. Defaults to UTF8 if not specified</param>
         /// <param name="cultureInfo">culture info for formatting values</param>
-        public static void WriteCsv(DataFrame dataFrame, string path,
+        public static void SaveCsv(DataFrame dataFrame, string path,
                                    char separator = ',', bool header = true,
                                    Encoding encoding = null, CultureInfo cultureInfo = null)
         {
             using (FileStream csvStream = new FileStream(path, FileMode.Create))
             {
-                WriteCsv(dataFrame: dataFrame, csvStream: csvStream,
+                SaveCsv(dataFrame: dataFrame, csvStream: csvStream,
                            separator: separator, header: header,
                            encoding: encoding, cultureInfo: cultureInfo);
             }
         }
 
         /// <summary>
-        /// Writes a DataFrame into a CSV.
+        /// Saves a DataFrame into a CSV.
         /// </summary>
         /// <param name="dataFrame"><see cref="DataFrame"/></param>
         /// <param name="csvStream">stream of CSV data to be write out</param>
@@ -426,7 +426,7 @@ namespace Microsoft.Data.Analysis
         /// <param name="header">has a header or not</param>
         /// <param name="encoding">the character encoding. Defaults to UTF8 if not specified</param>
         /// <param name="cultureInfo">culture info for formatting values</param>
-        public static void WriteCsv(DataFrame dataFrame, Stream csvStream,
+        public static void SaveCsv(DataFrame dataFrame, Stream csvStream,
                            char separator = ',', bool header = true,
                            Encoding encoding = null, CultureInfo cultureInfo = null)
         {
@@ -451,7 +451,7 @@ namespace Microsoft.Data.Analysis
                 {
                     if (header)
                     {
-                        WriteHeader(csvFile, dataFrame.Columns.GetColumnNames(), separator);
+                        SaveHeader(csvFile, dataFrame.Columns.GetColumnNames(), separator);
                     }
 
                     var record = new StringBuilder();
@@ -519,7 +519,7 @@ namespace Microsoft.Data.Analysis
             }
         }
 
-        private static void WriteHeader(StreamWriter csvFile, IReadOnlyList<string> columnNames, char separator)
+        private static void SaveHeader(StreamWriter csvFile, IReadOnlyList<string> columnNames, char separator)
         {
             bool firstColumn = true;
             foreach (string name in columnNames)

--- a/src/Microsoft.Data.Analysis/DataFrame.IO.cs
+++ b/src/Microsoft.Data.Analysis/DataFrame.IO.cs
@@ -435,7 +435,7 @@ namespace Microsoft.Data.Analysis
         }
 
         /// <summary>
-        /// Saves a DataFrame into a CSV.
+        /// Writes a DataFrame into a CSV.
         /// </summary>
         /// <param name="dataFrame"><see cref="DataFrame"/></param>
         /// <param name="csvStream">stream of CSV data to be write out</param>

--- a/src/Microsoft.Data.Analysis/DataFrame.IO.cs
+++ b/src/Microsoft.Data.Analysis/DataFrame.IO.cs
@@ -396,6 +396,24 @@ namespace Microsoft.Data.Analysis
             return ReadCsvLinesIntoDataFrame(wrappedStreamReaderOrStringReader, separator, header, columnNames, dataTypes, numberOfRowsToRead, guessRows, addIndexColumn);
         }
 
+
+        /// <summary>
+        /// Writes a DataFrame into a CSV.
+        /// </summary>
+        /// <param name="dataFrame"><see cref="DataFrame"/></param>
+        /// <param name="path">CSV file path</param>
+        /// <param name="separator">column separator</param>
+        /// <param name="header">has a header or not</param>
+        /// <param name="encoding">The character encoding. Defaults to UTF8 if not specified</param>
+        /// <param name="cultureInfo">culture info for formatting values</param>
+        [Obsolete("Use SaveCsv")]
+        public static void WriteCsv(DataFrame dataFrame, string path,
+                                   char separator = ',', bool header = true,
+                                   Encoding encoding = null, CultureInfo cultureInfo = null)
+        {
+            SaveCsv(dataFrame, path, separator, header, encoding, cultureInfo);
+        }
+
         /// <summary>
         /// Saves a DataFrame into a CSV.
         /// </summary>
@@ -417,6 +435,24 @@ namespace Microsoft.Data.Analysis
             }
         }
 
+
+        /// <summary>
+        /// Saves a DataFrame into a CSV.
+        /// </summary>
+        /// <param name="dataFrame"><see cref="DataFrame"/></param>
+        /// <param name="csvStream">stream of CSV data to be write out</param>
+        /// <param name="separator">column separator</param>
+        /// <param name="header">has a header or not</param>
+        /// <param name="encoding">the character encoding. Defaults to UTF8 if not specified</param>
+        /// <param name="cultureInfo">culture info for formatting values</param>
+        [Obsolete("Use SaveCsv")]
+        public static void WriteCsv(DataFrame dataFrame, Stream csvStream,
+                           char separator = ',', bool header = true,
+                           Encoding encoding = null, CultureInfo cultureInfo = null)
+        {
+            SaveCsv(dataFrame, csvStream, separator, header, encoding, cultureInfo);
+        }
+
         /// <summary>
         /// Saves a DataFrame into a CSV.
         /// </summary>
@@ -427,8 +463,8 @@ namespace Microsoft.Data.Analysis
         /// <param name="encoding">the character encoding. Defaults to UTF8 if not specified</param>
         /// <param name="cultureInfo">culture info for formatting values</param>
         public static void SaveCsv(DataFrame dataFrame, Stream csvStream,
-                           char separator = ',', bool header = true,
-                           Encoding encoding = null, CultureInfo cultureInfo = null)
+                        char separator = ',', bool header = true,
+                        Encoding encoding = null, CultureInfo cultureInfo = null)
         {
             if (cultureInfo is null)
             {

--- a/test/Microsoft.Data.Analysis.Tests/DataFrame.IOTests.cs
+++ b/test/Microsoft.Data.Analysis.Tests/DataFrame.IOTests.cs
@@ -832,7 +832,7 @@ CMT,1,1,null";
             using MemoryStream csvStream = new MemoryStream();
             DataFrame dataFrame = DataFrameTests.MakeDataFrameWithAllColumnTypes(10, true);
 
-            DataFrame.WriteCsv(dataFrame, csvStream);
+            DataFrame.SaveCsv(dataFrame, csvStream);
 
             csvStream.Seek(0, SeekOrigin.Begin);
             DataFrame readIn = DataFrame.LoadCsv(csvStream);
@@ -853,7 +853,7 @@ CMT,1,1,null";
         }
 
         [Fact]
-        public void TestWriteCsvWithCultureInfoRomanianAndSemiColon()
+        public void TestSaveCsvWithCultureInfoRomanianAndSemiColon()
         {
             DataFrame dataFrame = DataFrameTests.MakeDataFrameWithNumericColumns(10, true);
             dataFrame[1, 1] = 1.1M;
@@ -863,7 +863,7 @@ CMT,1,1,null";
             using MemoryStream csvStream = new MemoryStream();
             var cultureInfo = new CultureInfo("ro-RO");
             var separator = ';';
-            DataFrame.WriteCsv(dataFrame, csvStream, separator: separator, cultureInfo: cultureInfo);
+            DataFrame.SaveCsv(dataFrame, csvStream, separator: separator, cultureInfo: cultureInfo);
 
             csvStream.Seek(0, SeekOrigin.Begin);
             DataFrame readIn = DataFrame.LoadCsv(csvStream, separator: separator);
@@ -887,7 +887,7 @@ CMT,1,1,null";
         }
 
         [Fact]
-        public void TestWriteCsvWithCultureInfo()
+        public void TestSaveCsvWithCultureInfo()
         {
             using MemoryStream csvStream = new MemoryStream();
             DataFrame dataFrame = DataFrameTests.MakeDataFrameWithNumericColumns(10, true);
@@ -896,7 +896,7 @@ CMT,1,1,null";
             dataFrame[1, 3] = 1.3F;
 
             var cultureInfo = new CultureInfo("en-US");
-            DataFrame.WriteCsv(dataFrame, csvStream, cultureInfo: cultureInfo);
+            DataFrame.SaveCsv(dataFrame, csvStream, cultureInfo: cultureInfo);
 
             csvStream.Seek(0, SeekOrigin.Begin);
             DataFrame readIn = DataFrame.LoadCsv(csvStream);
@@ -917,7 +917,7 @@ CMT,1,1,null";
         }
 
         [Fact]
-        public void TestWriteCsvWithCultureInfoRomanianAndComma()
+        public void TestSaveCsvWithCultureInfoRomanianAndComma()
         {
             using MemoryStream csvStream = new MemoryStream();
             DataFrame dataFrame = DataFrameTests.MakeDataFrameWithNumericColumns(10, true);
@@ -925,16 +925,16 @@ CMT,1,1,null";
             var cultureInfo = new CultureInfo("ro-RO");
             var separator = cultureInfo.NumberFormat.NumberDecimalSeparator.First();
 
-            Assert.Throws<ArgumentException>(() => DataFrame.WriteCsv(dataFrame, csvStream, separator: separator, cultureInfo: cultureInfo));
+            Assert.Throws<ArgumentException>(() => DataFrame.SaveCsv(dataFrame, csvStream, separator: separator, cultureInfo: cultureInfo));
         }
 
         [Fact]
-        public void TestWriteCsvWithNoHeader()
+        public void TestSaveCsvWithNoHeader()
         {
             using MemoryStream csvStream = new MemoryStream();
             DataFrame dataFrame = DataFrameTests.MakeDataFrameWithAllColumnTypes(10, true);
 
-            DataFrame.WriteCsv(dataFrame, csvStream, header: false);
+            DataFrame.SaveCsv(dataFrame, csvStream, header: false);
 
             csvStream.Seek(0, SeekOrigin.Begin);
             DataFrame readIn = DataFrame.LoadCsv(csvStream, header: false);
@@ -955,13 +955,13 @@ CMT,1,1,null";
         }
 
         [Fact]
-        public void TestWriteCsvWithSemicolonSeparator()
+        public void TestSaveCsvWithSemicolonSeparator()
         {
             using MemoryStream csvStream = new MemoryStream();
             DataFrame dataFrame = DataFrameTests.MakeDataFrameWithAllColumnTypes(10, true);
 
             var separator = ';';
-            DataFrame.WriteCsv(dataFrame, csvStream, separator: separator);
+            DataFrame.SaveCsv(dataFrame, csvStream, separator: separator);
 
             csvStream.Seek(0, SeekOrigin.Begin);
             DataFrame readIn = DataFrame.LoadCsv(csvStream, separator: separator);
@@ -1261,14 +1261,14 @@ CMT,";
 
         [Theory]
         [MemberData(nameof(CsvWithTextQualifiers_TestData))]
-        public void TestWriteCsvWithTextQualifiers(string data, char separator, Type[] dataTypes, LoadCsvVerifyingHelper helper)
+        public void TestSaveCsvWithTextQualifiers(string data, char separator, Type[] dataTypes, LoadCsvVerifyingHelper helper)
         {
             DataFrame df = DataFrame.LoadCsv(GetStream(data), dataTypes: dataTypes, separator: separator);
 
             using MemoryStream csvStream = new MemoryStream();
-            DataFrame.WriteCsv(df, csvStream, separator: separator);
+            DataFrame.SaveCsv(df, csvStream, separator: separator);
 
-            // We are verifying that WriteCsv works by reading the result back to a DataFrame and verifying correctness,
+            // We are verifying that SaveCsv works by reading the result back to a DataFrame and verifying correctness,
             // ensuring no information loss
             csvStream.Seek(0, SeekOrigin.Begin);
             DataFrame df2 = DataFrame.LoadCsv(csvStream, dataTypes: dataTypes, separator: separator);


### PR DESCRIPTION
It seems like there was [general agreement](https://github.com/dotnet/machinelearning/issues/5883) to update the name about a year ago, but it has been a while, so I want to resurface this and ask the following questions:

1. Do we still want to go ahead with this change?
2. Is this considered a "breaking change"? If yes, are there any repercussions we should be aware of?
3. Is there anything else I'm missing that might need to be updated (documentation, other files, etc)?