### PR TITLE
fix cancellation bug in SweepablePipelineRunner && fix object null exception in AutoML v1.0 regression API

### DIFF
--- a/src/Microsoft.ML.AutoML/API/BinaryClassificationExperiment.cs
+++ b/src/Microsoft.ML.AutoML/API/BinaryClassificationExperiment.cs
@@ -447,7 +447,7 @@ namespace Microsoft.ML.AutoML
                     _context?.CancelExecution();
                 }))
                 {
-                    return Task.Run(() => Run(settings));
+                    return Task.FromResult(Run(settings));
                 }
             }
             catch (Exception ex) when (ct.IsCancellationRequested)

--- a/src/Microsoft.ML.AutoML/API/MulticlassClassificationExperiment.cs
+++ b/src/Microsoft.ML.AutoML/API/MulticlassClassificationExperiment.cs
@@ -445,7 +445,7 @@ namespace Microsoft.ML.AutoML
                     _context?.CancelExecution();
                 }))
                 {
-                    return Task.Run(() => Run(settings));
+                    return Task.FromResult(Run(settings));
                 }
             }
             catch (Exception ex) when (ct.IsCancellationRequested)

--- a/src/Microsoft.ML.AutoML/API/RegressionExperiment.cs
+++ b/src/Microsoft.ML.AutoML/API/RegressionExperiment.cs
@@ -159,7 +159,7 @@ namespace Microsoft.ML.AutoML
                 int numCrossValFolds = 10;
                 _experiment.SetDataset(trainData, numCrossValFolds);
                 _pipeline = CreateRegressionPipeline(trainData, columnInformation, preFeaturizer);
-
+                _experiment.SetPipeline(_pipeline);
                 TrialResultMonitor<RegressionMetrics> monitor = null;
                 _experiment.SetMonitor((provider) =>
                 {

--- a/src/Microsoft.ML.AutoML/AutoMLExperiment/AutoMLExperiment.cs
+++ b/src/Microsoft.ML.AutoML/AutoMLExperiment/AutoMLExperiment.cs
@@ -51,15 +51,7 @@ namespace Microsoft.ML.AutoML
             _serviceCollection.TryAddTransient((provider) =>
             {
                 var contextManager = provider.GetRequiredService<IMLContextManager>();
-                var trainingStopManager = provider.GetRequiredService<AggregateTrainingStopManager>();
                 var context = contextManager.CreateMLContext();
-                trainingStopManager.OnStopTraining += (s, e) =>
-                {
-                    // only force-canceling running trials when there's completed trials.
-                    // otherwise, wait for the current running trial to be completed.
-                    if (_bestTrialResult != null)
-                        context.CancelExecution();
-                };
 
                 return context;
             });

--- a/src/Microsoft.ML.AutoML/AutoMLExperiment/Runner/SweepablePipelineRunner.cs
+++ b/src/Microsoft.ML.AutoML/AutoMLExperiment/Runner/SweepablePipelineRunner.cs
@@ -96,7 +96,7 @@ namespace Microsoft.ML.AutoML
                     _mLContext?.CancelExecution();
                 }))
                 {
-                    return Task.Run(() => Run(settings));
+                    return Task.FromResult(Run(settings));
                 }
             }
             catch (Exception ex) when (ct.IsCancellationRequested)

--- a/test/Microsoft.ML.AutoML.Tests/AutoFitTests.cs
+++ b/test/Microsoft.ML.AutoML.Tests/AutoFitTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.ML.AutoML.Test
             var trainData = textLoader.Load(dataPath);
             var settings = new BinaryExperimentSettings
             {
-                MaxExperimentTimeInSeconds = 1,
+                MaxModels = 1,
             };
 
             settings.Trainers.Remove(BinaryClassificationTrainer.LightGbm);
@@ -101,7 +101,7 @@ namespace Microsoft.ML.AutoML.Test
             var trainData = textLoader.Load(dataPath);
             var settings = new BinaryExperimentSettings
             {
-                MaxExperimentTimeInSeconds = 1,
+                MaxModels = 1,
             };
 
             settings.Trainers.Remove(BinaryClassificationTrainer.LightGbm);
