### PR TITLE
Refactor official build to use arcade templates

### DIFF
--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -201,57 +201,51 @@ stages:
       displayName: Dotnet Server Shutdown
 
   ################################################################################
-  - job: Package
+  - template: /eng/common/templates/job/job.yml
+    parameters:
+      name: Package
   ################################################################################
-    dependsOn:
-    - Linux_x64
-    - Linux_arm
-    - Linux_arm64
-    - MacOS
-    - Windows_x86
-    - Windows_x64
-    - MacOS_Apple_Silicon
-    variables:
-      DotnetVersionKind: $[variables.VERSIONKIND] # If no "VERSIONKIND" variable is set when queuing the publishing task, this defaults to empty string.
-      NUGET_PACKAGES: $(Build.SourcesDirectory)/.packages
-      _SignType: real
-      _TeamName: DotNetCore
-      _InternalBuildArgs: /p:DotNetSignType=$(_SignType) 
-                          /p:TeamName=$(_TeamName)
-                          /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
-                          /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
-                          /p:OfficialBuildId=$(OfficialBuildId)
-                          /p:DotNetPublishUsingPipelines=$true
-                          
-      # Only enable publishing in non-public, non PR scenarios.
-      ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-        # DotNet-Symbol-Server-Pats provides: microsoft-symbol-server-pat symweb-symbol-server-pat
-        group: DotNet-Symbol-Server-Pats
+      dependsOn:
+      - Linux_x64
+      - Linux_arm
+      - Linux_arm64
+      - MacOS
+      - Windows_x86
+      - Windows_x64
+      - MacOS_Apple_Silicon
+      variables:
+        DotnetVersionKind: $[variables.VERSIONKIND] # If no "VERSIONKIND" variable is set when queuing the publishing task, this defaults to empty string.
+        NUGET_PACKAGES: $(Build.SourcesDirectory)/.packages
+        _SignType: real
+        _TeamName: DotNetCore
+        _InternalBuildArgs: /p:DotNetSignType=$(_SignType) 
+                            /p:TeamName=$(_TeamName)
+                            /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
+                            /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
+                            /p:OfficialBuildId=$(OfficialBuildId)
+                            /p:DotNetPublishUsingPipelines=$true
+      pool:
+        name: NetCore1ESPool-Internal
+        demands: ImageOverride -equals Build.Server.Amd64.VS2019
+      steps:
 
-    pool:
-      name: NetCore1ESPool-Internal
-      demands: ImageOverride -equals Build.Server.Amd64.VS2019
-    steps:
+      # Download all agent packages from all previous phases
+      - task: DownloadBuildArtifacts@0
+        displayName: Download package assets
+        inputs:
+          artifactName: pkgassets
+          downloadPath: $(Build.SourcesDirectory)/artifacts
 
-    # Download all agent packages from all previous phases
-    - task: DownloadBuildArtifacts@0
-      displayName: Download package assets
-      inputs:
-        artifactName: pkgassets
-        downloadPath: $(Build.SourcesDirectory)/artifacts
+      # Depending on the value of DotNetFinalVersionKind, the name of the package will change.
+      # For our nightly builds we want it to be empty, and when creating the official nugets, we want it to be "release"
+      # the value of the version kind is set when queuing the publishing job on AzureDevOps by adding a VERSIONKIND variable
+      # See more info in: https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/Versioning.md#package-version
+      - script: ./build.cmd -configuration $(BuildConfig) -pack -publish -ci /p:DotNetFinalVersionKind=$(DotnetVersionKind) $(_InternalBuildArgs)
+        displayName: Build Packages
 
-    # Depending on the value of DotNetFinalVersionKind, the name of the package will change.
-    # For our nightly builds we want it to be empty, and when creating the official nugets, we want it to be "release"
-    # the value of the version kind is set when queuing the publishing job on AzureDevOps by adding a VERSIONKIND variable
-    # See more info in: https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/Versioning.md#package-version
-    - script: ./build.cmd -configuration $(BuildConfig) -pack -publish -ci /p:DotNetFinalVersionKind=$(DotnetVersionKind) $(_InternalBuildArgs)
-      displayName: Build Packages
-
-    - template: /eng/common/templates/steps/generate-sbom.yml
-
-    # Terminate all dotnet build processes.
-    - script: $(Build.SourcesDirectory)/.dotnet/dotnet.exe build-server shutdown
-      displayName: Dotnet Server Shutdown
+      # Terminate all dotnet build processes.
+      - script: $(Build.SourcesDirectory)/.dotnet/dotnet.exe build-server shutdown
+        displayName: Dotnet Server Shutdown
 
   - template: /eng/common/templates/job/publish-build-assets.yml
     parameters:

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -164,25 +164,11 @@ stages:
   - job: Windows_x86
   ################################################################################
     variables:
-      _SignType: real
-      _UseEsrpSigning: true
       _TeamName: DotNetCore
     pool:
       name: NetCore1ESPool-Internal
       demands: ImageOverride -equals Build.Server.Amd64.VS2019
     steps:
-
-    - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@4
-      displayName: Install MicroBuild Signing Plugin
-      inputs:
-        signType: '$(_SignType)'
-        zipSources: false
-        esrpSigning: '$(_UseEsrpSigning)'
-        feedSource: 'https://dnceng.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
-      env:
-        TeamName: $(_TeamName)
-      continueOnError: false
-      condition: and(succeeded(), in(variables._SignType, 'real', 'test'))
 
     - script: ./restore.cmd
       displayName: restore all projects
@@ -191,9 +177,6 @@ stages:
     # Only build native assets to avoid conflicts.
     - script: ./build.cmd -projects $(Build.SourcesDirectory)/src/Native/Native.proj -configuration $(BuildConfig) /p:TargetArchitecture=x86 /p:CopyPackageAssets=true
       displayName: Build Native Assets
-
-    - script: ./sign.cmd -configuration $(BuildConfig) /p:TargetArchitecture=x86 /p:SignBinaries=true
-      displayName: sign binaries
 
     - task: PublishBuildArtifacts@1
       displayName: Publish Windows_x86 package assets
@@ -213,25 +196,11 @@ stages:
   ################################################################################
     variables:
       Codeql.SkipTaskAutoInjection: False  # run CodeQL in this job
-      _SignType: real
-      _UseEsrpSigning: true
       _TeamName: DotNetCore
     pool:
       name: NetCore1ESPool-Internal
       demands: ImageOverride -equals Build.Server.Amd64.VS2019
     steps:
-
-    - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@4
-      displayName: Install MicroBuild Signing Plugin
-      inputs:
-        signType: '$(_SignType)'
-        zipSources: false
-        esrpSigning: '$(_UseEsrpSigning)'
-        feedSource: 'https://dnceng.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
-      env:
-        TeamName: $(_TeamName)
-      continueOnError: false
-      condition: and(succeeded(), in(variables._SignType, 'real', 'test'))
 
     # Build both native and managed assets.
     - script: ./build.cmd -configuration $(BuildConfig) /p:TargetArchitecture=x64 /p:CopyPackageAssets=true
@@ -242,10 +211,6 @@ stages:
         scanType: 'Register'
         verbosity: 'Verbose'
         alertWarningLevel: 'High'
-
-
-    - script: ./sign.cmd -configuration $(BuildConfig) /p:TargetArchitecture=x64 /p:SignBinaries=true
-      displayName: sign binaries
 
     - task: PublishBuildArtifacts@1
       displayName: Publish Windows_x64 package assets
@@ -275,12 +240,14 @@ stages:
       DotnetVersionKind: $[variables.VERSIONKIND] # If no "VERSIONKIND" variable is set when queuing the publishing task, this defaults to empty string.
       NUGET_PACKAGES: $(Build.SourcesDirectory)/.packages
       _SignType: real
-      _UseEsrpSigning: true
       _TeamName: DotNetCore
-      _AzureDevopsFeedUrl: https://pkgs.dev.azure.com/dnceng/public/_packaging/MachineLearning/nuget/v3/index.json
-      _SymwebSymbolServerPath: https://microsoft.artifacts.visualstudio.com/DefaultCollection
-      _MsdlSymbolServerPath: https://microsoftpublicsymbols.artifacts.visualstudio.com/DefaultCollection
-
+      _InternalBuildArgs: /p:DotNetSignType=$(_SignType) 
+                          /p:TeamName=$(_TeamName)
+                          /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
+                          /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
+                          /p:OfficialBuildId=$(OfficialBuildId)
+                          /p:DotNetPublishUsingPipelines=$true
+                          
       # Only enable publishing in non-public, non PR scenarios.
       ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
         # DotNet-Symbol-Server-Pats provides: microsoft-symbol-server-pat symweb-symbol-server-pat
@@ -290,19 +257,6 @@ stages:
       name: NetCore1ESPool-Internal
       demands: ImageOverride -equals Build.Server.Amd64.VS2019
     steps:
