### PR TITLE
Change code coverage build pool to correct pool

### DIFF
--- a/build/codecoverage-ci.yml
+++ b/build/codecoverage-ci.yml
@@ -15,4 +15,5 @@ jobs:
         _targetFramework: net6.0
     codeCoverage: true
     pool:
-      vmImage: windows-2019
+      name: NetCore-Public
+      demands: ImageOverride -equals 1es-windows-2019-open


### PR DESCRIPTION
Changed code coverage build pool to the correct pool. These machines are more powerful so hopefully code coverage runs faster and is less flaky.