@@ -239,7 +239,7 @@ namespace Microsoft.ML.AutoML.Test
                 uint numberOfCVFolds = 5;
                 var settings = new MulticlassExperimentSettings
                 {
-                    MaxExperimentTimeInSeconds = 1,
+                    MaxModels = 1,
                 };
 
                 settings.Trainers.Remove(MulticlassClassificationTrainer.LightGbm);
@@ -296,8 +296,13 @@ namespace Microsoft.ML.AutoML.Test
             TrainTestData trainTestData = context.Data.TrainTestSplit(trainData, testFraction: 0.2, seed: 1);
             IDataView trainDataset = SplitUtil.DropAllColumnsExcept(context, trainTestData.TrainSet, originalColumnNames);
             IDataView testDataset = SplitUtil.DropAllColumnsExcept(context, trainTestData.TestSet, originalColumnNames);
+            var settings = new MulticlassExperimentSettings
+            {
+                MaxModels = 1,
+            };
+
             var result = context.Auto()
-                            .CreateMulticlassClassificationExperiment(20)
+                            .CreateMulticlassClassificationExperiment(settings)
                             .Execute(trainDataset, testDataset, columnInference.ColumnInformation);
 
             result.BestRun.ValidationMetrics.MicroAccuracy.Should().BeGreaterThan(0.1);
@@ -315,8 +320,12 @@ namespace Microsoft.ML.AutoML.Test
             var textLoader = context.Data.CreateTextLoader(columnInference.TextLoaderOptions);
             var trainData = context.Data.ShuffleRows(textLoader.Load(datasetPath), seed: 1);
             var originalColumnNames = trainData.Schema.Select(c => c.Name);
+            var settings = new MulticlassExperimentSettings
+            {
+                MaxModels = 1,
+            };
             var result = context.Auto()
-                            .CreateMulticlassClassificationExperiment(100)
+                            .CreateMulticlassClassificationExperiment(settings)
                             .Execute(trainData, 5, columnInference.ColumnInformation);
 
             result.BestRun.Results.Select(x => x.ValidationMetrics.MicroAccuracy).Max().Should().BeGreaterThan(0.1);
@@ -340,8 +349,12 @@ namespace Microsoft.ML.AutoML.Test
             var columnInference = context.Auto().InferColumns(datasetPath, "Label");
             var textLoader = context.Data.CreateTextLoader(columnInference.TextLoaderOptions);
             var trainData = textLoader.Load(datasetPath);
+            var settings = new MulticlassExperimentSettings
+            {
+                MaxModels = 1,
+            };
             var result = context.Auto()
-                            .CreateMulticlassClassificationExperiment(100)
+                            .CreateMulticlassClassificationExperiment(settings)
                             .Execute(trainData, columnInference.ColumnInformation);
 
             Assert.InRange(result.BestRun.ValidationMetrics.MicroAccuracy, 0.1, 0.9);
@@ -368,7 +381,7 @@ namespace Microsoft.ML.AutoML.Test
             // STEP 2: Run AutoML experiment
             var settings = new RankingExperimentSettings()
             {
-                MaxExperimentTimeInSeconds = 5,
+                MaxModels = 5,
                 OptimizationMetricTruncationLevel = 3
             };
             var experiment = mlContext.Auto()

--- a/test/Microsoft.ML.AutoML.Tests/AutoFitTests.cs
+++ b/test/Microsoft.ML.AutoML.Tests/AutoFitTests.cs
@@ -267,7 +267,7 @@ namespace Microsoft.ML.AutoML.Test
                 trainData = context.Data.TakeRows(trainData, crossValRowCountThreshold - 1);
                 var settings = new MulticlassExperimentSettings
                 {
-                    MaxExperimentTimeInSeconds = 1,
+                    MaxModels = 1,
                 };
 
                 settings.Trainers.Remove(MulticlassClassificationTrainer.LightGbm);

--- a/test/Microsoft.ML.AutoML.Tests/AutoFitTests.cs
+++ b/test/Microsoft.ML.AutoML.Tests/AutoFitTests.cs
@@ -197,9 +197,19 @@ namespace Microsoft.ML.AutoML.Test
             settings.Trainers.Remove(RegressionTrainer.StochasticDualCoordinateAscent);
             settings.Trainers.Remove(RegressionTrainer.LbfgsPoissonRegression);
 