-
-    # Install MicroBuild plugin
-    - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@4
-      displayName: Install MicroBuild Signing Plugin
-      inputs:
-        signType: '$(_SignType)'
-        zipSources: false
-        esrpSigning: '$(_UseEsrpSigning)'
-        feedSource: 'https://dnceng.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
-      env:
-        TeamName: $(_TeamName)
-      continueOnError: false
-      condition: and(succeeded(), in(variables._SignType, 'real', 'test'))
 
     # Download all agent packages from all previous phases
     - task: DownloadBuildArtifacts@0
@@ -322,48 +276,10 @@ stages:
     # For our nightly builds we want it to be empty, and when creating the official nugets, we want it to be "release"
     # the value of the version kind is set when queuing the publishing job on AzureDevOps by adding a VERSIONKIND variable
     # See more info in: https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/Versioning.md#package-version
-    - script: ./build.cmd -configuration $(BuildConfig) -pack -ci /p:OfficialBuildId=$(OfficialBuildId) /p:DotNetFinalVersionKind=$(DotnetVersionKind)
+    - script: ./build.cmd -configuration $(BuildConfig) -pack -ci /p:DotNetFinalVersionKind=$(DotnetVersionKind) $(_InternalBuildArgs)
       displayName: Build Packages
 
-    - script: ./sign.cmd /p:SignNugetPackages=true
-      displayName: sign packages
-      continueOnError: false
-
     - template: /eng/common/templates/steps/generate-sbom.yml
-
-    # The generated .nupkgs and .snupkgs packages are published to Azure artifacts,
-    # in case we need to debug them. They're found under Release/Shipping
-    - task: PublishBuildArtifacts@1
-      displayName: Push packages and symbol packages to Azure Artifacts
-      inputs:
-        pathToPublish: $(Build.SourcesDirectory)/artifacts/packages
-        artifactName: PackageAssets
-        artifactType: container
-      continueOnError: true
-
-    - task: NuGetCommand@2
-      displayName: Push packages to AzureDevOps feed
-      inputs:
-        command: push
-        nuGetFeedType: 'internal'
-        publishVstsFeed: 'public/MachineLearning'
-        packagesToPush: $(Build.SourcesDirectory)/artifacts/**/*.nupkg;!$(Build.SourcesDirectory)/artifacts/**/*.snupkg
-
-    - task: MSBuild@1
-      displayName: Publish Symbols to SymWeb Symbol Server
-      inputs:
-        solution: build/publish.proj
-        msbuildArguments: /t:PublishSymbolPackages /p:SymbolServerPath=$(_SymwebSymbolServerPath) /p:SymbolServerPAT=$(symweb-symbol-server-pat)
-        msbuildVersion: 15.0
-      continueOnError: true
-
-    - task: MSBuild@1
-      displayName: Publish Symbols to Msdl Symbol Server
-      inputs:
-        solution: build/publish.proj
-        msbuildArguments: /t:PublishSymbolPackages /p:SymbolServerPath=$(_MsdlSymbolServerPath) /p:SymbolServerPAT=$(microsoft-symbol-server-pat)
-        msbuildVersion: 15.0
-      continueOnError: true
 
     # Terminate all dotnet build processes.
     - script: $(Build.SourcesDirectory)/.dotnet/dotnet.exe build-server shutdown

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -13,14 +13,7 @@ resources:
   - container: UbuntuCrossArm64Container
     image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-mlnet-cross-arm64
 variables:
-- group: SDL_Settings
-  BuildConfig: Release
-  OfficialBuildId: $(BUILD.BUILDNUMBER)
-  DOTNET_CLI_TELEMETRY_OPTOUT: 1
-  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
-  DOTNET_MULTILEVEL_LOOKUP: 0
-  Codeql.Enabled: true
-  Codeql.SkipTaskAutoInjection: True  #default to not inject CodeQL tasks, we'll enable it in a single job.
+- template: /eng/common-variables.yml
   
 stages:
 - stage: build

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -205,6 +205,7 @@ stages:
     parameters:
       name: Package
   ################################################################################
+      enablePublishUsingPipelines: true
       dependsOn:
       - Linux_x64
       - Linux_arm

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -22,345 +22,352 @@ variables:
   Codeql.Enabled: true
   Codeql.SkipTaskAutoInjection: True  #default to not inject CodeQL tasks, we'll enable it in a single job.
 
