### PR TITLE
Add support for string vectors to DataFrame

### DIFF
--- a/src/Microsoft.Data.Analysis/IDataView.Extension.cs
+++ b/src/Microsoft.Data.Analysis/IDataView.Extension.cs
@@ -204,6 +204,10 @@ namespace Microsoft.ML
             {
                 return new VBufferDataFrameColumn<decimal>(name);
             }
+            else if (itemType.RawType == typeof(ReadOnlyMemory<char>))
+            {
+                return new VBufferDataFrameColumn<ReadOnlyMemory<char>>(name);
+            }
 
             throw new NotSupportedException(String.Format(Microsoft.Data.Strings.VectorSubTypeNotSupported, itemType.ToString()));
         }

--- a/src/Microsoft.Data.Analysis/VBufferDataFrameColumn.cs
+++ b/src/Microsoft.Data.Analysis/VBufferDataFrameColumn.cs
@@ -390,6 +390,10 @@ namespace Microsoft.Data.Analysis
             {
                 return new VectorDataViewType(NumberDataViewType.Double);
             }
+            else if (typeof(T) == typeof(ReadOnlyMemory<char>))
+            {
+                return new VectorDataViewType(TextDataViewType.Instance);
+            }
 
             throw new NotSupportedException();
         }

--- a/test/Microsoft.Data.Analysis.Tests/DataFrameIDataViewTests.cs
+++ b/test/Microsoft.Data.Analysis.Tests/DataFrameIDataViewTests.cs
@@ -461,6 +461,7 @@ namespace Microsoft.Data.Analysis.Tests
                     ushortFeatures = new ushort[] {0, 0},
                     uintFeatures = new uint[] {0, 0},
                     ulongFeatures = new ulong[] {0, 0},
+                    stringFeatures = new string[]{ "A", "B"},
                 },
                 new {
                     boolFeature = new bool[] {false, false},
@@ -474,13 +475,14 @@ namespace Microsoft.Data.Analysis.Tests
                     ushortFeatures = new ushort[] {0, 0},
                     uintFeatures = new uint[] {0, 0},
                     ulongFeatures = new ulong[] {0, 0},
+                    stringFeatures = new string[]{ "A", "B"},
                 }
             };
 
             var data = mlContext.Data.LoadFromEnumerable(inputData);
             var df = data.ToDataFrame();
 
-            Assert.Equal(11, df.Columns.Count);
+            Assert.Equal(12, df.Columns.Count);
             Assert.Equal(2, df.Rows.Count);
         }
     }


### PR DESCRIPTION
This PR adds support for string vector/"ReadOnlyMemory<char>" vectors.

Relevant issue: https://github.com/dotnet/machinelearning/issues/5872

Building on: https://github.com/dotnet/machinelearning/pull/6409
