### PR TITLE
mac python fix

### DIFF
--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -100,7 +100,7 @@ stages:
     pool:
       vmImage: macOS-12
     steps:
-    - script: brew update && brew unlink python@3.8 &&  rm '/usr/local/bin/2to3-3.11' && brew unlink libomp && brew install $(Build.SourcesDirectory)/build/libomp.rb --build-from-source --formula
+    - script: brew update &&  rm '/usr/local/bin/2to3-3.11' && brew unlink libomp && brew install $(Build.SourcesDirectory)/build/libomp.rb --build-from-source --formula
       displayName: Install build dependencies
     # Only build native assets to avoid conflicts.
     - script: ./build.sh -projects $(Build.SourcesDirectory)/src/Native/Native.proj -configuration $(BuildConfig) /p:TargetArchitecture=x64 /p:CopyPackageAssets=true
@@ -126,7 +126,7 @@ stages:
         rm -rf /usr/local/bin/2to3
       displayName: MacOS Homebrew bug Workaround
       continueOnError: true
-    - script: brew update && brew unlink python@3.8 && brew install libomp && brew link libomp --force
+    - script: brew update && brew install libomp && brew link libomp --force
       displayName: Install build dependencies
     # Only build native assets to avoid conflicts.
     - script: ./build.sh -projects $(Build.SourcesDirectory)/src/Native/Native.proj -configuration $(BuildConfig) /p:TargetArchitecture=arm64 /p:CopyPackageAssets=true


### PR DESCRIPTION
Official build is having issues in the mac setup step again. Seems to be caused by a machine change. We used to remove python 3.8 cause it was causing problems, now 3.8 is no longer installed so removing the step to remove it.

Already tested/validated with the official build.