-jobs:
+stages:
+- stage: build
+  displayName: Build
+  jobs:
+  ################################################################################
+  - job: Linux_x64
+  ################################################################################
+    pool:
+      name: NetCore1ESPool-Internal
+      demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
+    container: CentosContainer
+    steps:
+    - script: ./restore.sh
+      displayName: restore all projects
+    - script: ./build.sh -configuration $(BuildConfig) /p:CopyPackageAssets=true /p:SkipRIDAgnosticAssets=true -projects $(Build.SourcesDirectory)/src/Redist/Microsoft.ML.DnnImageFeaturizer.ModelRedist/Microsoft.ML.DnnImageFeaturizer.ModelRedist.proj
+      displayName: build redist
+    # Only build native assets to avoid conflicts.
+    - script: ./build.sh -configuration $(BuildConfig) -projects $(Build.SourcesDirectory)/src/Native/Native.proj /p:TargetArchitecture=x64 /p:CopyPackageAssets=true
+      displayName: Build Native Assets
+
+    - task: PublishBuildArtifacts@1
+      displayName: Publish Linux package assets
+      inputs:
+        pathToPublish: $(Build.SourcesDirectory)/artifacts/pkgassets
+        artifactName: PackageAssets
+        artifactType: container
+
+    - template: /eng/common/templates/steps/generate-sbom.yml
+
+  ################################################################################
+  - job: Linux_arm
+  ################################################################################
+    variables:
+      ROOTFS_DIR: '/crossrootfs/arm'
+    pool:
+      name: NetCore1ESPool-Internal
+      demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
+    container: UbuntuCrossArmContainer
+    steps:
+    - script: ./restore.sh
+      displayName: restore all projects
+    - script: ./build.sh -configuration $(BuildConfig) /p:CopyPackageAssets=true /p:SkipRIDAgnosticAssets=true -projects $(Build.SourcesDirectory)/src/Redist/Microsoft.ML.DnnImageFeaturizer.ModelRedist/Microsoft.ML.DnnImageFeaturizer.ModelRedist.proj
+      displayName: build redist
+    # Only build native assets to avoid conflicts.
+    - script: ./build.sh -configuration $(BuildConfig) -projects $(Build.SourcesDirectory)/src/Native/Native.proj /p:TargetArchitecture=arm /p:CopyPackageAssets=true
+      displayName: Build Native Assets
+
+    - task: PublishBuildArtifacts@1
+      displayName: Publish Linux package assets
+      inputs:
+        pathToPublish: $(Build.SourcesDirectory)/artifacts/pkgassets
+        artifactName: PackageAssets
+        artifactType: container
+
+    - template: /eng/common/templates/steps/generate-sbom.yml
+
+  ################################################################################
+  - job: Linux_arm64
+  ################################################################################
+    variables:
+      ROOTFS_DIR: '/crossrootfs/arm64'
+    pool:
+      name: NetCore1ESPool-Internal
+      demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
+    container: UbuntuCrossArm64Container
+    steps:
+    - script: ./restore.sh
+      displayName: restore all projects
+    - script: ./build.sh -configuration $(BuildConfig) /p:CopyPackageAssets=true /p:SkipRIDAgnosticAssets=true -projects $(Build.SourcesDirectory)/src/Redist/Microsoft.ML.DnnImageFeaturizer.ModelRedist/Microsoft.ML.DnnImageFeaturizer.ModelRedist.proj
+      displayName: build redist
+    # Only build native assets to avoid conflicts.
+    - script: ./build.sh -configuration $(BuildConfig) -projects $(Build.SourcesDirectory)/src/Native/Native.proj /p:TargetArchitecture=arm64 /p:CopyPackageAssets=true
+      displayName: Build Native Assets
+
+    - task: PublishBuildArtifacts@1
+      displayName: Publish Linux package assets
+      inputs:
+        pathToPublish: $(Build.SourcesDirectory)/artifacts/pkgassets
+        artifactName: PackageAssets
+        artifactType: container
+
+    - template: /eng/common/templates/steps/generate-sbom.yml
+
+  ################################################################################
+  - job: MacOS
+  ################################################################################
+    pool:
+      vmImage: macOS-12
+    steps:
+    - script: brew update && brew unlink python@3.8 && brew unlink libomp && brew install $(Build.SourcesDirectory)/build/libomp.rb --build-from-source --formula
+      displayName: Install build dependencies
+    - script: ./restore.sh
+      displayName: restore all projects
+    - script: ./build.sh -configuration $(BuildConfig) /p:CopyPackageAssets=true /p:SkipRIDAgnosticAssets=true -projects $(Build.SourcesDirectory)/src/Redist/Microsoft.ML.DnnImageFeaturizer.ModelRedist/Microsoft.ML.DnnImageFeaturizer.ModelRedist.proj
+      displayName: build redist
+    # Only build native assets to avoid conflicts.
+    - script: ./build.sh -projects $(Build.SourcesDirectory)/src/Native/Native.proj -configuration $(BuildConfig) /p:TargetArchitecture=x64 /p:CopyPackageAssets=true
+      displayName: Build Native Assets
+
+    - task: PublishBuildArtifacts@1
+      displayName: Publish macOS package assets
+      inputs:
+        pathToPublish: $(Build.SourcesDirectory)/artifacts/pkgassets
+        artifactName: PackageAssets
+        artifactType: container
+
+    - template: /eng/common/templates/steps/generate-sbom.yml
+
+  ################################################################################
+  - job: MacOS_Apple_Silicon
+  ################################################################################
+    pool:
+      vmImage: macOS-12
+    steps:
+    # Work around MacOS Homebrew image/environment bug: https://github.com/actions/virtual-environments/issues/2322#issuecomment-749211076
+    - script: |
+        rm -rf /usr/local/bin/2to3
+      displayName: MacOS Homebrew bug Workaround
+      continueOnError: true
+    - script: brew update && brew unlink python@3.8 && brew install libomp && brew link libomp --force
+      displayName: Install build dependencies
+    - script: ./restore.sh
+      displayName: restore all projects
+    - script: ./build.sh -configuration $(BuildConfig) /p:CopyPackageAssets=true /p:SkipRIDAgnosticAssets=true -projects $(Build.SourcesDirectory)/src/Redist/Microsoft.ML.DnnImageFeaturizer.ModelRedist/Microsoft.ML.DnnImageFeaturizer.ModelRedist.proj
+      displayName: build redist
+    # Only build native assets to avoid conflicts.
+    - script: ./build.sh -projects $(Build.SourcesDirectory)/src/Native/Native.proj -configuration $(BuildConfig) /p:TargetArchitecture=arm64 /p:CopyPackageAssets=true
+      displayName: Build Native Assets
+
+    - task: PublishBuildArtifacts@1
+      displayName: Publish macOS package assets
+      inputs:
+        pathToPublish: $(Build.SourcesDirectory)/artifacts/pkgassets
+        artifactName: PackageAssets
+        artifactType: container
+
+    - template: /eng/common/templates/steps/generate-sbom.yml
+
+  ################################################################################
+  - job: Windows_x86
+  ################################################################################
+    variables:
+      _SignType: real
+      _UseEsrpSigning: true
+      _TeamName: DotNetCore
+    pool:
+      name: NetCore1ESPool-Internal
+      demands: ImageOverride -equals Build.Server.Amd64.VS2019
+    steps:
+
+    - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@4
+      displayName: Install MicroBuild Signing Plugin
+      inputs:
+        signType: '$(_SignType)'
+        zipSources: false
+        esrpSigning: '$(_UseEsrpSigning)'
+        feedSource: 'https://dnceng.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
+      env:
+        TeamName: $(_TeamName)
+      continueOnError: false
+      condition: and(succeeded(), in(variables._SignType, 'real', 'test'))
+
+    - script: ./restore.cmd
+      displayName: restore all projects
+    - script: ./build.cmd -configuration $(BuildConfig) /p:CopyPackageAssets=true /p:SkipRIDAgnosticAssets=true -projects $(Build.SourcesDirectory)/src/Redist/Microsoft.ML.DnnImageFeaturizer.ModelRedist/Microsoft.ML.DnnImageFeaturizer.ModelRedist.proj
+      displayName: build redist
+    # Only build native assets to avoid conflicts.
+    - script: ./build.cmd -projects $(Build.SourcesDirectory)/src/Native/Native.proj -configuration $(BuildConfig) /p:TargetArchitecture=x86 /p:CopyPackageAssets=true
+      displayName: Build Native Assets
+
+    - script: ./sign.cmd -configuration $(BuildConfig) /p:TargetArchitecture=x86 /p:SignBinaries=true
+      displayName: sign binaries
+
+    - task: PublishBuildArtifacts@1
+      displayName: Publish Windows_x86 package assets
+      inputs:
+        pathToPublish: $(Build.SourcesDirectory)/artifacts/pkgassets
+        artifactName: PackageAssets
+        artifactType: container
+
+    - template: /eng/common/templates/steps/generate-sbom.yml
+
+    # Terminate all dotnet build processes.
+    - script: $(Build.SourcesDirectory)/.dotnet/dotnet.exe build-server shutdown
+      displayName: Dotnet Server Shutdown
+
+  ################################################################################
+  - job: Windows_x64
+  ################################################################################
+    variables:
+      Codeql.SkipTaskAutoInjection: False  # run CodeQL in this job
+      _SignType: real
+      _UseEsrpSigning: true
+      _TeamName: DotNetCore
+    pool:
+      name: NetCore1ESPool-Internal
+      demands: ImageOverride -equals Build.Server.Amd64.VS2019
+    steps:
+
+    - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@4
+      displayName: Install MicroBuild Signing Plugin
+      inputs:
+        signType: '$(_SignType)'
+        zipSources: false
+        esrpSigning: '$(_UseEsrpSigning)'
+        feedSource: 'https://dnceng.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
+      env:
+        TeamName: $(_TeamName)
+      continueOnError: false
+      condition: and(succeeded(), in(variables._SignType, 'real', 'test'))
+
+    # Build both native and managed assets.
+    - script: ./build.cmd -configuration $(BuildConfig) /p:TargetArchitecture=x64 /p:CopyPackageAssets=true
+      displayName: Build
+
+    - task: ComponentGovernanceComponentDetection@0
+      inputs:
+        scanType: 'Register'
+        verbosity: 'Verbose'
+        alertWarningLevel: 'High'
+
+
+    - script: ./sign.cmd -configuration $(BuildConfig) /p:TargetArchitecture=x64 /p:SignBinaries=true
+      displayName: sign binaries
+
+    - task: PublishBuildArtifacts@1
+      displayName: Publish Windows_x64 package assets
+      inputs:
+        pathToPublish: $(Build.SourcesDirectory)/artifacts/pkgassets
+        artifactName: PackageAssets
+        artifactType: container
+
+    - template: /eng/common/templates/steps/generate-sbom.yml
+
+    # Terminate all dotnet build processes.
+    - script: $(Build.SourcesDirectory)/.dotnet/dotnet.exe build-server shutdown
+      displayName: Dotnet Server Shutdown
+
 ################################################################################
-- job: Linux_x64
-################################################################################
-  pool:
-    name: NetCore1ESPool-Internal
-    demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
-  container: CentosContainer
-  steps:
-  - script: ./restore.sh
-    displayName: restore all projects
-  - script: ./build.sh -configuration $(BuildConfig) /p:CopyPackageAssets=true /p:SkipRIDAgnosticAssets=true -projects $(Build.SourcesDirectory)/src/Redist/Microsoft.ML.DnnImageFeaturizer.ModelRedist/Microsoft.ML.DnnImageFeaturizer.ModelRedist.proj
-    displayName: build redist
-  # Only build native assets to avoid conflicts.
-  - script: ./build.sh -configuration $(BuildConfig) -projects $(Build.SourcesDirectory)/src/Native/Native.proj /p:TargetArchitecture=x64 /p:CopyPackageAssets=true
-    displayName: Build Native Assets
+  - job: Package
+  ################################################################################
+    dependsOn:
+    - Linux_x64
+    - Linux_arm
+    - Linux_arm64
+    - MacOS
+    - Windows_x86
+    - Windows_x64
+    - MacOS_Apple_Silicon
+    variables:
+      DotnetVersionKind: $[variables.VERSIONKIND] # If no "VERSIONKIND" variable is set when queuing the publishing task, this defaults to empty string.
+      NUGET_PACKAGES: $(Build.SourcesDirectory)/.packages
+      _SignType: real
+      _UseEsrpSigning: true
+      _TeamName: DotNetCore
+      _AzureDevopsFeedUrl: https://pkgs.dev.azure.com/dnceng/public/_packaging/MachineLearning/nuget/v3/index.json
+      _SymwebSymbolServerPath: https://microsoft.artifacts.visualstudio.com/DefaultCollection
+      _MsdlSymbolServerPath: https://microsoftpublicsymbols.artifacts.visualstudio.com/DefaultCollection
 
-  - task: PublishBuildArtifacts@1
-    displayName: Publish Linux package assets
-    inputs:
-      pathToPublish: $(Build.SourcesDirectory)/artifacts/pkgassets
-      artifactName: PackageAssets
-      artifactType: container
+      # Only enable publishing in non-public, non PR scenarios.
+      ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+        # DotNet-Symbol-Server-Pats provides: microsoft-symbol-server-pat symweb-symbol-server-pat
+        group: DotNet-Symbol-Server-Pats
 