+            // verify for dataset > 15000L
             var result = context.Auto()
                 .CreateRegressionExperiment(settings)
                 .Execute(dataset, label);
+
+            Assert.True(result.BestRun.ValidationMetrics.RSquared > 0.70);
+            Assert.NotNull(result.BestRun.Estimator);
+            Assert.NotNull(result.BestRun.TrainerName);
+
+            // verify for dataset < 15000L
+            result = context.Auto()
+                .CreateRegressionExperiment(settings)
+                .Execute(context.Data.TakeRows(dataset, 1000), label);
 
             Assert.True(result.BestRun.ValidationMetrics.RSquared > 0.70);
             Assert.NotNull(result.BestRun.Estimator);

--- a/test/Microsoft.ML.AutoML.Tests/AutoMLExperimentTests.cs
+++ b/test/Microsoft.ML.AutoML.Tests/AutoMLExperimentTests.cs
@@ -160,17 +160,17 @@ namespace Microsoft.ML.AutoML.Test
             };
 
             var experiment = context.Auto().CreateExperiment();
-            experiment.SetTrainingTimeInSeconds(10)
+            experiment.SetTrainingTimeInSeconds(5)
                       .SetTrialRunner((serviceProvider) =>
                       {
                           var channel = serviceProvider.GetService<IChannel>();
                           var settings = serviceProvider.GetService<AutoMLExperiment.AutoMLExperimentSettings>();
-                          return new DummyTrialRunner(settings, 1, channel);
+                          return new DummyTrialRunner(settings, 0, channel);
                       })
                       .SetTuner<RandomSearchTuner>();
 
             var cts = new CancellationTokenSource();
-            cts.CancelAfter(20 * 1000);
+            cts.CancelAfter(10 * 1000);
 
             var res = await experiment.RunAsync(cts.Token);
             res.Metric.Should().BeGreaterThan(0);

--- a/test/Microsoft.ML.AutoML.Tests/AutoMLExperimentTests.cs
+++ b/test/Microsoft.ML.AutoML.Tests/AutoMLExperimentTests.cs
@@ -14,7 +14,6 @@ using FluentAssertions;
 using Microsoft.Data.Analysis;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.ML.AutoML.CodeGen;
-using Microsoft.ML.Data;
 using Microsoft.ML.Runtime;
 using Microsoft.ML.TestFramework;
 using Microsoft.ML.TestFramework.Attributes;
@@ -74,7 +73,7 @@ namespace Microsoft.ML.AutoML.Test
             // the following experiment set memory usage limit to 0.01mb
             // so all trials should be canceled and there should be no successful trials.
             // therefore when experiment finishes, it should throw timeout exception with no model trained message.
-            experiment.SetMaxModelToExplore(10)
+            experiment.SetTrainingTimeInSeconds(10)
                       .SetTrialRunner((serviceProvider) =>
                       {
                           var channel = serviceProvider.GetService<IChannel>();
@@ -82,7 +81,8 @@ namespace Microsoft.ML.AutoML.Test
                           return new DummyTrialRunner(settings, 5, channel);
                       })
                       .SetTuner<RandomSearchTuner>()
-                      .SetMaximumMemoryUsageInMegaByte(0.01);
+                      .SetMaximumMemoryUsageInMegaByte(0.01)
+                      .SetPerformanceMonitor<DummyPeformanceMonitor>();
 
             var runExperimentAction = async () => await experiment.RunAsync();
             await runExperimentAction.Should().ThrowExactlyAsync<TimeoutException>();
