### PR TITLE
Update version to 3.0.0

### DIFF
--- a/eng/BranchInfo.props
+++ b/eng/BranchInfo.props
@@ -28,15 +28,15 @@
     <IsStableProject Condition="'$(StableProjects.IndexOf($(_NormalizedStableProjectName), StringComparison.OrdinalIgnoreCase))' != '-1'">true</IsStableProject>
   </PropertyGroup>
   <PropertyGroup Condition="'$(IsStableProject)' == 'true'">
-    <MajorVersion>2</MajorVersion>
+    <MajorVersion>3</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <!-- Set baseline version for stable packages to check for API Compat -->
-    <PackageValidationBaselineVersion>1.7.1</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>2.0.0-preview.22551.1</PackageValidationBaselineVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(IsStableProject)' != 'true'">
     <MajorVersion>0</MajorVersion>
-    <MinorVersion>20</MinorVersion>
+    <MinorVersion>21</MinorVersion>
     <PatchVersion>0</PatchVersion>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -9,7 +9,7 @@
         https://github.com/dotnet/arcade/blob/c788ffa83b088cafe9dbffc1cbc8155ba88b2553/Documentation/CorePackages/Versioning.md#output
     -->
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>3.0.0</VersionPrefix>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <!-- .NET Runtime product dependencies -->


### PR DESCRIPTION
This rebrands `main` to 3.0.  I've created the release/2.0 branch as https://github.com/dotnet/machinelearning/tree/release/2.0 from commit https://github.com/dotnet/machinelearning/commit/1a83389bbd9c2f3ae27de30d10209ca9321adb7d.

From here on out we can cherry-pick changes into release/2.0 as necessary.