-  - template: /eng/common/templates/steps/generate-sbom.yml
+    pool:
+      name: NetCore1ESPool-Internal
+      demands: ImageOverride -equals Build.Server.Amd64.VS2019
+    steps:
 
-################################################################################
-- job: Linux_arm
-################################################################################
-  variables:
-    ROOTFS_DIR: '/crossrootfs/arm'
-  pool:
-    name: NetCore1ESPool-Internal
-    demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
-  container: UbuntuCrossArmContainer
-  steps:
-  - script: ./restore.sh
-    displayName: restore all projects
-  - script: ./build.sh -configuration $(BuildConfig) /p:CopyPackageAssets=true /p:SkipRIDAgnosticAssets=true -projects $(Build.SourcesDirectory)/src/Redist/Microsoft.ML.DnnImageFeaturizer.ModelRedist/Microsoft.ML.DnnImageFeaturizer.ModelRedist.proj
-    displayName: build redist
-  # Only build native assets to avoid conflicts.
-  - script: ./build.sh -configuration $(BuildConfig) -projects $(Build.SourcesDirectory)/src/Native/Native.proj /p:TargetArchitecture=arm /p:CopyPackageAssets=true
-    displayName: Build Native Assets
+    # Install MicroBuild plugin
+    - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@4
+      displayName: Install MicroBuild Signing Plugin
+      inputs:
+        signType: '$(_SignType)'
+        zipSources: false
+        esrpSigning: '$(_UseEsrpSigning)'
+        feedSource: 'https://dnceng.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
+      env:
+        TeamName: $(_TeamName)
+      continueOnError: false
+      condition: and(succeeded(), in(variables._SignType, 'real', 'test'))
 
-  - task: PublishBuildArtifacts@1
-    displayName: Publish Linux package assets
-    inputs:
-      pathToPublish: $(Build.SourcesDirectory)/artifacts/pkgassets
-      artifactName: PackageAssets
-      artifactType: container
+    # Download all agent packages from all previous phases
+    - task: DownloadBuildArtifacts@0
+      displayName: Download package assets
+      inputs:
+        artifactName: PackageAssets
+        downloadPath: $(Build.SourcesDirectory)/artifacts/pkgassets
 
-  - template: /eng/common/templates/steps/generate-sbom.yml
+    # Workaround https://github.com/Microsoft/vsts-tasks/issues/6739
+    - task: CopyFiles@2
+      displayName: Copy package assets to correct folder
+      inputs:
+        sourceFolder: $(Build.SourcesDirectory)/artifacts/pkgassets/PackageAssets
+        targetFolder: $(Build.SourcesDirectory)/artifacts/pkgassets
 
-################################################################################
-- job: Linux_arm64
-################################################################################
-  variables:
-    ROOTFS_DIR: '/crossrootfs/arm64'
-  pool:
-    name: NetCore1ESPool-Internal
-    demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
-  container: UbuntuCrossArm64Container
-  steps:
-  - script: ./restore.sh
-    displayName: restore all projects
-  - script: ./build.sh -configuration $(BuildConfig) /p:CopyPackageAssets=true /p:SkipRIDAgnosticAssets=true -projects $(Build.SourcesDirectory)/src/Redist/Microsoft.ML.DnnImageFeaturizer.ModelRedist/Microsoft.ML.DnnImageFeaturizer.ModelRedist.proj
-    displayName: build redist
-  # Only build native assets to avoid conflicts.
-  - script: ./build.sh -configuration $(BuildConfig) -projects $(Build.SourcesDirectory)/src/Native/Native.proj /p:TargetArchitecture=arm64 /p:CopyPackageAssets=true
-    displayName: Build Native Assets
+    # Depending on the value of DotNetFinalVersionKind, the name of the package will change.
+    # For our nightly builds we want it to be empty, and when creating the official nugets, we want it to be "release"
+    # the value of the version kind is set when queuing the publishing job on AzureDevOps by adding a VERSIONKIND variable
+    # See more info in: https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/Versioning.md#package-version
+    - script: ./build.cmd -configuration $(BuildConfig) -pack -ci /p:OfficialBuildId=$(OfficialBuildId) /p:DotNetFinalVersionKind=$(DotnetVersionKind)
+      displayName: Build Packages
 
-  - task: PublishBuildArtifacts@1
-    displayName: Publish Linux package assets
-    inputs:
-      pathToPublish: $(Build.SourcesDirectory)/artifacts/pkgassets
-      artifactName: PackageAssets
-      artifactType: container
+    - script: ./sign.cmd /p:SignNugetPackages=true
+      displayName: sign packages
+      continueOnError: false
 
-  - template: /eng/common/templates/steps/generate-sbom.yml
+    - template: /eng/common/templates/steps/generate-sbom.yml
 
-################################################################################
-- job: MacOS
-################################################################################
-  pool:
-    vmImage: macOS-12
-  steps:
-  - script: brew update && brew unlink python@3.8 && brew unlink libomp && brew install $(Build.SourcesDirectory)/build/libomp.rb --build-from-source --formula
-    displayName: Install build dependencies
-  - script: ./restore.sh
-    displayName: restore all projects
-  - script: ./build.sh -configuration $(BuildConfig) /p:CopyPackageAssets=true /p:SkipRIDAgnosticAssets=true -projects $(Build.SourcesDirectory)/src/Redist/Microsoft.ML.DnnImageFeaturizer.ModelRedist/Microsoft.ML.DnnImageFeaturizer.ModelRedist.proj
-    displayName: build redist
-  # Only build native assets to avoid conflicts.
-  - script: ./build.sh -projects $(Build.SourcesDirectory)/src/Native/Native.proj -configuration $(BuildConfig) /p:TargetArchitecture=x64 /p:CopyPackageAssets=true
-    displayName: Build Native Assets
+    # The generated .nupkgs and .snupkgs packages are published to Azure artifacts,
+    # in case we need to debug them. They're found under Release/Shipping
+    - task: PublishBuildArtifacts@1
+      displayName: Push packages and symbol packages to Azure Artifacts
+      inputs:
+        pathToPublish: $(Build.SourcesDirectory)/artifacts/packages
+        artifactName: PackageAssets
+        artifactType: container
+      continueOnError: true
 
-  - task: PublishBuildArtifacts@1
-    displayName: Publish macOS package assets
-    inputs:
-      pathToPublish: $(Build.SourcesDirectory)/artifacts/pkgassets
-      artifactName: PackageAssets
-      artifactType: container
+    - task: NuGetCommand@2
+      displayName: Push packages to AzureDevOps feed
+      inputs:
+        command: push
+        nuGetFeedType: 'internal'
+        publishVstsFeed: 'public/MachineLearning'
+        packagesToPush: $(Build.SourcesDirectory)/artifacts/**/*.nupkg;!$(Build.SourcesDirectory)/artifacts/**/*.snupkg
 
-  - template: /eng/common/templates/steps/generate-sbom.yml
+    - task: MSBuild@1
+      displayName: Publish Symbols to SymWeb Symbol Server
+      inputs:
+        solution: build/publish.proj
+        msbuildArguments: /t:PublishSymbolPackages /p:SymbolServerPath=$(_SymwebSymbolServerPath) /p:SymbolServerPAT=$(symweb-symbol-server-pat)
+        msbuildVersion: 15.0
+      continueOnError: true
 
-################################################################################
-- job: MacOS_Apple_Silicon
-################################################################################
-  pool:
-    vmImage: macOS-12
-  steps:
-  # Work around MacOS Homebrew image/environment bug: https://github.com/actions/virtual-environments/issues/2322#issuecomment-749211076
-  - script: |
-      rm -rf /usr/local/bin/2to3
-    displayName: MacOS Homebrew bug Workaround
-    continueOnError: true
-  - script: brew update && brew unlink python@3.8 && brew install libomp && brew link libomp --force
-    displayName: Install build dependencies
-  - script: ./restore.sh
-    displayName: restore all projects
-  - script: ./build.sh -configuration $(BuildConfig) /p:CopyPackageAssets=true /p:SkipRIDAgnosticAssets=true -projects $(Build.SourcesDirectory)/src/Redist/Microsoft.ML.DnnImageFeaturizer.ModelRedist/Microsoft.ML.DnnImageFeaturizer.ModelRedist.proj
-    displayName: build redist
-  # Only build native assets to avoid conflicts.
-  - script: ./build.sh -projects $(Build.SourcesDirectory)/src/Native/Native.proj -configuration $(BuildConfig) /p:TargetArchitecture=arm64 /p:CopyPackageAssets=true
-    displayName: Build Native Assets
+    - task: MSBuild@1
+      displayName: Publish Symbols to Msdl Symbol Server
+      inputs:
+        solution: build/publish.proj
+        msbuildArguments: /t:PublishSymbolPackages /p:SymbolServerPath=$(_MsdlSymbolServerPath) /p:SymbolServerPAT=$(microsoft-symbol-server-pat)
+        msbuildVersion: 15.0
+      continueOnError: true
 