@@ -152,13 +152,7 @@ namespace Microsoft.ML.AutoML.Test
         public async Task AutoMLExperiment_finish_training_when_time_is_up_Async()
         {
             var context = new MLContext(1);
-            context.Log += (o, e) =>
-            {
-                if (e.Source.StartsWith("AutoMLExperiment"))
-                {
-                    this.Output.WriteLine(e.RawMessage);
-                }
-            };
+
             var experiment = context.Auto().CreateExperiment();
             experiment.SetTrainingTimeInSeconds(5)
                       .SetTrialRunner((serviceProvider) =>
@@ -244,14 +238,13 @@ namespace Microsoft.ML.AutoML.Test
             var experiment = context.Auto().CreateExperiment();
             var pipeline = context.Auto().Featurizer(data, "_Features_", excludeColumns: new[] { DatasetUtil.UciAdultLabel })
                                 .Append(context.Auto().BinaryClassification(DatasetUtil.UciAdultLabel, "_Features_", useLgbm: false, useSdcaLogisticRegression: false, useLbfgsLogisticRegression: false));
-            var cts = new CancellationTokenSource();
-            cts.CancelAfter(50000);
+
             experiment.SetDataset(data, 5)
                     .SetBinaryClassificationMetric(BinaryClassificationMetric.AreaUnderRocCurve, DatasetUtil.UciAdultLabel)
                     .SetPipeline(pipeline)
-                    .SetTrainingTimeInSeconds(100);
+                    .SetTrainingTimeInSeconds(10);
 
-            var result = await experiment.RunAsync(cts.Token);
+            var result = await experiment.RunAsync();
             result.Metric.Should().BeGreaterThan(0.8);
         }
 
@@ -368,94 +361,91 @@ namespace Microsoft.ML.AutoML.Test
             settings = experiment.ServiceCollection.BuildServiceProvider().GetRequiredService<AutoMLExperiment.AutoMLExperimentSettings>();
             settings.Seed.Should().Be(1);
         }
+    }
 
-        class DummyTrialRunner : ITrialRunner
+    class DummyTrialRunner : ITrialRunner
+    {
+        private readonly int _finishAfterNSeconds;
+        private readonly CancellationToken _ct;
+        private readonly IChannel _logger;
+
+        public DummyTrialRunner(AutoMLExperiment.AutoMLExperimentSettings automlSettings, int finishAfterNSeconds, IChannel logger)
         {
-            private readonly int _finishAfterNSeconds;
-            private readonly IChannel _logger;
-
-            public DummyTrialRunner(AutoMLExperiment.AutoMLExperimentSettings automlSettings, int finishAfterNSeconds, IChannel logger)
-            {
-                _finishAfterNSeconds = finishAfterNSeconds;
-                _logger = logger;
-            }
-
-            public void Dispose()
-            {
-            }
-
-            public async Task<TrialResult> RunAsync(TrialSettings settings, CancellationToken ct)
-            {
-                _logger.Info("Update Running Trial");
-                await Task.Delay(_finishAfterNSeconds * 1000, ct);
-                ct.ThrowIfCancellationRequested();
-                _logger.Info("Update Completed Trial");
-                var metric = 1.000 + 0.01 * settings.TrialId;
-                return new TrialResult
-                {
-                    TrialSettings = settings,
-                    DurationInMilliseconds = _finishAfterNSeconds * 1000,
-                    Metric = metric,
-                    Loss = - -metric,
-                };
-            }
+            _finishAfterNSeconds = finishAfterNSeconds;
+            _ct = automlSettings.CancellationToken;
+            _logger = logger;
         }
-        class DummyPeformanceMonitor : IPerformanceMonitor
+
+        public void Dispose()
         {
-            private readonly int _checkIntervalInMilliseconds;
-            private System.Timers.Timer _timer;
+        }
 
-            public DummyPeformanceMonitor()
+        public async Task<TrialResult> RunAsync(TrialSettings settings, CancellationToken ct)
+        {
+            _logger.Info("Update Running Trial");
+            await Task.Delay(_finishAfterNSeconds * 1000, ct);
+            _ct.ThrowIfCancellationRequested();
+            _logger.Info("Update Completed Trial");
+            var metric = 1.000 + 0.01 * settings.TrialId;
+            return new TrialResult
             {
-                _checkIntervalInMilliseconds = 1000;
-            }
+                TrialSettings = settings,
+                DurationInMilliseconds = _finishAfterNSeconds * 1000,
+                Metric = metric,
+                Loss = - -metric,
+            };
+        }
+    }
 
