### PR TITLE
moving onedal nuget download from onedal to native where its needed for building.

### DIFF
--- a/src/Microsoft.ML.OneDal/Microsoft.ML.OneDal.csproj
+++ b/src/Microsoft.ML.OneDal/Microsoft.ML.OneDal.csproj
@@ -30,20 +30,4 @@
   <ItemGroup>
     <Content Include="$(RepoRoot)eng\pkg\CommonPackage.props" Pack="true" PackagePath="build\netstandard2.0\$(MSBuildProjectName).props" />
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageDownload Include="inteldal.devel.win-x64" Version="[2023.0.0.23189]" />
-
-    <PackageDownload Condition="$([MSBuild]::IsOSPlatform('Linux'))" Include="inteldal.redist.linux-x64" Version="[2023.0.0.23046]" />
-    <PackageDownload Condition="$([MSBuild]::IsOSPlatform('Linux'))" Include="inteltbb.devel.linux" Version="[2021.7.1.15005]" />
-
-    <PackageDownload Condition="$([MSBuild]::IsOSPlatform('osx'))" Include="inteldal.redist.osx-x64" Version="[2023.0.0.22995]" />
-    <PackageDownload Condition="$([MSBuild]::IsOSPlatform('osx'))" Include="inteltbb.devel.osx" Version="[2021.7.1.14939]" />
-
-    <PackageDownload Condition="'$(OS)' == 'Windows_NT'" Include="inteldal.redist.win-x64" Version="[2023.0.0.23189]" />
-    <PackageDownload Condition="'$(OS)' == 'Windows_NT'" Include="inteltbb.redist.win" Version="[2021.7.1.15305]" />
-    <PackageDownload Condition="'$(OS)' == 'Windows_NT'" Include="inteltbb.devel.win" Version="[2021.7.1.15305]" />
-
-
-  </ItemGroup>
 </Project>

--- a/src/Native/Native.proj
+++ b/src/Native/Native.proj
@@ -8,6 +8,21 @@
   -->
   <Import Project="Sdk.targets" Sdk="Microsoft.Build.Traversal" />
 
+  <!-- Download Nugets for OneDal -->
+  <ItemGroup>
+    <PackageDownload Include="inteldal.devel.win-x64" Version="[2023.0.0.23189]" />
+
+    <PackageDownload Condition="$([MSBuild]::IsOSPlatform('Linux'))" Include="inteldal.redist.linux-x64" Version="[2023.0.0.23046]" />
+    <PackageDownload Condition="$([MSBuild]::IsOSPlatform('Linux'))" Include="inteltbb.devel.linux" Version="[2021.7.1.15005]" />
+
+    <PackageDownload Condition="$([MSBuild]::IsOSPlatform('osx'))" Include="inteldal.redist.osx-x64" Version="[2023.0.0.22995]" />
+    <PackageDownload Condition="$([MSBuild]::IsOSPlatform('osx'))" Include="inteltbb.devel.osx" Version="[2021.7.1.14939]" />
+
+    <PackageDownload Condition="'$(OS)' == 'Windows_NT'" Include="inteldal.redist.win-x64" Version="[2023.0.0.23189]" />
+    <PackageDownload Condition="'$(OS)' == 'Windows_NT'" Include="inteltbb.redist.win" Version="[2021.7.1.15305]" />
+    <PackageDownload Condition="'$(OS)' == 'Windows_NT'" Include="inteltbb.devel.win" Version="[2021.7.1.15305]" />
+  </ItemGroup>
+
   <PropertyGroup>
     <!-- versioning.targets will import this file, so don't import it again -->
     <DisableImportVersioningProps>true</DisableImportVersioningProps>
@@ -149,7 +164,7 @@
     <Copy Condition="'$(TargetArchitecture)' == 'x64'"
           SourceFiles="$(NuGetPackageRoot)inteldal.redist.$(PackageRid)\$(OneDalPkgVersion)\build\native\daal\latest\$(OneDalLibDir)\$(NativeLibPrefix)onedal_thread$(OneDalLibExtension)"
           DestinationFolder="$(PackageAssetsPath)\Microsoft.ML.OneDal\runtimes\$(PackageRid)\native" />
-	  
+
     <!-- Copy oneTBB (dependency of oneDAL) -->
     <Copy Condition="'$(TargetArchitecture)' == 'x64'"
           SourceFiles="$(NuGetPackageRoot)inteltbb.$(TbbPkgType).$(TbbSystem)\$(OneTbbPkgVersion)\runtimes\$(PackageRid)\native\$(TbbLibrary)"


### PR DESCRIPTION
Moving nuget download from onedal project to native project because its needed for building and when we build the "official build" "native only" components it fails without this.