-  - task: PublishBuildArtifacts@1
-    displayName: Publish macOS package assets
-    inputs:
-      pathToPublish: $(Build.SourcesDirectory)/artifacts/pkgassets
-      artifactName: PackageAssets
-      artifactType: container
-
-  - template: /eng/common/templates/steps/generate-sbom.yml
-
-################################################################################
-- job: Windows_x86
-################################################################################
-  variables:
-    _SignType: real
-    _UseEsrpSigning: true
-    _TeamName: DotNetCore
-  pool:
-    name: NetCore1ESPool-Internal
-    demands: ImageOverride -equals Build.Server.Amd64.VS2019
-  steps:
-
-  - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@4
-    displayName: Install MicroBuild Signing Plugin
-    inputs:
-      signType: '$(_SignType)'
-      zipSources: false
-      esrpSigning: '$(_UseEsrpSigning)'
-      feedSource: 'https://dnceng.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
-    env:
-      TeamName: $(_TeamName)
-    continueOnError: false
-    condition: and(succeeded(), in(variables._SignType, 'real', 'test'))
-
-  - script: ./restore.cmd
-    displayName: restore all projects
-  - script: ./build.cmd -configuration $(BuildConfig) /p:CopyPackageAssets=true /p:SkipRIDAgnosticAssets=true -projects $(Build.SourcesDirectory)/src/Redist/Microsoft.ML.DnnImageFeaturizer.ModelRedist/Microsoft.ML.DnnImageFeaturizer.ModelRedist.proj
-    displayName: build redist
-  # Only build native assets to avoid conflicts.
-  - script: ./build.cmd -projects $(Build.SourcesDirectory)/src/Native/Native.proj -configuration $(BuildConfig) /p:TargetArchitecture=x86 /p:CopyPackageAssets=true
-    displayName: Build Native Assets
-
-  - script: ./sign.cmd -configuration $(BuildConfig) /p:TargetArchitecture=x86 /p:SignBinaries=true
-    displayName: sign binaries
-
-  - task: PublishBuildArtifacts@1
-    displayName: Publish Windows_x86 package assets
-    inputs:
-      pathToPublish: $(Build.SourcesDirectory)/artifacts/pkgassets
-      artifactName: PackageAssets
-      artifactType: container
-
-  - template: /eng/common/templates/steps/generate-sbom.yml
-
-  # Terminate all dotnet build processes.
-  - script: $(Build.SourcesDirectory)/.dotnet/dotnet.exe build-server shutdown
-    displayName: Dotnet Server Shutdown
-
-################################################################################
-- job: Windows_x64
-################################################################################
-  variables:
-    Codeql.SkipTaskAutoInjection: False  # run CodeQL in this job
-    _SignType: real
-    _UseEsrpSigning: true
-    _TeamName: DotNetCore
-  pool:
-    name: NetCore1ESPool-Internal
-    demands: ImageOverride -equals Build.Server.Amd64.VS2019
-  steps:
-
-  - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@4
-    displayName: Install MicroBuild Signing Plugin
-    inputs:
-      signType: '$(_SignType)'
-      zipSources: false
-      esrpSigning: '$(_UseEsrpSigning)'
-      feedSource: 'https://dnceng.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
-    env:
-      TeamName: $(_TeamName)
-    continueOnError: false
-    condition: and(succeeded(), in(variables._SignType, 'real', 'test'))
-
-  # Build both native and managed assets.
-  - script: ./build.cmd -configuration $(BuildConfig) /p:TargetArchitecture=x64 /p:CopyPackageAssets=true
-    displayName: Build
-
-  - task: ComponentGovernanceComponentDetection@0
-    inputs:
-      scanType: 'Register'
-      verbosity: 'Verbose'
-      alertWarningLevel: 'High'
-
-
-  - script: ./sign.cmd -configuration $(BuildConfig) /p:TargetArchitecture=x64 /p:SignBinaries=true
-    displayName: sign binaries
-
-  - task: PublishBuildArtifacts@1
-    displayName: Publish Windows_x64 package assets
-    inputs:
-      pathToPublish: $(Build.SourcesDirectory)/artifacts/pkgassets
-      artifactName: PackageAssets
-      artifactType: container
-
-  - template: /eng/common/templates/steps/generate-sbom.yml
-
-  # Terminate all dotnet build processes.
-  - script: $(Build.SourcesDirectory)/.dotnet/dotnet.exe build-server shutdown
-    displayName: Dotnet Server Shutdown
-
-################################################################################
-- job: Package
-################################################################################
-  dependsOn:
-  - Linux_x64
-  - Linux_arm
-  - Linux_arm64
-  - MacOS
-  - Windows_x86
-  - Windows_x64
-  - MacOS_Apple_Silicon
-  variables:
-    DotnetVersionKind: $[variables.VERSIONKIND] # If no "VERSIONKIND" variable is set when queuing the publishing task, this defaults to empty string.
-    NUGET_PACKAGES: $(Build.SourcesDirectory)/.packages
-    _SignType: real
-    _UseEsrpSigning: true
-    _TeamName: DotNetCore
-    _AzureDevopsFeedUrl: https://pkgs.dev.azure.com/dnceng/public/_packaging/MachineLearning/nuget/v3/index.json
-    _SymwebSymbolServerPath: https://microsoft.artifacts.visualstudio.com/DefaultCollection
-    _MsdlSymbolServerPath: https://microsoftpublicsymbols.artifacts.visualstudio.com/DefaultCollection
-
-    # Only enable publishing in non-public, non PR scenarios.
-    ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      # DotNet-Symbol-Server-Pats provides: microsoft-symbol-server-pat symweb-symbol-server-pat
-      group: DotNet-Symbol-Server-Pats
-
-  pool:
-    name: NetCore1ESPool-Internal
-    demands: ImageOverride -equals Build.Server.Amd64.VS2019
-  steps:
-
-  # Install MicroBuild plugin
-  - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@4
-    displayName: Install MicroBuild Signing Plugin
-    inputs:
-      signType: '$(_SignType)'
-      zipSources: false
-      esrpSigning: '$(_UseEsrpSigning)'
-      feedSource: 'https://dnceng.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
-    env:
-      TeamName: $(_TeamName)
-    continueOnError: false
-    condition: and(succeeded(), in(variables._SignType, 'real', 'test'))
-
-  # Download all agent packages from all previous phases
-  - task: DownloadBuildArtifacts@0
-    displayName: Download package assets
-    inputs:
-      artifactName: PackageAssets
-      downloadPath: $(Build.SourcesDirectory)/artifacts/pkgassets
-
-  # Workaround https://github.com/Microsoft/vsts-tasks/issues/6739
-  - task: CopyFiles@2
-    displayName: Copy package assets to correct folder
-    inputs:
-      sourceFolder: $(Build.SourcesDirectory)/artifacts/pkgassets/PackageAssets
-      targetFolder: $(Build.SourcesDirectory)/artifacts/pkgassets
-
-  # Depending on the value of DotNetFinalVersionKind, the name of the package will change.
-  # For our nightly builds we want it to be empty, and when creating the official nugets, we want it to be "release"
-  # the value of the version kind is set when queuing the publishing job on AzureDevOps by adding a VERSIONKIND variable
-  # See more info in: https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/Versioning.md#package-version
-  - script: ./build.cmd -configuration $(BuildConfig) -pack -ci /p:OfficialBuildId=$(OfficialBuildId) /p:DotNetFinalVersionKind=$(DotnetVersionKind)
-    displayName: Build Packages
-
-  - script: ./sign.cmd /p:SignNugetPackages=true
-    displayName: sign packages
-    continueOnError: false
-
-  - template: /eng/common/templates/steps/generate-sbom.yml
-
-  # The generated .nupkgs and .snupkgs packages are published to Azure artifacts,
-  # in case we need to debug them. They're found under Release/Shipping
-  - task: PublishBuildArtifacts@1
-    displayName: Push packages and symbol packages to Azure Artifacts
-    inputs:
-      pathToPublish: $(Build.SourcesDirectory)/artifacts/packages
-      artifactName: PackageAssets
-      artifactType: container
-    continueOnError: true
-
-  - task: NuGetCommand@2
-    displayName: Push packages to AzureDevOps feed
-    inputs:
-      command: push
-      nuGetFeedType: 'internal'
-      publishVstsFeed: 'public/MachineLearning'
-      packagesToPush: $(Build.SourcesDirectory)/artifacts/**/*.nupkg;!$(Build.SourcesDirectory)/artifacts/**/*.snupkg
-
-  - task: MSBuild@1
-    displayName: Publish Symbols to SymWeb Symbol Server
-    inputs:
-      solution: build/publish.proj
-      msbuildArguments: /t:PublishSymbolPackages /p:SymbolServerPath=$(_SymwebSymbolServerPath) /p:SymbolServerPAT=$(symweb-symbol-server-pat)
-      msbuildVersion: 15.0
-    continueOnError: true
-
-  - task: MSBuild@1
-    displayName: Publish Symbols to Msdl Symbol Server
-    inputs:
-      solution: build/publish.proj
-      msbuildArguments: /t:PublishSymbolPackages /p:SymbolServerPath=$(_MsdlSymbolServerPath) /p:SymbolServerPAT=$(microsoft-symbol-server-pat)
-      msbuildVersion: 15.0
-    continueOnError: true
+    # Terminate all dotnet build processes.
+    - script: $(Build.SourcesDirectory)/.dotnet/dotnet.exe build-server shutdown
+      displayName: Dotnet Server Shutdown
 
   - template: /eng/common/templates/post-build/post-build.yml
     parameters:
