### PR TITLE
Add cancellation and resource monitoring to IMonitor (used for AutoML experiments)

### DIFF
--- a/src/Microsoft.ML.AutoML.Interactive/NotebookMonitor.cs
+++ b/src/Microsoft.ML.AutoML.Interactive/NotebookMonitor.cs
@@ -24,6 +24,8 @@ namespace Microsoft.ML.AutoML
         public List<TrialResult> CompletedTrials { get; set; }
         public DataFrame TrialData { get; set; }
 
+        public int ResourceUsageCheckInterval => 5000;
+
         public NotebookMonitor(SweepablePipeline pipeline)
         {
             CompletedTrials = new List<TrialResult>();
@@ -83,6 +85,10 @@ namespace Microsoft.ML.AutoML
         {
             _valueToUpdate = valueToUpdate;
             ThrottledUpdate();
+        }
+
+        public void ReportTrialResourceUsage(TrialSettings setting)
+        {
         }
     }
 }

--- a/src/Microsoft.ML.AutoML/AutoMLExperiment/IMonitor.cs
+++ b/src/Microsoft.ML.AutoML/AutoMLExperiment/IMonitor.cs
@@ -13,13 +13,12 @@ namespace Microsoft.ML.AutoML
     /// </summary>
     public interface IMonitor
     {
+        int ResourceUsageCheckInterval { get; }
         void ReportCompletedTrial(TrialResult result);
-
         void ReportBestTrial(TrialResult result);
-
         void ReportFailTrial(TrialSettings settings, Exception exception = null);
-
-        void ReportRunningTrial(TrialSettings setting);
+        void ReportRunningTrial(TrialSettings settings);
+        void ReportTrialResourceUsage(TrialSettings settings);
     }
 
     /// <summary>
@@ -30,11 +29,14 @@ namespace Microsoft.ML.AutoML
         private readonly IChannel _logger;
         private readonly List<TrialResult> _completedTrials;
         private readonly SweepablePipeline _pipeline;
-        public MLContextMonitor(IChannel logger, SweepablePipeline pipeline)
+        public int ResourceUsageCheckInterval { get; private set; }
+
+        public MLContextMonitor(IChannel logger, SweepablePipeline pipeline, int resourceUsageCheckInterval = 6000)
         {
             _logger = logger;
             _completedTrials = new List<TrialResult>();
             _pipeline = pipeline;
+            ResourceUsageCheckInterval = resourceUsageCheckInterval;
         }
 
         public virtual void ReportBestTrial(TrialResult result)
@@ -56,6 +58,10 @@ namespace Microsoft.ML.AutoML
         public virtual void ReportRunningTrial(TrialSettings setting)
         {
             _logger.Info($"Update Running Trial - Id: {setting.TrialId} - Pipeline: {_pipeline.ToString(setting.Parameter)}");
+        }
+
+        public void ReportTrialResourceUsage(TrialSettings setting)
+        {
         }
     }
 