-            public event EventHandler<TrialPerformanceMetrics> PerformanceMetricsUpdated;
+    class DummyPeformanceMonitor : IPerformanceMonitor
+    {
+        private readonly int _checkIntervalInMilliseconds;
+        private System.Timers.Timer _timer;
 
-            public void Dispose()
+        public DummyPeformanceMonitor()
+        {
+            _checkIntervalInMilliseconds = 1000;
+        }
+
+        public event EventHandler<double> CpuUsage;
+
+        public event EventHandler<double> MemoryUsageInMegaByte;
+
+        public void Dispose()
+        {
+        }
+
+        public double? GetPeakCpuUsage()
+        {
+            return 100;
+        }
+
+        public double? GetPeakMemoryUsageInMegaByte()
+        {
+            return 1000;
+        }
+
+        public void Start()
+        {
+            if (_timer == null)
             {
-            }
-
-            public double? GetPeakCpuUsage()
-            {
-                return 100;
-            }
-
-            public double? GetPeakMemoryUsageInMegaByte()
-            {
-                return 1000;
-            }
-
-            public void OnPerformanceMetricsUpdatedHandler(TrialSettings trialSettings, TrialPerformanceMetrics metrics, CancellationTokenSource trialCancellationTokenSource)
-            {
-            }
-
-            public void Start()
-            {
-                if (_timer == null)
+                _timer = new System.Timers.Timer(_checkIntervalInMilliseconds);
+                _timer.Elapsed += (o, e) =>
                 {
-                    _timer = new System.Timers.Timer(_checkIntervalInMilliseconds);
-                    _timer.Elapsed += (o, e) =>
-                    {
-                        PerformanceMetricsUpdated?.Invoke(this, new TrialPerformanceMetrics() { PeakCpuUsage = 100, PeakMemoryUsage = 1000 });
-                    };
+                    CpuUsage?.Invoke(this, 100);
+                    MemoryUsageInMegaByte?.Invoke(this, 1000);
+                };
 
-                    _timer.AutoReset = true;
-                }
+                _timer.AutoReset = true;
                 _timer.Enabled = true;
             }
+        }
 
-            public void Pause()
-            {
-                _timer.Enabled = false;
-            }
-
-            public void Stop()
-            {
-                _timer?.Stop();
-                _timer?.Dispose();
-                _timer = null;
-            }
+        public void Stop()
+        {
+            _timer?.Stop();
+            _timer?.Dispose();
+            _timer = null;
         }
     }
 }

--- a/test/Microsoft.ML.AutoML.Tests/AutoMLExperimentTests.cs
+++ b/test/Microsoft.ML.AutoML.Tests/AutoMLExperimentTests.cs
@@ -153,7 +153,7 @@ namespace Microsoft.ML.AutoML.Test
             var context = new MLContext(1);
 
             var experiment = context.Auto().CreateExperiment();