@@ -380,7 +387,3 @@ jobs:
         -TsaRepositoryName "machinelearning"
         -TsaCodebaseName "machinelearning"
         -TsaPublish $True'
-
-  # Terminate all dotnet build processes.
-  - script: $(Build.SourcesDirectory)/.dotnet/dotnet.exe build-server shutdown
-    displayName: Dotnet Server Shutdown

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -259,6 +259,8 @@ stages:
         demands: ImageOverride -equals windows.vs2019.amd64
 
 - template: /eng/common/templates/post-build/post-build.yml
+  variables:
+    - group: SDL_Settings
   parameters:
     publishingInfraVersion: 3
     # This is to enable SDL runs part of Post-Build Validation Stage

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -276,8 +276,14 @@ stages:
     # For our nightly builds we want it to be empty, and when creating the official nugets, we want it to be "release"
     # the value of the version kind is set when queuing the publishing job on AzureDevOps by adding a VERSIONKIND variable
     # See more info in: https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/Versioning.md#package-version
-    - script: ./build.cmd -configuration $(BuildConfig) -pack -ci /p:DotNetFinalVersionKind=$(DotnetVersionKind) $(_InternalBuildArgs)
+    - script: ./build.cmd -configuration $(BuildConfig) -pack -publish -ci /p:DotNetFinalVersionKind=$(DotnetVersionKind) $(_InternalBuildArgs)
       displayName: Build Packages
+
+    - template: /eng/common/templates/job/publish-build-assets.yml
+      parameters:
+        enablePublishBuildArtifacts: true
+        publishAssetsImmediately: true
+        publishUsingPipelines: true
 
     - template: /eng/common/templates/steps/generate-sbom.yml
 

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -260,7 +260,7 @@ stages:
     - script: $(Build.SourcesDirectory)/.dotnet/dotnet.exe build-server shutdown
       displayName: Dotnet Server Shutdown
 
-################################################################################
+  ################################################################################
   - job: Package
   ################################################################################
     dependsOn:
@@ -369,7 +369,7 @@ stages:
     - script: $(Build.SourcesDirectory)/.dotnet/dotnet.exe build-server shutdown
       displayName: Dotnet Server Shutdown
 
-template: /eng/common/templates/post-build/post-build.yml
+- template: /eng/common/templates/post-build/post-build.yml
   parameters:
     publishingInfraVersion: 3
     # This is to enable SDL runs part of Post-Build Validation Stage

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -369,21 +369,21 @@ stages:
     - script: $(Build.SourcesDirectory)/.dotnet/dotnet.exe build-server shutdown
       displayName: Dotnet Server Shutdown
 
-  - template: /eng/common/templates/post-build/post-build.yml
-    parameters:
-      publishingInfraVersion: 3
-      # This is to enable SDL runs part of Post-Build Validation Stage
-      SDLValidationParameters:
-        enable: true
-        publishGdn: true
-        continueOnError: false
-        params: ' -SourceToolsList @("policheck","credscan")
-        -TsaInstanceURL $(_TsaInstanceURL)
-        -TsaProjectName $(_TsaProjectName)
-        -TsaNotificationEmail $(_TsaNotificationEmail)
-        -TsaCodebaseAdmin $(_TsaCodebaseAdmin)
-        -TsaBugAreaPath $(_TsaBugAreaPath)
-        -TsaIterationPath $(_TsaIterationPath)
-        -TsaRepositoryName "machinelearning"
-        -TsaCodebaseName "machinelearning"
-        -TsaPublish $True'
+template: /eng/common/templates/post-build/post-build.yml
+  parameters:
+    publishingInfraVersion: 3
+    # This is to enable SDL runs part of Post-Build Validation Stage
+    SDLValidationParameters:
+      enable: true
+      publishGdn: true
+      continueOnError: false
+      params: ' -SourceToolsList @("policheck","credscan")
+      -TsaInstanceURL $(_TsaInstanceURL)
+      -TsaProjectName $(_TsaProjectName)
+      -TsaNotificationEmail $(_TsaNotificationEmail)
+      -TsaCodebaseAdmin $(_TsaCodebaseAdmin)
+      -TsaBugAreaPath $(_TsaBugAreaPath)
+      -TsaIterationPath $(_TsaIterationPath)
+      -TsaRepositoryName "machinelearning"
+      -TsaCodebaseName "machinelearning"
+      -TsaPublish $True'

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -34,10 +34,6 @@ stages:
       demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
     container: CentosContainer
     steps:
-    - script: ./restore.sh
-      displayName: restore all projects
-    - script: ./build.sh -configuration $(BuildConfig) /p:CopyPackageAssets=true /p:SkipRIDAgnosticAssets=true -projects $(Build.SourcesDirectory)/src/Redist/Microsoft.ML.DnnImageFeaturizer.ModelRedist/Microsoft.ML.DnnImageFeaturizer.ModelRedist.proj
-      displayName: build redist
     # Only build native assets to avoid conflicts.
     - script: ./build.sh -configuration $(BuildConfig) -projects $(Build.SourcesDirectory)/src/Native/Native.proj /p:TargetArchitecture=x64 /p:CopyPackageAssets=true
       displayName: Build Native Assets
@@ -61,10 +57,6 @@ stages:
       demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
     container: UbuntuCrossArmContainer
     steps:
-    - script: ./restore.sh
-      displayName: restore all projects
-    - script: ./build.sh -configuration $(BuildConfig) /p:CopyPackageAssets=true /p:SkipRIDAgnosticAssets=true -projects $(Build.SourcesDirectory)/src/Redist/Microsoft.ML.DnnImageFeaturizer.ModelRedist/Microsoft.ML.DnnImageFeaturizer.ModelRedist.proj
-      displayName: build redist
     # Only build native assets to avoid conflicts.
     - script: ./build.sh -configuration $(BuildConfig) -projects $(Build.SourcesDirectory)/src/Native/Native.proj /p:TargetArchitecture=arm /p:CopyPackageAssets=true
       displayName: Build Native Assets
@@ -88,10 +80,6 @@ stages:
       demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
     container: UbuntuCrossArm64Container
     steps:
-    - script: ./restore.sh
-      displayName: restore all projects
-    - script: ./build.sh -configuration $(BuildConfig) /p:CopyPackageAssets=true /p:SkipRIDAgnosticAssets=true -projects $(Build.SourcesDirectory)/src/Redist/Microsoft.ML.DnnImageFeaturizer.ModelRedist/Microsoft.ML.DnnImageFeaturizer.ModelRedist.proj
-      displayName: build redist
     # Only build native assets to avoid conflicts.
     - script: ./build.sh -configuration $(BuildConfig) -projects $(Build.SourcesDirectory)/src/Native/Native.proj /p:TargetArchitecture=arm64 /p:CopyPackageAssets=true
       displayName: Build Native Assets
@@ -113,10 +101,6 @@ stages:
     steps:
     - script: brew update && brew unlink python@3.8 && brew unlink libomp && brew install $(Build.SourcesDirectory)/build/libomp.rb --build-from-source --formula
       displayName: Install build dependencies
-    - script: ./restore.sh
-      displayName: restore all projects
-    - script: ./build.sh -configuration $(BuildConfig) /p:CopyPackageAssets=true /p:SkipRIDAgnosticAssets=true -projects $(Build.SourcesDirectory)/src/Redist/Microsoft.ML.DnnImageFeaturizer.ModelRedist/Microsoft.ML.DnnImageFeaturizer.ModelRedist.proj
-      displayName: build redist
     # Only build native assets to avoid conflicts.
     - script: ./build.sh -projects $(Build.SourcesDirectory)/src/Native/Native.proj -configuration $(BuildConfig) /p:TargetArchitecture=x64 /p:CopyPackageAssets=true
       displayName: Build Native Assets
@@ -143,10 +127,6 @@ stages:
       continueOnError: true
     - script: brew update && brew unlink python@3.8 && brew install libomp && brew link libomp --force
       displayName: Install build dependencies
