### PR TITLE
Don't publish artifacts of package job

### DIFF
--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -200,7 +200,7 @@ stages:
   ################################################################################
       artifacts:
         publish:
-          artifacts: true
+          artifacts: false
           logs: true
           manifests: true
       enableMicrobuild: true


### PR DESCRIPTION
This was publishing 15 GB of data, none of which is needed.  That was taking ~30 minutes which put us close to the timeout for the job.