### PR TITLE
Change Test to Validate  in Dataset manager

### DIFF
--- a/src/Microsoft.ML.AutoML/API/AutoMLExperimentExtension.cs
+++ b/src/Microsoft.ML.AutoML/API/AutoMLExperimentExtension.cs
@@ -27,10 +27,10 @@ namespace Microsoft.ML.AutoML
         /// <returns><see cref="AutoMLExperiment"/></returns>
         public static AutoMLExperiment SetDataset(this AutoMLExperiment experiment, IDataView train, IDataView validation)
         {
-            var datasetManager = new TrainTestDatasetManager()
+            var datasetManager = new TrainValidateDatasetManager()
             {
                 TrainDataset = train,
-                TestDataset = validation
+                ValidateDataset = validation
             };
 
             experiment.ServiceCollection.AddSingleton<IDatasetManager>(datasetManager);

--- a/src/Microsoft.ML.AutoML/API/BinaryClassificationExperiment.cs
+++ b/src/Microsoft.ML.AutoML/API/BinaryClassificationExperiment.cs
@@ -400,12 +400,12 @@ namespace Microsoft.ML.AutoML
                     };
                 }
 
-                if (_datasetManager is ITrainTestDatasetManager trainTestDatasetManager)
+                if (_datasetManager is ITrainValidateDatasetManager trainTestDatasetManager)
                 {
                     var stopWatch = new Stopwatch();
                     stopWatch.Start();
                     var model = pipeline.Fit(trainTestDatasetManager.TrainDataset);
-                    var eval = model.Transform(trainTestDatasetManager.TestDataset);
+                    var eval = model.Transform(trainTestDatasetManager.ValidateDataset);
                     var metrics = _context.BinaryClassification.EvaluateNonCalibrated(eval, metricManager.LabelColumn, predictedLabelColumnName: metricManager.PredictedColumn);
                     var metric = GetMetric(metricManager.Metric, metrics);
                     var loss = metricManager.IsMaximize ? -metric : metric;
@@ -426,7 +426,7 @@ namespace Microsoft.ML.AutoML
                 }
             }
 
-            throw new ArgumentException($"The runner metric manager is of type {_metricManager.GetType()} which expected to be of type {typeof(ITrainTestDatasetManager)} or {typeof(ICrossValidateDatasetManager)}");
+            throw new ArgumentException($"The runner metric manager is of type {_metricManager.GetType()} which expected to be of type {typeof(ITrainValidateDatasetManager)} or {typeof(ICrossValidateDatasetManager)}");
         }
 
         public Task<TrialResult> RunAsync(TrialSettings settings, CancellationToken ct)

--- a/src/Microsoft.ML.AutoML/API/MulticlassClassificationExperiment.cs
+++ b/src/Microsoft.ML.AutoML/API/MulticlassClassificationExperiment.cs
@@ -394,12 +394,12 @@ namespace Microsoft.ML.AutoML
                     };
                 }
 
-                if (_datasetManager is ITrainTestDatasetManager trainTestDatasetManager)
+                if (_datasetManager is ITrainValidateDatasetManager trainTestDatasetManager)
                 {
                     var stopWatch = new Stopwatch();
                     stopWatch.Start();
                     var model = pipeline.Fit(trainTestDatasetManager.TrainDataset);
-                    var eval = model.Transform(trainTestDatasetManager.TestDataset);
+                    var eval = model.Transform(trainTestDatasetManager.ValidateDataset);
                     var metrics = _context.MulticlassClassification.Evaluate(eval, metricManager.LabelColumn, predictedLabelColumnName: metricManager.PredictedColumn);
                     var metric = GetMetric(metricManager.Metric, metrics);
                     var loss = metricManager.IsMaximize ? -metric : metric;
@@ -420,7 +420,7 @@ namespace Microsoft.ML.AutoML
                 }
             }
 
-            throw new ArgumentException($"The runner metric manager is of type {_metricManager.GetType()} which expected to be of type {typeof(ITrainTestDatasetManager)} or {typeof(ICrossValidateDatasetManager)}");
+            throw new ArgumentException($"The runner metric manager is of type {_metricManager.GetType()} which expected to be of type {typeof(ITrainValidateDatasetManager)} or {typeof(ICrossValidateDatasetManager)}");
         }
 
         public Task<TrialResult> RunAsync(TrialSettings settings, CancellationToken ct)