-            experiment.SetTrainingTimeInSeconds(5)
+            experiment.SetTrainingTimeInSeconds(10)
                       .SetTrialRunner((serviceProvider) =>
                       {
                           var channel = serviceProvider.GetService<IChannel>();
@@ -163,7 +163,7 @@ namespace Microsoft.ML.AutoML.Test
                       .SetTuner<RandomSearchTuner>();
 
             var cts = new CancellationTokenSource();
-            cts.CancelAfter(10 * 1000);
+            cts.CancelAfter(20 * 1000);
 
             var res = await experiment.RunAsync(cts.Token);
             res.Metric.Should().BeGreaterThan(0);

--- a/test/Microsoft.ML.AutoML.Tests/AutoMLExperimentTests.cs
+++ b/test/Microsoft.ML.AutoML.Tests/AutoMLExperimentTests.cs
@@ -422,7 +422,11 @@ namespace Microsoft.ML.AutoML.Test
             var experiment = context.Auto().CreateExperiment();
             var chain = new EstimatorChain<ITransformer>();
             var pipeline = chain.Append(context.Transforms.Conversion.MapValueToKey("Label", "Sentiment"))
-                            .Append(context.MulticlassClassification.Trainers.TextClassification(outputColumnName: "PredictedLabel", maxEpochs: 100))
+                            .Append(SweepableEstimatorFactory.CreateTextClassificationMulti(new TextClassificationOption
+                            {
+                                MaxEpochs = 100,
+                                LabelColumnName = "Label",
+                            }))
                             .Append(SweepableEstimatorFactory.CreateMapKeyToValue(new MapKeyToValueOption
                             {
                                 InputColumnName = "PredictedLabel",

--- a/test/Microsoft.ML.AutoML.Tests/AutoMLExperimentTests.cs
+++ b/test/Microsoft.ML.AutoML.Tests/AutoMLExperimentTests.cs
@@ -14,9 +14,11 @@ using FluentAssertions;
 using Microsoft.Data.Analysis;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.ML.AutoML.CodeGen;
+using Microsoft.ML.Data;
 using Microsoft.ML.Runtime;
 using Microsoft.ML.TestFramework;
 using Microsoft.ML.TestFramework.Attributes;
+using Microsoft.ML.TorchSharp;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -237,13 +239,14 @@ namespace Microsoft.ML.AutoML.Test
             var experiment = context.Auto().CreateExperiment();
             var pipeline = context.Auto().Featurizer(data, "_Features_", excludeColumns: new[] { DatasetUtil.UciAdultLabel })
                                 .Append(context.Auto().BinaryClassification(DatasetUtil.UciAdultLabel, "_Features_", useLgbm: false, useSdcaLogisticRegression: false, useLbfgsLogisticRegression: false));
-
+            var cts = new CancellationTokenSource();
+            cts.CancelAfter(50000);
             experiment.SetDataset(data, 5)
                     .SetBinaryClassificationMetric(BinaryClassificationMetric.AreaUnderRocCurve, DatasetUtil.UciAdultLabel)
                     .SetPipeline(pipeline)
-                    .SetTrainingTimeInSeconds(10);
+                    .SetTrainingTimeInSeconds(100);
 
-            var result = await experiment.RunAsync();
+            var result = await experiment.RunAsync(cts.Token);
             result.Metric.Should().BeGreaterThan(0.8);
         }
 
@@ -360,6 +363,84 @@ namespace Microsoft.ML.AutoML.Test
             settings = experiment.ServiceCollection.BuildServiceProvider().GetRequiredService<AutoMLExperiment.AutoMLExperimentSettings>();
             settings.Seed.Should().Be(1);
         }
+
+        [Fact]
+        public async Task AutoMLExperiment_should_cancel_text_classification()
+        {
+            var context = new MLContext(1);
+            context.Log += (o, e) =>
+            {
+                if (e.Message.Contains("AutoMLExperiment") || e.Message.Contains("NasBertTrainer"))
+                {
+                    this.Output.WriteLine(e.RawMessage);
+                }
+            };
+            var dataView = context.Data.LoadFromEnumerable(
+                new List<TestSingleSentenceData>(new TestSingleSentenceData[] {
+                    new TestSingleSentenceData()
+                    {   // Testing longer than 512 words.
+                        Sentence1 = "ultimately feels as flat as the scruffy sands of its titular community .ultimately feels as flat as the scruffy sands of its titular community .ultimately feels as flat as the scruffy sands of its titular community .ultimately feels as flat as the scruffy sands of its titular community .ultimately feels as flat as the scruffy sands of its titular community .ultimately feels as flat as the scruffy sands of its titular community .ultimately feels as flat as the scruffy sands of its titular community .ultimately feels as flat as the scruffy sands of its titular community . ultimately feels as flat as the scruffy sands of its titular community .ultimately feels as flat as the scruffy sands of its titular community .ultimately feels as flat as the scruffy sands of its titular community .ultimately feels as flat as the scruffy sands of its titular community .ultimately feels as flat as the scruffy sands of its titular community .ultimately feels as flat as the scruffy sands of its titular community .ultimately feels as flat as the scruffy sands of its titular community .ultimately feels as flat as the scruffy sands of its titular community . ultimately feels as flat as the scruffy sands of its titular community .ultimately feels as flat as the scruffy sands of its titular community .ultimately feels as flat as the scruffy sands of its titular community .ultimately feels as flat as the scruffy sands of its titular community .ultimately feels as flat as the scruffy sands of its titular community .ultimately feels as flat as the scruffy sands of its titular community .ultimately feels as flat as the scruffy sands of its titular community .ultimately feels as flat as the scruffy sands of its titular community . ultimately feels as flat as the scruffy sands of its titular community .ultimately feels as flat as the scruffy sands of its titular community .ultimately feels as flat as the scruffy sands of its titular community .ultimately feels as flat as the scruffy sands of its titular community .ultimately feels as flat as the scruffy sands of its titular community .ultimately feels as flat as the scruffy sands of its titular community .ultimately feels as flat as the scruffy sands of its titular community .ultimately feels as flat as the scruffy sands of its titular community .",
+                        Sentiment = "Negative"
+                    },
+                     new TestSingleSentenceData()
+                     {
+                         Sentence1 = "with a sharp script and strong performances",
+                         Sentiment = "Positive"
+                     },
+                     new TestSingleSentenceData()
+                     {
+                         Sentence1 = "that director m. night shyamalan can weave an eerie spell and",
+                         Sentiment = "Positive"
+                     },
+                     new TestSingleSentenceData()
+                     {
+                         Sentence1 = "comfortable",
+                         Sentiment = "Positive"
+                     },
+                     new TestSingleSentenceData()
+                     {
+                         Sentence1 = "does have its charms .",
+                         Sentiment = "Positive"
+                     },
+                     new TestSingleSentenceData()
+                     {
+                         Sentence1 = "banal as the telling",
+                         Sentiment = "Negative"
+                     },
+                     new TestSingleSentenceData()
+                     {
+                         Sentence1 = "faithful without being forceful , sad without being shrill , `` a walk to remember '' succeeds through sincerity .",
+                         Sentiment = "Negative"
+                     },
+                     new TestSingleSentenceData()
+                     {
+                         Sentence1 = "leguizamo 's best movie work so far",
+                         Sentiment = "Negative"
+                     }
+                }));
+
+            var experiment = context.Auto().CreateExperiment();
+            var chain = new EstimatorChain<ITransformer>();
+            var pipeline = chain.Append(context.Transforms.Conversion.MapValueToKey("Label", "Sentiment"))
+                            .Append(context.MulticlassClassification.Trainers.TextClassification(outputColumnName: "PredictedLabel", maxEpochs: 100))
+                            .Append(SweepableEstimatorFactory.CreateMapKeyToValue(new MapKeyToValueOption
+                            {
+                                InputColumnName = "PredictedLabel",
+                                OutputColumnName = "PredictedLabel",
+                            }));
+            experiment.SetPipeline(pipeline)
+                      .SetDataset(dataView, dataView)
+                      .SetMulticlassClassificationMetric(MulticlassClassificationMetric.MacroAccuracy, "Label")
+                      .SetMaxModelToExplore(1);
+            var cts = new CancellationTokenSource();
+            cts.CancelAfter(15_000);
+            await experiment.RunAsync(cts.Token);
+        }
+    }
+    class TestSingleSentenceData
+    {
+        public string Sentence1;
+        public string Sentiment;
     }
 
     class DummyTrialRunner : ITrialRunner

--- a/test/Microsoft.ML.AutoML.Tests/Microsoft.ML.AutoML.Tests.csproj
+++ b/test/Microsoft.ML.AutoML.Tests/Microsoft.ML.AutoML.Tests.csproj
@@ -9,7 +9,6 @@
     <ProjectReference Include="..\..\src\Microsoft.ML.Core\Microsoft.ML.Core.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.ML.SearchSpace\Microsoft.ML.SearchSpace.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.ML.Transforms\Microsoft.ML.Transforms.csproj" />
-    <ProjectReference Include="..\..\src\Microsoft.ML.TorchSharp\Microsoft.ML.TorchSharp.csproj" Condition="'$(TargetArchitecture)' == 'x64'" />
     <ProjectReference Include="..\Microsoft.ML.TestFramework\Microsoft.ML.TestFramework.csproj" />
   </ItemGroup>
 
@@ -50,13 +49,6 @@
       <Link>DnnImageModels\ResNet18Onnx\ResNet18.onnx</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetArchitecture)' == 'x64'">
-    <PackageReference Include="libtorch-cpu-win-x64" Version="$(LibTorchVersion)" Condition="$([MSBuild]::IsOSPlatform('Windows')) AND '$(TargetArchitecture)' == 'x64'" />
-    <!-- <PackageReference Include="TorchSharp-cuda-windows" Version="0.96.8" Condition="$([MSBuild]::IsOSPlatform('Windows'))" /> -->
-    <PackageReference Include="libtorch-cpu-linux-x64" Version="$(LibTorchVersion)" Condition="$([MSBuild]::IsOSPlatform('Linux')) AND '$(TargetArchitecture)' == 'x64'" />
-    <PackageReference Include="libtorch-cpu-osx-x64" Version="$(LibTorchVersion)" Condition="$([MSBuild]::IsOSPlatform('OSX')) AND '$(TargetArchitecture)' == 'x64'" />
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.ML.AutoML.Tests/Microsoft.ML.AutoML.Tests.csproj
+++ b/test/Microsoft.ML.AutoML.Tests/Microsoft.ML.AutoML.Tests.csproj
@@ -9,6 +9,7 @@
     <ProjectReference Include="..\..\src\Microsoft.ML.Core\Microsoft.ML.Core.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.ML.SearchSpace\Microsoft.ML.SearchSpace.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.ML.Transforms\Microsoft.ML.Transforms.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.ML.TorchSharp\Microsoft.ML.TorchSharp.csproj" Condition="'$(TargetArchitecture)' == 'x64'" />
     <ProjectReference Include="..\Microsoft.ML.TestFramework\Microsoft.ML.TestFramework.csproj" />
   </ItemGroup>
 
@@ -49,6 +50,13 @@
       <Link>DnnImageModels\ResNet18Onnx\ResNet18.onnx</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetArchitecture)' == 'x64'">
