### PR TITLE
Fix Mac CMake warnings

### DIFF
--- a/src/Native/CMakeLists.txt
+++ b/src/Native/CMakeLists.txt
@@ -1,5 +1,11 @@
 cmake_minimum_required(VERSION 2.8.12)
 
+project(Native)
+
+if (POLICY CMP0042)
+  cmake_policy(SET CMP0042 NEW) # MACOSX_RPATH enabled by default
+endif()
+
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_INSTALL_PREFIX $ENV{__CMakeBinDir})
 set(RESOURCES)

--- a/src/Native/CMakeLists.txt
+++ b/src/Native/CMakeLists.txt
@@ -83,11 +83,10 @@ else()
     add_compile_options(-fPIC)
     add_compile_options(-fvisibility=hidden)
     add_definitions(-Werror) # treat warnings as errors
+    add_compile_options(-g) # generate debug information
 
     # On Unix CMAKE_BUILD_TYPE is not passed in as just Debug/Release, so manually adding the extra flags
-    if(${CMAKE_BUILD_TYPE} MATCHES "Debug*")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
-    else()
+    if(${CMAKE_BUILD_TYPE} MATCHES "Release*")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -DNDEBUG")
     endif()
 
@@ -185,11 +184,21 @@ function(strip_symbols targetName outputFilename)
             if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
                 set(strip_destination_file ${strip_source_file}.dwarf)
 
+                execute_process(
+                    COMMAND ${DSYMUTIL} --help
+                    OUTPUT_VARIABLE DSYMUTIL_HELP_OUTPUT
+                )
+
+                set(DSYMUTIL_OPTS "--flat")
+                if ("${DSYMUTIL_HELP_OUTPUT}" MATCHES "--minimize")
+                    list(APPEND DSYMUTIL_OPTS "--minimize")
+                endif ()
+
                 add_custom_command(
                     TARGET ${targetName}
                     POST_BUILD
                     VERBATIM
-                    COMMAND ${DSYMUTIL} --flat --minimize ${strip_source_file}
+                    COMMAND ${DSYMUTIL} ${DSYMUTIL_OPTS} ${strip_source_file}
                     COMMAND ${STRIP} -u -r ${strip_source_file}
                     COMMENT Stripping symbols from ${strip_source_file} into file ${strip_destination_file}
                 )

--- a/src/Native/Native.proj
+++ b/src/Native/Native.proj
@@ -55,11 +55,16 @@
           DependsOnTargets="GenerateNativeVersionFile">
     <PropertyGroup>
       <StripArgs Condition="'$(StripNativeSymbols)' == 'True'">--stripSymbols</StripArgs>
+      <BuildArgs>--configuration $(Configuration) --arch $(TargetArchitecture) $(StripArgs)</BuildArgs>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="!$(TargetArchitecture.StartsWith('arm'))">
+      <BuildArgs>$(BuildArgs) --mkllibpath $(NuGetPackageRoot)mlnetmkldeps/$(MlNetMklDepsVersion)/runtimes/$(PackageRid)/native</BuildArgs>
       <!-- mkllibrpath is used as rpath on macOS by binaries such as SymSDGNative and MklProxyNative to locate mkl library.
            We are shipping 2 native assemblies in different nuget packages, and one has a reference on the other and MacOS needs to have
            the rpath in the assembly to where it should load the referenced assembly and since .NET Core can run assemblies out of a NuGet cache,
            we need to add the NuGet cache relative location. -->
-      <BuildArgs>--configuration $(Configuration) --arch $(TargetArchitecture) $(StripArgs) --mkllibpath $(NuGetPackageRoot)mlnetmkldeps/$(MlNetMklDepsVersion)/runtimes/$(PackageRid)/native --mkllibrpath ../../../../../microsoft.ml.mkl.redist/$(Version)/runtimes/$(PackageRid)/native</BuildArgs>
+      <BuildArgs Condition="$([MSBuild]::IsOSPlatform('osx'))">$(BuildArgs) --mkllibrpath ../../../../../microsoft.ml.mkl.redist/$(Version)/runtimes/$(PackageRid)/native</BuildArgs>
     </PropertyGroup>
 
     <Message Text="$(MSBuildProjectDirectory)/build.sh $(BuildArgs)" Importance="High"/>

--- a/src/Native/SymSgdNative/CMakeLists.txt
+++ b/src/Native/SymSgdNative/CMakeLists.txt
@@ -43,8 +43,6 @@ target_link_libraries(SymSgdNative PUBLIC ${MKL_LIBRARY} PUBLIC ${OPENMP_LIBRARY
 
 if(APPLE)
     set_target_properties(SymSgdNative PROPERTIES INSTALL_RPATH "@loader_path;@loader_path/${MKL_LIB_RPATH}}")
-else()
-    SET(UNUSED_MKL_LIB_RPATH, "${MKL_LIB_RPATH}")
 endif()
 
 install_library_and_symbols (SymSgdNative)

--- a/src/Native/build.sh
+++ b/src/Native/build.sh
@@ -63,7 +63,15 @@ while [ "$1" != "" ]; do
     shift
 done
 
-__cmake_defines="-DCMAKE_BUILD_TYPE=${__configuration} ${__strip_argument} -DMKL_LIB_PATH=${__mkllibpath} -DMKL_LIB_RPATH=${__mkllibrpath}"
+__cmake_defines="-DCMAKE_BUILD_TYPE=${__configuration} ${__strip_argument}"
+
+if [ -n "$__mkllibpath" ]; then
+    __cmake_defines="${__cmake_defines} -DMKL_LIB_PATH=${__mkllibpath}"
+fi
+
+if [ -n "$__mkllibrpath" ]; then
+    __cmake_defines="${__cmake_defines} -DMKL_LIB_RPATH=${__mkllibrpath}"
+fi
 
 __IntermediatesDir="$__baseIntermediateOutputPath/Native/$__build_arch.$__configuration"
 __BinDir="$__rootBinPath/Native/$__build_arch.$__configuration"


### PR DESCRIPTION
This should fix all the CMake warnings in our build (I will double check all platforms in CI).

Most notably this will fix the symbols for release builds on mac and linux where we weren't producing usable symbols.