--- a/src/Microsoft.ML.AutoML/AutoMLExperiment/IMonitor.cs
+++ b/src/Microsoft.ML.AutoML/AutoMLExperiment/IMonitor.cs
@@ -13,6 +13,9 @@ namespace Microsoft.ML.AutoML
     /// </summary>
     public interface IMonitor
     {
+        /// <summary>
+        /// Interval in milliseconds to report resource usage.
+        /// </summary>
         int ResourceUsageCheckInterval { get; }
         void ReportCompletedTrial(TrialResult result);
         void ReportBestTrial(TrialResult result);

--- a/src/Microsoft.ML.AutoML/AutoMLExperiment/TrialPerformanceMetrics.cs
+++ b/src/Microsoft.ML.AutoML/AutoMLExperiment/TrialPerformanceMetrics.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.ML.AutoML
+{
+    public class TrialPerformanceMetrics
+    {
+        public double? PeakMemoryUsage { get; set; }
+        public double? PeakCpuUsage { get; set; }
+        public double CpuUsage { get; internal set; }
+        public double MemoryUsage { get; internal set; }
+        public float[] FreeSpaceOnDrives { get; internal set; }
+    }
+}

--- a/src/Microsoft.ML.AutoML/AutoMLExperiment/TrialPerformanceMetrics.cs
+++ b/src/Microsoft.ML.AutoML/AutoMLExperiment/TrialPerformanceMetrics.cs
@@ -8,12 +8,30 @@ using System.Text;
 
 namespace Microsoft.ML.AutoML
 {
+    /// <summary>
+    /// Performance metrics for a trial.
+    /// </summary>
     public class TrialPerformanceMetrics
     {
+        /// <summary>
+        /// Peak memory usage during the trial in megabytes
+        /// </summary>
         public double? PeakMemoryUsage { get; set; }
+        /// <summary>
+        /// Peak CPU usage during the trial
+        /// </summary>
         public double? PeakCpuUsage { get; set; }
+        /// <summary>
+        /// Current CPU usage of the runner process
+        /// </summary>
         public double CpuUsage { get; internal set; }
+        /// <summary>
+        /// Current memory usage of the runner process in megabytes
+        /// </summary>
         public double MemoryUsage { get; internal set; }
+        /// <summary>
+        /// The free space available on each drive in megabytes
+        /// </summary>
         public float[] FreeSpaceOnDrives { get; internal set; }
     }
 }

--- a/src/Microsoft.ML.AutoML/AutoMLExperiment/TrialSettings.cs
+++ b/src/Microsoft.ML.AutoML/AutoMLExperiment/TrialSettings.cs
@@ -10,13 +10,31 @@ using Microsoft.ML.SearchSpace;
 
 namespace Microsoft.ML.AutoML
 {
+    /// <summary>
+    /// Settings used for the trial
+    /// </summary>
     public class TrialSettings
     {
+        /// <summary>
+        /// Identifier of the trial
+        /// </summary>
         public int TrialId { get; set; }
+        /// <summary>
+        /// Parameters for the pipeline used in this trial
+        /// </summary>
         public Parameter Parameter { get; set; }
+        /// <summary>
+        /// Cancellation token source to have the ability to cancel the trial
+        /// </summary>
         [JsonIgnore]
         public CancellationTokenSource CancellationTokenSource { get; set; }
+        /// <summary>
+        /// Performance metrics of the trial
+        /// </summary>
         public TrialPerformanceMetrics PerformanceMetrics { get; internal set; }
+        /// <summary>
+        /// The time when the trial started (UTC)
+        /// </summary>
         public DateTime StartedAtUtc { get; internal set; }
     }
 }

--- a/src/Microsoft.ML.AutoML/AutoMLExperiment/TrialSettings.cs
+++ b/src/Microsoft.ML.AutoML/AutoMLExperiment/TrialSettings.cs
@@ -2,6 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
+using System.Threading;
 using Microsoft.ML.SearchSpace;
 
 namespace Microsoft.ML.AutoML
@@ -9,7 +13,10 @@ namespace Microsoft.ML.AutoML
     public class TrialSettings
     {
         public int TrialId { get; set; }
-
         public Parameter Parameter { get; set; }
+        [JsonIgnore]
+        public CancellationTokenSource CancellationTokenSource { get; set; }
+        public TrialPerformanceMetrics PerformanceMetrics { get; internal set; }
+        public DateTime StartedAtUtc { get; internal set; }
     }
 }

--- a/src/Microsoft.ML.SearchSpace/Parameter.cs
+++ b/src/Microsoft.ML.SearchSpace/Parameter.cs
@@ -50,7 +50,7 @@ namespace Microsoft.ML.SearchSpace
     }
 
     /// <summary>
-    /// <see cref="Parameter"/> is used to save sweeping result from tuner and is used to restore mlnet pipeline from sweepable pipline.
+    /// <see cref="Parameter"/> is used to save sweeping result from tuner and is used to restore mlnet pipeline from sweepable pipeline.
     /// </summary>
     [JsonConverter(typeof(ParameterConverter))]
     public sealed class Parameter : IDictionary<string, Parameter>, IEquatable<Parameter>, IEqualityComparer<Parameter>

--- a/test/Microsoft.ML.AutoML.Tests/AutoMLExperimentTests.cs
+++ b/test/Microsoft.ML.AutoML.Tests/AutoMLExperimentTests.cs
@@ -407,9 +407,7 @@ namespace Microsoft.ML.AutoML.Test
             _checkIntervalInMilliseconds = 1000;
         }
 