+    <PackageReference Include="libtorch-cpu-win-x64" Version="$(LibTorchVersion)" Condition="$([MSBuild]::IsOSPlatform('Windows')) AND '$(TargetArchitecture)' == 'x64'" />
+    <!-- <PackageReference Include="TorchSharp-cuda-windows" Version="0.96.8" Condition="$([MSBuild]::IsOSPlatform('Windows'))" /> -->
+    <PackageReference Include="libtorch-cpu-linux-x64" Version="$(LibTorchVersion)" Condition="$([MSBuild]::IsOSPlatform('Linux')) AND '$(TargetArchitecture)' == 'x64'" />
+    <PackageReference Include="libtorch-cpu-osx-x64" Version="$(LibTorchVersion)" Condition="$([MSBuild]::IsOSPlatform('OSX')) AND '$(TargetArchitecture)' == 'x64'" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
We are excited to review your PR.

So we can do the best job, please check:

- [ ] There's a descriptive title that will make sense to other developers some time from now. 
- [ ] There's associated issues. All PR's should have issue(s) associated - unless a trivial self-evident change such as fixing a typo. You can use the format `Fixes #nnnn` in your description to cause GitHub to automatically close the issue(s) when your PR is merged.
- [ ] Your change description explains what the change does, why you chose your approach, and anything else that reviewers should know.
- [x] You have included any necessary tests in the same PR.

# why cancellation doesn't work for SweepablePipelineRunner

SweepablePipelineRunner cancels running trial by calling `context.CancelExecution()`. When starting a trial, SweepablePipelineRunner first registers a `context.CancelExecution()` callback on cancellationtoken which will be triggered if cancellationtoken get cancelled. Then blocking on the running task until trial completed.The register callback will be unregistered after running trial completed through `using` statement.

The cause of cancellation doesn't work is SweepablePipelineRunner doesn't actually block on running trial. It simply create a wrapped task that kick off a trial, and return that task immediately. After the wrapped task is returned, the `context.CancelExecution()` will be unregistered and the running trial won't be cancelled any more.

The fix is simply change SweepablePipelineRunner to wait until the trial task is completed before return.