-    - script: ./restore.sh
-      displayName: restore all projects
-    - script: ./build.sh -configuration $(BuildConfig) /p:CopyPackageAssets=true /p:SkipRIDAgnosticAssets=true -projects $(Build.SourcesDirectory)/src/Redist/Microsoft.ML.DnnImageFeaturizer.ModelRedist/Microsoft.ML.DnnImageFeaturizer.ModelRedist.proj
-      displayName: build redist
     # Only build native assets to avoid conflicts.
     - script: ./build.sh -projects $(Build.SourcesDirectory)/src/Native/Native.proj -configuration $(BuildConfig) /p:TargetArchitecture=arm64 /p:CopyPackageAssets=true
       displayName: Build Native Assets
@@ -169,11 +149,6 @@ stages:
       name: NetCore1ESPool-Internal
       demands: ImageOverride -equals Build.Server.Amd64.VS2019
     steps:
-
-    - script: ./restore.cmd
-      displayName: restore all projects
-    - script: ./build.cmd -configuration $(BuildConfig) /p:CopyPackageAssets=true /p:SkipRIDAgnosticAssets=true -projects $(Build.SourcesDirectory)/src/Redist/Microsoft.ML.DnnImageFeaturizer.ModelRedist/Microsoft.ML.DnnImageFeaturizer.ModelRedist.proj
-      displayName: build redist
     # Only build native assets to avoid conflicts.
     - script: ./build.cmd -projects $(Build.SourcesDirectory)/src/Native/Native.proj -configuration $(BuildConfig) /p:TargetArchitecture=x86 /p:CopyPackageAssets=true
       displayName: Build Native Assets

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -241,7 +241,7 @@ stages:
       # For our nightly builds we want it to be empty, and when creating the official nugets, we want it to be "release"
       # the value of the version kind is set when queuing the publishing job on AzureDevOps by adding a VERSIONKIND variable
       # See more info in: https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/Versioning.md#package-version
-      - script: ./build.cmd -configuration $(BuildConfig) -pack -publish -ci /p:DotNetFinalVersionKind=$(DotnetVersionKind) $(_InternalBuildArgs)
+      - script: ./build.cmd -configuration $(BuildConfig) -pack -sign -publish -ci /p:DotNetFinalVersionKind=$(DotnetVersionKind) $(_InternalBuildArgs)
         displayName: Build Packages
 
       # Terminate all dotnet build processes.

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -21,7 +21,7 @@ variables:
   DOTNET_MULTILEVEL_LOOKUP: 0
   Codeql.Enabled: true
   Codeql.SkipTaskAutoInjection: True  #default to not inject CodeQL tasks, we'll enable it in a single job.
-
+  - group: SDL_Settings
 stages:
 - stage: build
   displayName: Build
@@ -266,8 +266,6 @@ stages:
         demands: ImageOverride -equals windows.vs2019.amd64
 
 - template: /eng/common/templates/post-build/post-build.yml
-  variables:
-    - group: SDL_Settings
   parameters:
     publishingInfraVersion: 3
     # This is to enable SDL runs part of Post-Build Validation Stage

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -214,16 +214,16 @@ stages:
       - Windows_x64
       - MacOS_Apple_Silicon
       variables:
-        DotnetVersionKind: $[variables.VERSIONKIND] # If no "VERSIONKIND" variable is set when queuing the publishing task, this defaults to empty string.
-        NUGET_PACKAGES: $(Build.SourcesDirectory)/.packages
-        _SignType: real
-        _TeamName: DotNetCore
-        _InternalBuildArgs: /p:DotNetSignType=$(_SignType) 
-                            /p:TeamName=$(_TeamName)
-                            /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
-                            /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
-                            /p:OfficialBuildId=$(OfficialBuildId)
-                            /p:DotNetPublishUsingPipelines=$true
+        - DotnetVersionKind: $[variables.VERSIONKIND] # If no "VERSIONKIND" variable is set when queuing the publishing task, this defaults to empty string.
+        - NUGET_PACKAGES: $(Build.SourcesDirectory)/.packages
+        - _SignType: real
+        - _TeamName: DotNetCore
+        - _InternalBuildArgs: /p:DotNetSignType=$(_SignType) 
+                              /p:TeamName=$(_TeamName)
+                              /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
+                              /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
+                              /p:OfficialBuildId=$(OfficialBuildId)
+                              /p:DotNetPublishUsingPipelines=$true
       pool:
         name: NetCore1ESPool-Internal
         demands: ImageOverride -equals Build.Server.Amd64.VS2019

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -12,8 +12,8 @@ resources:
 
   - container: UbuntuCrossArm64Container
     image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-mlnet-cross-arm64
-
 variables:
+- group: SDL_Settings
   BuildConfig: Release
   OfficialBuildId: $(BUILD.BUILDNUMBER)
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
@@ -21,7 +21,7 @@ variables:
   DOTNET_MULTILEVEL_LOOKUP: 0
   Codeql.Enabled: true
   Codeql.SkipTaskAutoInjection: True  #default to not inject CodeQL tasks, we'll enable it in a single job.
-  - group: SDL_Settings
+  
 stages:
 - stage: build
   displayName: Build

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -279,17 +279,17 @@ stages:
     - script: ./build.cmd -configuration $(BuildConfig) -pack -publish -ci /p:DotNetFinalVersionKind=$(DotnetVersionKind) $(_InternalBuildArgs)
       displayName: Build Packages
 
-    - template: /eng/common/templates/job/publish-build-assets.yml
-      parameters:
-        enablePublishBuildArtifacts: true
-        publishAssetsImmediately: true
-        publishUsingPipelines: true
-
     - template: /eng/common/templates/steps/generate-sbom.yml
 
     # Terminate all dotnet build processes.
     - script: $(Build.SourcesDirectory)/.dotnet/dotnet.exe build-server shutdown
       displayName: Dotnet Server Shutdown
+
+  - template: /eng/common/templates/job/publish-build-assets.yml
+    parameters:
+      enablePublishBuildArtifacts: true
+      publishAssetsImmediately: true
+      publishUsingPipelines: true
 
 - template: /eng/common/templates/post-build/post-build.yml
   parameters:

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -362,7 +362,7 @@ jobs:
       msbuildVersion: 15.0
     continueOnError: true
 
-  - template: eng\common\templates\post-build\post-build.yml
+  - template: /eng/common/templates/post-build/post-build.yml
     parameters:
       publishingInfraVersion: 3
       # This is to enable SDL runs part of Post-Build Validation Stage

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -249,6 +249,7 @@ stages:
 
   - template: /eng/common/templates/job/publish-build-assets.yml
     parameters:
+      dependsOn: Package
       enablePublishBuildArtifacts: true
       publishAssetsImmediately: true
       publishUsingPipelines: true

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -42,7 +42,7 @@ stages:
       displayName: Publish Linux package assets
       inputs:
         pathToPublish: $(Build.SourcesDirectory)/artifacts/pkgassets
-        artifactName: PackageAssets
+        artifactName: pkgassets
         artifactType: container
 
     - template: /eng/common/templates/steps/generate-sbom.yml
@@ -65,7 +65,7 @@ stages:
       displayName: Publish Linux package assets
       inputs:
         pathToPublish: $(Build.SourcesDirectory)/artifacts/pkgassets
-        artifactName: PackageAssets
+        artifactName: pkgassets
         artifactType: container
 
     - template: /eng/common/templates/steps/generate-sbom.yml
@@ -88,7 +88,7 @@ stages:
       displayName: Publish Linux package assets
       inputs:
         pathToPublish: $(Build.SourcesDirectory)/artifacts/pkgassets
-        artifactName: PackageAssets
+        artifactName: pkgassets
         artifactType: container
 
     - template: /eng/common/templates/steps/generate-sbom.yml
@@ -109,7 +109,7 @@ stages:
       displayName: Publish macOS package assets
       inputs:
         pathToPublish: $(Build.SourcesDirectory)/artifacts/pkgassets
-        artifactName: PackageAssets
+        artifactName: pkgassets
         artifactType: container
 
     - template: /eng/common/templates/steps/generate-sbom.yml
@@ -135,7 +135,7 @@ stages:
       displayName: Publish macOS package assets
       inputs:
         pathToPublish: $(Build.SourcesDirectory)/artifacts/pkgassets
-        artifactName: PackageAssets
+        artifactName: pkgassets
         artifactType: container
 
     - template: /eng/common/templates/steps/generate-sbom.yml
@@ -157,7 +157,7 @@ stages:
       displayName: Publish Windows_x86 package assets
       inputs:
         pathToPublish: $(Build.SourcesDirectory)/artifacts/pkgassets
-        artifactName: PackageAssets
+        artifactName: pkgassets
         artifactType: container
 
     - template: /eng/common/templates/steps/generate-sbom.yml