-        public event EventHandler<double> CpuUsage;
-
-        public event EventHandler<double> MemoryUsageInMegaByte;
+        public event EventHandler<TrialPerformanceMetrics> PerformanceMetricsUpdated;
 
         public void Dispose()
         {
@@ -432,8 +430,7 @@ namespace Microsoft.ML.AutoML.Test
                 _timer = new System.Timers.Timer(_checkIntervalInMilliseconds);
                 _timer.Elapsed += (o, e) =>
                 {
-                    CpuUsage?.Invoke(this, 100);
-                    MemoryUsageInMegaByte?.Invoke(this, 1000);
+                    PerformanceMetricsUpdated?.Invoke(this, new TrialPerformanceMetrics() { PeakCpuUsage = 100, PeakMemoryUsage = 1000 });
                 };
 
                 _timer.AutoReset = true;


### PR DESCRIPTION
Fixes #6320, #6465, #6426, #6425 and helps investigating further problems with AutoML trials.

This PR lets the user skip trials based various performance metrics. It changed my user experience with AutoML experiments significantly, because I regularly had crashes and failed trials when I tried to run experiments for a long time. With this modification I could implement my own IMonitor and react to changes in memory demand, disk space or I could skip a trial if it was running unexpectedly long.
Before the modifications my experiments usually stopped with an error in a few hours and after 15-20 trials, but now I just had my longest, 12-hour-long successful run with 729 trials!

I include my logs that were generated by [my custom IMonitor implementation](https://github.com/andrasfuchs/BioBalanceDetector/blob/master/Software/Source/BBDProto08/BBD.BodyMonitor/BBD.BodyMonitor.API/Models/MLContextLoggerMonitor.cs) as an example:
```
03:41:00.5 info:   Resources Trial # 725 - Pipeline: LightGbmRegression                  -   Memory:       26,3 GB -      CPU:         94,5% - Duration:   2,0 minutes
03:41:03.9 info:   Completed Trial # 725 - Pipeline: LightGbmRegression                  -   Metric:        0,7367 - Duration:   2,1 minutes
03:41:03.9 info:  ------------------------------------------------------------------------------------------------------------------------------------------------------
03:41:03.9 info:     Running Trial # 726
03:41:10.0 info:   Resources Trial # 726 - Pipeline: LightGbmRegression                  -   Memory:        5,0 GB -      CPU:         45,9% - Duration:   0,1 minutes
03:41:15.9 info:   Resources Trial # 726 - Pipeline: LightGbmRegression                  -   Memory:       26,3 GB -      CPU:         88,1% - Duration:   0,2 minutes
03:41:21.9 info:   Resources Trial # 726 - Pipeline: LightGbmRegression                  -   Memory:       26,3 GB -      CPU:         94,5% - Duration:   0,3 minutes
03:41:27.9 info:   Resources Trial # 726 - Pipeline: LightGbmRegression                  -   Memory:       26,3 GB -      CPU:         94,7% - Duration:   0,4 minutes
03:41:33.9 info:   Resources Trial # 726 - Pipeline: LightGbmRegression                  -   Memory:       26,3 GB -      CPU:         93,3% - Duration:   0,5 minutes
03:41:39.9 info:   Resources Trial # 726 - Pipeline: LightGbmRegression                  -   Memory:       26,3 GB -      CPU:         94,0% - Duration:   0,6 minutes
03:41:45.9 info:   Resources Trial # 726 - Pipeline: LightGbmRegression                  -   Memory:       26,3 GB -      CPU:         94,7% - Duration:   0,7 minutes
03:41:51.9 info:   Resources Trial # 726 - Pipeline: LightGbmRegression                  -   Memory:       26,3 GB -      CPU:         93,5% - Duration:   0,8 minutes
03:41:58.0 info:   Resources Trial # 726 - Pipeline: LightGbmRegression                  -   Memory:       26,3 GB -      CPU:         93,7% - Duration:   0,9 minutes
03:42:03.9 info:   Resources Trial # 726 - Pipeline: LightGbmRegression                  -   Memory:       26,4 GB -      CPU:         93,0% - Duration:   1,0 minutes
03:42:09.9 info:   Resources Trial # 726 - Pipeline: LightGbmRegression                  -   Memory:       26,4 GB -      CPU:         91,6% - Duration:   1,1 minutes
03:42:16.0 info:   Resources Trial # 726 - Pipeline: LightGbmRegression                  -   Memory:       26,4 GB -      CPU:         91,5% - Duration:   1,2 minutes
03:42:21.9 info:   Resources Trial # 726 - Pipeline: LightGbmRegression                  -   Memory:       26,4 GB -      CPU:         93,5% - Duration:   1,3 minutes
03:42:27.9 info:   Resources Trial # 726 - Pipeline: LightGbmRegression                  -   Memory:       26,4 GB -      CPU:         92,6% - Duration:   1,4 minutes
03:42:33.9 info:   Resources Trial # 726 - Pipeline: LightGbmRegression                  -   Memory:       26,4 GB -      CPU:         93,2% - Duration:   1,5 minutes
03:42:40.0 info:   Resources Trial # 726 - Pipeline: LightGbmRegression                  -   Memory:       26,4 GB -      CPU:         92,6% - Duration:   1,6 minutes
03:42:45.9 info:   Resources Trial # 726 - Pipeline: LightGbmRegression                  -   Memory:       26,4 GB -      CPU:         93,2% - Duration:   1,7 minutes
03:42:51.9 info:   Resources Trial # 726 - Pipeline: LightGbmRegression                  -   Memory:       26,4 GB -      CPU:         93,6% - Duration:   1,8 minutes
03:42:58.0 info:   Resources Trial # 726 - Pipeline: LightGbmRegression                  -   Memory:       26,4 GB -      CPU:         93,9% - Duration:   1,9 minutes
03:43:03.9 info:   Resources Trial # 726 - Pipeline: LightGbmRegression                  -   Memory:       26,4 GB -      CPU:         94,7% - Duration:   2,0 minutes
03:43:10.0 info:   Resources Trial # 726 - Pipeline: LightGbmRegression                  -   Memory:       21,0 GB -      CPU:         80,9% - Duration:   2,1 minutes
03:43:10.1 info:   Completed Trial # 726 - Pipeline: LightGbmRegression                  -   Metric:        0,7325 - Duration:   2,1 minutes
03:43:10.1 info:  ------------------------------------------------------------------------------------------------------------------------------------------------------
03:43:10.1 info:     Running Trial # 727
03:43:14.7 info:   Completed Trial # 727 - Pipeline: LbfgsPoissonRegressionRegression    -   Metric:        0,2601 - Duration:   0,1 minutes
03:43:14.7 info:  ------------------------------------------------------------------------------------------------------------------------------------------------------
03:43:14.7 info:     Running Trial # 728
03:43:20.7 info:   Resources Trial # 728 - Pipeline: LightGbmRegression                  -   Memory:        4,9 GB -      CPU:         46,6% - Duration:   0,1 minutes
03:43:26.7 info:   Resources Trial # 728 - Pipeline: LightGbmRegression                  -   Memory:       26,4 GB -      CPU:         92,4% - Duration:   0,2 minutes
03:43:32.7 info:   Resources Trial # 728 - Pipeline: LightGbmRegression                  -   Memory:       26,4 GB -      CPU:         85,5% - Duration:   0,3 minutes
03:43:38.7 info:   Resources Trial # 728 - Pipeline: LightGbmRegression                  -   Memory:       26,4 GB -      CPU:         92,4% - Duration:   0,4 minutes
03:43:44.7 info:   Resources Trial # 728 - Pipeline: LightGbmRegression                  -   Memory:       26,4 GB -      CPU:         92,9% - Duration:   0,5 minutes
03:43:50.7 info:   Resources Trial # 728 - Pipeline: LightGbmRegression                  -   Memory:       26,4 GB -      CPU:         93,2% - Duration:   0,6 minutes
03:43:56.7 info:   Resources Trial # 728 - Pipeline: LightGbmRegression                  -   Memory:       26,4 GB -      CPU:         94,1% - Duration:   0,7 minutes
03:44:02.7 info:   Resources Trial # 728 - Pipeline: LightGbmRegression                  -   Memory:       26,4 GB -      CPU:         93,2% - Duration:   0,8 minutes
03:44:08.7 info:   Resources Trial # 728 - Pipeline: LightGbmRegression                  -   Memory:       26,4 GB -      CPU:         91,5% - Duration:   0,9 minutes
03:44:14.7 info:   Resources Trial # 728 - Pipeline: LightGbmRegression                  -   Memory:       26,4 GB -      CPU:         92,8% - Duration:   1,0 minutes
03:44:20.7 info:   Resources Trial # 728 - Pipeline: LightGbmRegression                  -   Memory:       26,4 GB -      CPU:         93,7% - Duration:   1,1 minutes
03:44:26.7 info:   Resources Trial # 728 - Pipeline: LightGbmRegression                  -   Memory:       26,4 GB -      CPU:         93,6% - Duration:   1,2 minutes
03:44:32.7 info:   Resources Trial # 728 - Pipeline: LightGbmRegression                  -   Memory:       26,4 GB -      CPU:         91,7% - Duration:   1,3 minutes
03:44:38.7 info:   Resources Trial # 728 - Pipeline: LightGbmRegression                  -   Memory:       26,4 GB -      CPU:         94,7% - Duration:   1,4 minutes
03:44:44.7 info:   Resources Trial # 728 - Pipeline: LightGbmRegression                  -   Memory:       26,4 GB -      CPU:         91,0% - Duration:   1,5 minutes
03:44:50.7 info:   Resources Trial # 728 - Pipeline: LightGbmRegression                  -   Memory:       26,4 GB -      CPU:         93,7% - Duration:   1,6 minutes
03:44:56.7 info:   Resources Trial # 728 - Pipeline: LightGbmRegression                  -   Memory:       26,4 GB -      CPU:         93,0% - Duration:   1,7 minutes
03:45:02.7 info:   Resources Trial # 728 - Pipeline: LightGbmRegression                  -   Memory:       26,4 GB -      CPU:         93,9% - Duration:   1,8 minutes
03:45:08.7 info:   Resources Trial # 728 - Pipeline: LightGbmRegression                  -   Memory:       26,4 GB -      CPU:         93,3% - Duration:   1,9 minutes
03:45:14.7 info:   Resources Trial # 728 - Pipeline: LightGbmRegression                  -   Memory:       26,4 GB -      CPU:         92,3% - Duration:   2,0 minutes
03:45:17.2 info:   Completed Trial # 728 - Pipeline: LightGbmRegression                  -   Metric:        0,7247 - Duration:   2,0 minutes
03:45:17.2 info:  ------------------------------------------------------------------------------------------------------------------------------------------------------
03:45:17.2 info:     Running Trial # 729
03:45:23.3 info:   Resources Trial # 729 - Pipeline: LightGbmRegression                  -   Memory:        5,5 GB -      CPU:         44,8% - Duration:   0,1 minutes
03:45:29.2 info:   Resources Trial # 729 - Pipeline: LightGbmRegression                  -   Memory:       26,8 GB -      CPU:         93,0% - Duration:   0,2 minutes
03:45:35.2 info:   Resources Trial # 729 - Pipeline: LightGbmRegression                  -   Memory:       26,8 GB -      CPU:         93,5% - Duration:   0,3 minutes
03:45:41.2 info:   Resources Trial # 729 - Pipeline: LightGbmRegression                  -   Memory:       26,8 GB -      CPU:         92,4% - Duration:   0,4 minutes
03:45:47.2 info:   Resources Trial # 729 - Pipeline: LightGbmRegression                  -   Memory:       26,8 GB -      CPU:         93,8% - Duration:   0,5 minutes
03:45:53.2 info:   Resources Trial # 729 - Pipeline: LightGbmRegression                  -   Memory:       26,8 GB -      CPU:         92,1% - Duration:   0,6 minutes
03:45:59.2 info:   Resources Trial # 729 - Pipeline: LightGbmRegression                  -   Memory:       26,8 GB -      CPU:         94,1% - Duration:   0,7 minutes
03:46:05.2 info:   Resources Trial # 729 - Pipeline: LightGbmRegression                  -   Memory:       26,8 GB -      CPU:         94,5% - Duration:   0,8 minutes
03:46:11.2 info:   Resources Trial # 729 - Pipeline: LightGbmRegression                  -   Memory:       26,8 GB -      CPU:         93,9% - Duration:   0,9 minutes
03:46:16.5 info:  AutoML result: 0,7441799613917761. Saving model as 'o:\Work\BBD.BodyMonitor\BBD_20221122__TrainingData.Sleep.MLP12__MLP12_0p25Hz-250Hz__Session_SegmentedData_Sleep_Level__15782rows.zip'
```