--- a/src/Microsoft.ML.AutoML/API/RegressionExperiment.cs
+++ b/src/Microsoft.ML.AutoML/API/RegressionExperiment.cs
@@ -421,12 +421,12 @@ namespace Microsoft.ML.AutoML
                             } as TrialResult);
                         }
 
-                        if (_datasetManager is ITrainTestDatasetManager trainTestDatasetManager)
+                        if (_datasetManager is ITrainValidateDatasetManager trainTestDatasetManager)
                         {
                             var stopWatch = new Stopwatch();
                             stopWatch.Start();
                             var model = pipeline.Fit(trainTestDatasetManager.TrainDataset);
-                            var eval = model.Transform(trainTestDatasetManager.TestDataset);
+                            var eval = model.Transform(trainTestDatasetManager.ValidateDataset);
                             var metrics = _context.Regression.Evaluate(eval, metricManager.LabelColumn, scoreColumnName: metricManager.ScoreColumn);
                             var metric = GetMetric(metricManager.Metric, metrics);
                             var loss = metricManager.IsMaximize ? -metric : metric;
@@ -447,7 +447,7 @@ namespace Microsoft.ML.AutoML
                         }
                     }
 
-                    throw new ArgumentException($"The runner metric manager is of type {_metricManager.GetType()} which expected to be of type {typeof(ITrainTestDatasetManager)} or {typeof(ICrossValidateDatasetManager)}");
+                    throw new ArgumentException($"The runner metric manager is of type {_metricManager.GetType()} which expected to be of type {typeof(ITrainValidateDatasetManager)} or {typeof(ICrossValidateDatasetManager)}");
                 }
             }
             catch (Exception ex) when (ct.IsCancellationRequested)

--- a/src/Microsoft.ML.AutoML/AutoMLExperiment/IDatasetManager.cs
+++ b/src/Microsoft.ML.AutoML/AutoMLExperiment/IDatasetManager.cs
@@ -19,18 +19,18 @@ namespace Microsoft.ML.AutoML
         IDataView Dataset { get; set; }
     }
 
-    internal interface ITrainTestDatasetManager
+    internal interface ITrainValidateDatasetManager
     {
         IDataView TrainDataset { get; set; }
 
-        IDataView TestDataset { get; set; }
+        IDataView ValidateDataset { get; set; }
     }
 
-    internal class TrainTestDatasetManager : IDatasetManager, ITrainTestDatasetManager
+    internal class TrainValidateDatasetManager : IDatasetManager, ITrainValidateDatasetManager
     {
         public IDataView TrainDataset { get; set; }
 
-        public IDataView TestDataset { get; set; }
+        public IDataView ValidateDataset { get; set; }
     }
 
     internal class CrossValidateDatasetManager : IDatasetManager, ICrossValidateDatasetManager

--- a/src/Microsoft.ML.AutoML/AutoMLExperiment/Runner/SweepablePipelineRunner.cs
+++ b/src/Microsoft.ML.AutoML/AutoMLExperiment/Runner/SweepablePipelineRunner.cs
@@ -66,10 +66,10 @@ namespace Microsoft.ML.AutoML
                 };
             }
 
-            if (_datasetManager is ITrainTestDatasetManager trainTestDatasetManager)
+            if (_datasetManager is ITrainValidateDatasetManager trainTestDatasetManager)
             {
                 var model = mlnetPipeline.Fit(trainTestDatasetManager.TrainDataset);
-                var eval = model.Transform(trainTestDatasetManager.TestDataset);
+                var eval = model.Transform(trainTestDatasetManager.ValidateDataset);
                 var metric = _metricManager.Evaluate(_mLContext, eval);
                 stopWatch.Stop();
                 var loss = _metricManager.IsMaximize ? -metric : metric;


### PR DESCRIPTION
The main goal of this PR is  in https://github.com/dotnet/machinelearning/blob/main/src/Microsoft.ML.AutoML/AutoMLExperiment/IDatasetManager.cs 
the main goal is to set train/ validate dataset, however, names are set like `TrainTestDatasetManager`, 'TestDataset`, hence to make names consistent with the actual usage we need to change "Test" to "validate"



