### PR TITLE
Fix CMake warning on Linux

### DIFF
--- a/src/Native/SymSgdNative/CMakeLists.txt
+++ b/src/Native/SymSgdNative/CMakeLists.txt
@@ -43,6 +43,8 @@ target_link_libraries(SymSgdNative PUBLIC ${MKL_LIBRARY} PUBLIC ${OPENMP_LIBRARY
 
 if(APPLE)
     set_target_properties(SymSgdNative PROPERTIES INSTALL_RPATH "@loader_path;@loader_path/${MKL_LIB_RPATH}}")
+else()
+    SET(UNUSED_MKL_LIB_RPATH, "${MKL_LIB_RPATH}")
 endif()
 
 install_library_and_symbols (SymSgdNative)


### PR DESCRIPTION
Cmake emits a warning because MKL_LIB_RPATH is specified but not used.

Fix this by consuming the property in the project that makes the decision to use it or not.

I chose to suppress the warning this way rather than duplicate the condition in more places.