@@ -191,7 +191,7 @@ stages:
       displayName: Publish Windows_x64 package assets
       inputs:
         pathToPublish: $(Build.SourcesDirectory)/artifacts/pkgassets
-        artifactName: PackageAssets
+        artifactName: pkgassets
         artifactType: container
 
     - template: /eng/common/templates/steps/generate-sbom.yml
@@ -237,15 +237,8 @@ stages:
     - task: DownloadBuildArtifacts@0
       displayName: Download package assets
       inputs:
-        artifactName: PackageAssets
-        downloadPath: $(Build.SourcesDirectory)/artifacts/pkgassets
-
-    # Workaround https://github.com/Microsoft/vsts-tasks/issues/6739
-    - task: CopyFiles@2
-      displayName: Copy package assets to correct folder
-      inputs:
-        sourceFolder: $(Build.SourcesDirectory)/artifacts/pkgassets/PackageAssets
-        targetFolder: $(Build.SourcesDirectory)/artifacts/pkgassets
+        artifactName: pkgassets
+        downloadPath: $(Build.SourcesDirectory)/artifacts
 
     # Depending on the value of DotNetFinalVersionKind, the name of the package will change.
     # For our nightly builds we want it to be empty, and when creating the official nugets, we want it to be "release"

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -205,7 +205,14 @@ stages:
     parameters:
       name: Package
   ################################################################################
+      artifacts:
+        publish:
+          artifacts: true
+          logs: true
+          manifests: true
+      enableMicrobuild: true
       enablePublishUsingPipelines: true
+      enableSourceIndex: true
       dependsOn:
       - Linux_x64
       - Linux_arm
@@ -228,10 +235,6 @@ stages:
       pool:
         name: NetCore1ESPool-Internal
         demands: ImageOverride -equals Build.Server.Amd64.VS2019
-      artifacts:
-        publish:
-          artifacts: true
-          logs: true
       steps:
 
       # Download all agent packages from all previous phases

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -362,6 +362,25 @@ jobs:
       msbuildVersion: 15.0
     continueOnError: true
 
+  - template: eng\common\templates\post-build\post-build.yml
+    parameters:
+      publishingInfraVersion: 3
+      # This is to enable SDL runs part of Post-Build Validation Stage
+      SDLValidationParameters:
+        enable: true
+        publishGdn: true
+        continueOnError: false
+        params: ' -SourceToolsList @("policheck","credscan")
+        -TsaInstanceURL $(_TsaInstanceURL)
+        -TsaProjectName $(_TsaProjectName)
+        -TsaNotificationEmail $(_TsaNotificationEmail)
+        -TsaCodebaseAdmin $(_TsaCodebaseAdmin)
+        -TsaBugAreaPath $(_TsaBugAreaPath)
+        -TsaIterationPath $(_TsaIterationPath)
+        -TsaRepositoryName "machinelearning"
+        -TsaCodebaseName "machinelearning"
+        -TsaPublish $True'
+
   # Terminate all dotnet build processes.
   - script: $(Build.SourcesDirectory)/.dotnet/dotnet.exe build-server shutdown
     displayName: Dotnet Server Shutdown

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -228,6 +228,10 @@ stages:
       pool:
         name: NetCore1ESPool-Internal
         demands: ImageOverride -equals Build.Server.Amd64.VS2019
+      artifacts:
+        publish:
+          artifacts: true
+          logs: true
       steps:
 
       # Download all agent packages from all previous phases

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -254,6 +254,9 @@ stages:
       enablePublishBuildArtifacts: true
       publishAssetsImmediately: true
       publishUsingPipelines: true
+      pool:
+        name: NetCore1ESPool-Svc-Internal
+        demands: ImageOverride -equals windows.vs2019.amd64
 
 - template: /eng/common/templates/post-build/post-build.yml
   parameters:

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <PublishingVersion>3</PublishingVersion>
+  </PropertyGroup>
+</Project>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -1,21 +1,10 @@
 <Project>
-    <ItemGroup Condition="'$(SignBinaries)' == 'true'">
-        <ItemsToSign Remove="@(ItemsToSign)" />
-        <ItemsToSign Include="$(ArtifactsDir)pkgassets\**\*.dll" />
-        <FileExtensionSignInfo Include="*.dll" CertificateName="MicrosoftDotNet500" />
-    </ItemGroup>
-    <ItemGroup Condition="'$(SignNugetPackages)' == 'true'">
-        <ItemsToSign Remove="@(ItemsToSign)" />
-        <ItemsToSign Include="$(ArtifactsDir)packages\**\*.nupkg" />
-        <ItemsToSign Include="$(ArtifactsDir)packages\**\*.snupkg" />
-        <FileExtensionSignInfo Include="*.nupkg" CertificateName="NuGet" />
-        <FileExtensionSignInfo Include="*.snupkg" CertificateName="NuGet" />
-    </ItemGroup>
+  <ItemGroup>
+    <ItemsToSign Include="$(ArtifactsPackagesDir)**\*.snupkg" />
+    <FileExtensionSignInfo Include="*.snupkg" CertificateName="NuGet" />
+  </ItemGroup>
 
-    <!-- Since this repo isn't on Arcade 6, the UseDotNetCertificate optionis not available. Do the update here instead. -->
-    <ItemGroup>
-      <FileExtensionSignInfo Update="@(FileExtensionSignInfo->WithMetadataValue('CertificateName','Microsoft400'))" CertificateName="MicrosoftDotNet500" />
-      <StrongNameSignInfo Update="@(StrongNameSignInfo->WithMetadataValue('CertificateName','Microsoft400'))" CertificateName="MicrosoftDotNet500" />
-      <FileSignInfo Update="@(FileSignInfo->WithMetadataValue('CertificateName','Microsoft400'))" CertificateName="MicrosoftDotNet500" />
-    </ItemGroup>
+  <PropertyGroup>
+    <UseDotNetCertificate>true</UseDotNetCertificate>
+  </PropertyGroup>
 </Project>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -6,6 +6,5 @@
 
   <PropertyGroup>
     <UseDotNetCertificate>true</UseDotNetCertificate>
-    <PostBuildSign>true</PostBuildSign>
   </PropertyGroup>
 </Project>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -6,5 +6,6 @@
 
   <PropertyGroup>
     <UseDotNetCertificate>true</UseDotNetCertificate>
+    <PostBuildSign>true</PostBuildSign>
   </PropertyGroup>
 </Project>

--- a/eng/common-variables.yml
+++ b/eng/common-variables.yml
@@ -1,0 +1,17 @@
+variables:
+- group: SDL_Settings
+- name: BuildConfig
+  value: Release
+- name: OfficialBuildId
+  value: $(BUILD.BUILDNUMBER)
+- name: DOTNET_CLI_TELEMETRY_OPTOUT
+  value: 1
+- name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
+  value: 1
+- name: DOTNET_MULTILEVEL_LOOKUP
+  value: 0
+- name: Codeql.Enabled
+  value: true
+- name: Codeql.SkipTaskAutoInjection
+  value: True  #default to not inject CodeQL tasks, we'll enable it in a single job.
+ 

--- a/global.json
+++ b/global.json
@@ -13,7 +13,7 @@
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "7.0.0-beta.22514.3",
     "Microsoft.DotNet.Helix.Sdk": "7.0.0-beta.22514.3",
-    "Microsoft.Build.Traversal": "2.1.1",
+    "Microsoft.Build.Traversal": "3.2.0",
     "Microsoft.SourceLink.GitHub": "1.1.0-beta-20206-02",
     "Microsoft.SourceLink.Common": "1.1.0-beta-20206-02"
   }

--- a/sign.cmd
+++ b/sign.cmd
@@ -1,3 +1,0 @@
-@echo off
-powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0eng\common\Build.ps1""" -sign -warnAsError 0 %*"
-exit /b %ErrorLevel% 

--- a/src/Microsoft.ML.Mkl.Redist/Microsoft.ML.Mkl.Redist.csproj
+++ b/src/Microsoft.ML.Mkl.Redist/Microsoft.ML.Mkl.Redist.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$(RepoRoot)eng/pkg/Pack.props" />
   <PropertyGroup>
-    <Authors>Intel</Authors>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <IncludeBuildOutput Condition="'$(TargetFramework)' == 'netstandard2.0'">false</IncludeBuildOutput>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>

--- a/src/Native/Native.proj
+++ b/src/Native/Native.proj
@@ -143,8 +143,10 @@
   </Target>
 
   <Target Name="Pack" />
-  <Target Name="Restore" />
   <Target Name="Test" />
 
+  <ItemGroup>
+    <PackageDownload Include="MlNetMklDeps" Version="[$(MlNetMklDepsVersion)]" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This refactors the official build to use the arcade templates which automate a lot of validation tasks.  It also removes some redundant signing we were doing before, opting for a single signing phase after all packages have been built.

Here's a successful build from this change https://dev.azure.com/dnceng/internal/_build/results?buildId=2030382&view=results