### PR TITLE
Fix DataFrame Null Math

### DIFF
--- a/src/Microsoft.Data.Analysis/DataFrame.BinaryOperators.tt
+++ b/src/Microsoft.Data.Analysis/DataFrame.BinaryOperators.tt
@@ -18,7 +18,7 @@ namespace Microsoft.Data.Analysis
 {
     public partial class DataFrame
     {
-        #pragma warning disable 1591
+#pragma warning disable 1591
 <# foreach (MethodConfiguration method in methodConfiguration) { #>
 <# if (method.MethodType == MethodType.BinaryScalar) { #>
 <# if (method.IsBitwise == true) { #>
@@ -32,7 +32,7 @@ namespace Microsoft.Data.Analysis
         {
             return df.<#=method.MethodName#>(value);
         }
-        
+
         public static DataFrame operator <#=method.Operator#>(<#=type.TypeName#> value, DataFrame df)
         {
             return df.Reverse<#=method.MethodName#>(value);

--- a/src/Microsoft.Data.Analysis/DataFrameColumn.BinaryOperators.tt
+++ b/src/Microsoft.Data.Analysis/DataFrameColumn.BinaryOperators.tt
@@ -18,7 +18,7 @@ namespace Microsoft.Data.Analysis
 {
     public abstract partial class DataFrameColumn
     {
-        #pragma warning disable 1591
+#pragma warning disable 1591
 <# foreach (MethodConfiguration method in methodConfiguration) { #>
 <# if (method.MethodType == MethodType.BinaryScalar) { #>
 <# if (method.IsBitwise == true) { #>

--- a/src/Microsoft.Data.Analysis/PrimitiveColumnContainer.BinaryOperations.tt
+++ b/src/Microsoft.Data.Analysis/PrimitiveColumnContainer.BinaryOperations.tt
@@ -18,15 +18,15 @@ namespace Microsoft.Data.Analysis
     {
 <# foreach (MethodConfiguration method in methodConfiguration) { #>
 <# if (method.MethodType == MethodType.Comparison || method.MethodType == MethodType.ComparisonScalar) { #>
-       public <#= method.GetSingleArgumentMethodSignature("PrimitiveColumnContainer", "T") #>
-       {
+        public <#= method.GetSingleArgumentMethodSignature("PrimitiveColumnContainer", "T") #>
+        {
 <# if (method.MethodType == MethodType.ComparisonScalar ) { #>
             PrimitiveDataFrameColumnArithmetic<T>.Instance.<#=method.MethodName#>(this, scalar, ret);
 <# } else { #>
             PrimitiveDataFrameColumnArithmetic<T>.Instance.<#=method.MethodName#>(this, right, ret);
 <# } #>
             return this;
-       }
+        }
 
 <# } else { #>
         public <#= method.GetSingleArgumentMethodSignature("PrimitiveColumnContainer", "T")#>
@@ -45,11 +45,11 @@ namespace Microsoft.Data.Analysis
 <# } #>
 <# foreach (MethodConfiguration method in methodConfiguration) { #>
 <# if (method.MethodType == MethodType.BinaryScalar) { #>
-       public PrimitiveColumnContainer<T> Reverse<#=method.MethodName#>(T scalar)
-       {
+        public PrimitiveColumnContainer<T> Reverse<#=method.MethodName#>(T scalar)
+        {
             PrimitiveDataFrameColumnArithmetic<T>.Instance.<#=method.MethodName#>(scalar, this);
             return this;
-       }
+        }
 <# } #>
 <# } #>
     }

--- a/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.cs
+++ b/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.cs
@@ -228,7 +228,7 @@ namespace Microsoft.Data.Analysis
             PrimitiveDataFrameColumn<long> sortIndices = GetAscendingSortIndices(out Int64DataFrameColumn _);
             long middle = sortIndices.Length / 2;
             double middleValue = (double)Convert.ChangeType(this[sortIndices[middle].Value].Value, typeof(double));
-            if (Length % 2 == 0)
+            if (sortIndices.Length % 2 == 0)
             {
                 double otherMiddleValue = (double)Convert.ChangeType(this[sortIndices[middle - 1].Value].Value, typeof(double));
                 return (middleValue + otherMiddleValue) / 2;
@@ -243,7 +243,7 @@ namespace Microsoft.Data.Analysis
         {
             if (Length == 0)
                 return 0;
-            return (double)Convert.ChangeType((T)Sum(), typeof(double)) / Length;
+            return (double)Convert.ChangeType((T)Sum(), typeof(double)) / (Length - NullCount);
         }
 
         protected internal override void Resize(long length)

--- a/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumnComputations.cs
+++ b/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumnComputations.cs
@@ -12,7 +12,7 @@ using System.Collections.Generic;
 namespace Microsoft.Data.Analysis
 {
     internal interface IPrimitiveColumnComputation<T>
-        where T : struct
+        where T : unmanaged
     {
         void Abs(PrimitiveColumnContainer<T> column);
         void All(PrimitiveColumnContainer<T> column, out bool ret);
@@ -37,7 +37,7 @@ namespace Microsoft.Data.Analysis
     }
 
     internal static class PrimitiveColumnComputation<T>
-        where T : struct
+        where T : unmanaged
     {
         public static IPrimitiveColumnComputation<T> Instance { get; } = PrimitiveColumnComputation.GetComputation<T>();
     }
@@ -45,7 +45,7 @@ namespace Microsoft.Data.Analysis
     internal static class PrimitiveColumnComputation
     {
         public static IPrimitiveColumnComputation<T> GetComputation<T>()
-            where T : struct
+            where T : unmanaged
         {
             if (typeof(T) == typeof(bool))
             {
@@ -284,8 +284,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (byte)(Math.Max(readOnlySpan[i], ret));
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -348,8 +348,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (byte)(Math.Min(readOnlySpan[i], ret));
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -412,8 +412,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (byte)(readOnlySpan[i] * ret);
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -476,8 +476,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (byte)(readOnlySpan[i] + ret);
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -751,8 +751,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (char)(Math.Max(readOnlySpan[i], ret));
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -815,8 +815,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (char)(Math.Min(readOnlySpan[i], ret));
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -879,8 +879,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (char)(readOnlySpan[i] * ret);
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -943,8 +943,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (char)(readOnlySpan[i] + ret);
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -1218,8 +1218,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (decimal)(Math.Max(readOnlySpan[i], ret));
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -1282,8 +1282,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (decimal)(Math.Min(readOnlySpan[i], ret));
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -1346,8 +1346,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (decimal)(readOnlySpan[i] * ret);
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -1410,8 +1410,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (decimal)(readOnlySpan[i] + ret);
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -1685,8 +1685,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (double)(Math.Max(readOnlySpan[i], ret));
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -1749,8 +1749,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (double)(Math.Min(readOnlySpan[i], ret));
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -1813,8 +1813,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (double)(readOnlySpan[i] * ret);
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -1877,8 +1877,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (double)(readOnlySpan[i] + ret);
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -2152,8 +2152,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (float)(Math.Max(readOnlySpan[i], ret));
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -2216,8 +2216,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (float)(Math.Min(readOnlySpan[i], ret));
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -2280,8 +2280,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (float)(readOnlySpan[i] * ret);
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -2344,8 +2344,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (float)(readOnlySpan[i] + ret);
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -2619,8 +2619,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (int)(Math.Max(readOnlySpan[i], ret));
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -2683,8 +2683,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (int)(Math.Min(readOnlySpan[i], ret));
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -2747,8 +2747,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (int)(readOnlySpan[i] * ret);
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -2811,8 +2811,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (int)(readOnlySpan[i] + ret);
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -3086,8 +3086,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (long)(Math.Max(readOnlySpan[i], ret));
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -3150,8 +3150,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (long)(Math.Min(readOnlySpan[i], ret));
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -3214,8 +3214,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (long)(readOnlySpan[i] * ret);
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -3278,8 +3278,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (long)(readOnlySpan[i] + ret);
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -3553,8 +3553,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (sbyte)(Math.Max(readOnlySpan[i], ret));
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -3617,8 +3617,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (sbyte)(Math.Min(readOnlySpan[i], ret));
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -3681,8 +3681,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (sbyte)(readOnlySpan[i] * ret);
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -3745,8 +3745,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (sbyte)(readOnlySpan[i] + ret);
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -4020,8 +4020,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (short)(Math.Max(readOnlySpan[i], ret));
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -4084,8 +4084,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (short)(Math.Min(readOnlySpan[i], ret));
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -4148,8 +4148,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (short)(readOnlySpan[i] * ret);
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -4212,8 +4212,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (short)(readOnlySpan[i] + ret);
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -4487,8 +4487,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (uint)(Math.Max(readOnlySpan[i], ret));
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -4551,8 +4551,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (uint)(Math.Min(readOnlySpan[i], ret));
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -4615,8 +4615,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (uint)(readOnlySpan[i] * ret);
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -4679,8 +4679,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (uint)(readOnlySpan[i] + ret);
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -4954,8 +4954,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (ulong)(Math.Max(readOnlySpan[i], ret));
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -5018,8 +5018,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (ulong)(Math.Min(readOnlySpan[i], ret));
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -5082,8 +5082,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (ulong)(readOnlySpan[i] * ret);
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -5146,8 +5146,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (ulong)(readOnlySpan[i] + ret);
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -5421,8 +5421,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (ushort)(Math.Max(readOnlySpan[i], ret));
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -5485,8 +5485,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (ushort)(Math.Min(readOnlySpan[i], ret));
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -5549,8 +5549,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (ushort)(readOnlySpan[i] * ret);
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -5613,8 +5613,8 @@ namespace Microsoft.Data.Analysis
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
                         ret = (ushort)(readOnlySpan[i] + ret);
+                        mutableSpan[i] = ret;
                     }
-                    mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
             }

--- a/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumnComputations.cs
+++ b/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumnComputations.cs
@@ -277,9 +277,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (byte)(Math.Max(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (byte)(Math.Max(readOnlySpan[i], ret));
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -336,9 +341,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (byte)(Math.Min(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (byte)(Math.Min(readOnlySpan[i], ret));
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -395,9 +405,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (byte)(readOnlySpan[i] * ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (byte)(readOnlySpan[i] * ret);
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -454,9 +469,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (byte)(readOnlySpan[i] + ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (byte)(readOnlySpan[i] + ret);
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -511,9 +531,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (byte)(Math.Max(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (byte)(Math.Max(readOnlySpan[i], ret));
+                    }
                 }
             }
         }
@@ -548,9 +573,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (byte)(Math.Min(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (byte)(Math.Min(readOnlySpan[i], ret));
+                    }
                 }
             }
         }
@@ -585,9 +615,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (byte)(readOnlySpan[i] * ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (byte)(readOnlySpan[i] * ret);
+                    }
                 }
             }
         }
@@ -622,9 +657,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (byte)(readOnlySpan[i] + ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (byte)(readOnlySpan[i] + ret);
+                    }
                 }
             }
         }
@@ -704,9 +744,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (char)(Math.Max(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (char)(Math.Max(readOnlySpan[i], ret));
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -763,9 +808,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (char)(Math.Min(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (char)(Math.Min(readOnlySpan[i], ret));
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -822,9 +872,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (char)(readOnlySpan[i] * ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (char)(readOnlySpan[i] * ret);
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -881,9 +936,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (char)(readOnlySpan[i] + ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (char)(readOnlySpan[i] + ret);
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -938,9 +998,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (char)(Math.Max(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (char)(Math.Max(readOnlySpan[i], ret));
+                    }
                 }
             }
         }
@@ -975,9 +1040,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (char)(Math.Min(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (char)(Math.Min(readOnlySpan[i], ret));
+                    }
                 }
             }
         }
@@ -1012,9 +1082,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (char)(readOnlySpan[i] * ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (char)(readOnlySpan[i] * ret);
+                    }
                 }
             }
         }
@@ -1049,9 +1124,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (char)(readOnlySpan[i] + ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (char)(readOnlySpan[i] + ret);
+                    }
                 }
             }
         }
@@ -1131,9 +1211,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (decimal)(Math.Max(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (decimal)(Math.Max(readOnlySpan[i], ret));
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -1190,9 +1275,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (decimal)(Math.Min(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (decimal)(Math.Min(readOnlySpan[i], ret));
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -1249,9 +1339,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (decimal)(readOnlySpan[i] * ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (decimal)(readOnlySpan[i] * ret);
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -1308,9 +1403,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (decimal)(readOnlySpan[i] + ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (decimal)(readOnlySpan[i] + ret);
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -1365,9 +1465,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (decimal)(Math.Max(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (decimal)(Math.Max(readOnlySpan[i], ret));
+                    }
                 }
             }
         }
@@ -1402,9 +1507,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (decimal)(Math.Min(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (decimal)(Math.Min(readOnlySpan[i], ret));
+                    }
                 }
             }
         }
@@ -1439,9 +1549,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (decimal)(readOnlySpan[i] * ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (decimal)(readOnlySpan[i] * ret);
+                    }
                 }
             }
         }
@@ -1476,9 +1591,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (decimal)(readOnlySpan[i] + ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (decimal)(readOnlySpan[i] + ret);
+                    }
                 }
             }
         }
@@ -1558,9 +1678,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (double)(Math.Max(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (double)(Math.Max(readOnlySpan[i], ret));
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -1617,9 +1742,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (double)(Math.Min(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (double)(Math.Min(readOnlySpan[i], ret));
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -1676,9 +1806,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (double)(readOnlySpan[i] * ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (double)(readOnlySpan[i] * ret);
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -1735,9 +1870,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (double)(readOnlySpan[i] + ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (double)(readOnlySpan[i] + ret);
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -1792,9 +1932,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (double)(Math.Max(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (double)(Math.Max(readOnlySpan[i], ret));
+                    }
                 }
             }
         }
@@ -1829,9 +1974,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (double)(Math.Min(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (double)(Math.Min(readOnlySpan[i], ret));
+                    }
                 }
             }
         }
@@ -1866,9 +2016,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (double)(readOnlySpan[i] * ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (double)(readOnlySpan[i] * ret);
+                    }
                 }
             }
         }
@@ -1903,9 +2058,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (double)(readOnlySpan[i] + ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (double)(readOnlySpan[i] + ret);
+                    }
                 }
             }
         }
@@ -1985,9 +2145,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (float)(Math.Max(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (float)(Math.Max(readOnlySpan[i], ret));
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -2044,9 +2209,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (float)(Math.Min(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (float)(Math.Min(readOnlySpan[i], ret));
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -2103,9 +2273,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (float)(readOnlySpan[i] * ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (float)(readOnlySpan[i] * ret);
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -2162,9 +2337,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (float)(readOnlySpan[i] + ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (float)(readOnlySpan[i] + ret);
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -2219,9 +2399,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (float)(Math.Max(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (float)(Math.Max(readOnlySpan[i], ret));
+                    }
                 }
             }
         }
@@ -2256,9 +2441,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (float)(Math.Min(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (float)(Math.Min(readOnlySpan[i], ret));
+                    }
                 }
             }
         }
@@ -2293,9 +2483,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (float)(readOnlySpan[i] * ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (float)(readOnlySpan[i] * ret);
+                    }
                 }
             }
         }
@@ -2330,9 +2525,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (float)(readOnlySpan[i] + ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (float)(readOnlySpan[i] + ret);
+                    }
                 }
             }
         }
@@ -2412,9 +2612,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (int)(Math.Max(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (int)(Math.Max(readOnlySpan[i], ret));
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -2471,9 +2676,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (int)(Math.Min(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (int)(Math.Min(readOnlySpan[i], ret));
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -2530,9 +2740,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (int)(readOnlySpan[i] * ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (int)(readOnlySpan[i] * ret);
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -2589,9 +2804,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (int)(readOnlySpan[i] + ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (int)(readOnlySpan[i] + ret);
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -2646,9 +2866,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (int)(Math.Max(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (int)(Math.Max(readOnlySpan[i], ret));
+                    }
                 }
             }
         }
@@ -2683,9 +2908,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (int)(Math.Min(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (int)(Math.Min(readOnlySpan[i], ret));
+                    }
                 }
             }
         }
@@ -2720,9 +2950,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (int)(readOnlySpan[i] * ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (int)(readOnlySpan[i] * ret);
+                    }
                 }
             }
         }
@@ -2757,9 +2992,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (int)(readOnlySpan[i] + ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (int)(readOnlySpan[i] + ret);
+                    }
                 }
             }
         }
@@ -2839,9 +3079,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (long)(Math.Max(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (long)(Math.Max(readOnlySpan[i], ret));
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -2898,9 +3143,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (long)(Math.Min(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (long)(Math.Min(readOnlySpan[i], ret));
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -2957,9 +3207,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (long)(readOnlySpan[i] * ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (long)(readOnlySpan[i] * ret);
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -3016,9 +3271,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (long)(readOnlySpan[i] + ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (long)(readOnlySpan[i] + ret);
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -3073,9 +3333,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (long)(Math.Max(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (long)(Math.Max(readOnlySpan[i], ret));
+                    }
                 }
             }
         }
@@ -3110,9 +3375,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (long)(Math.Min(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (long)(Math.Min(readOnlySpan[i], ret));
+                    }
                 }
             }
         }
@@ -3147,9 +3417,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (long)(readOnlySpan[i] * ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (long)(readOnlySpan[i] * ret);
+                    }
                 }
             }
         }
@@ -3184,9 +3459,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (long)(readOnlySpan[i] + ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (long)(readOnlySpan[i] + ret);
+                    }
                 }
             }
         }
@@ -3266,9 +3546,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (sbyte)(Math.Max(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (sbyte)(Math.Max(readOnlySpan[i], ret));
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -3325,9 +3610,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (sbyte)(Math.Min(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (sbyte)(Math.Min(readOnlySpan[i], ret));
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -3384,9 +3674,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (sbyte)(readOnlySpan[i] * ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (sbyte)(readOnlySpan[i] * ret);
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -3443,9 +3738,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (sbyte)(readOnlySpan[i] + ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (sbyte)(readOnlySpan[i] + ret);
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -3500,9 +3800,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (sbyte)(Math.Max(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (sbyte)(Math.Max(readOnlySpan[i], ret));
+                    }
                 }
             }
         }
@@ -3537,9 +3842,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (sbyte)(Math.Min(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (sbyte)(Math.Min(readOnlySpan[i], ret));
+                    }
                 }
             }
         }
@@ -3574,9 +3884,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (sbyte)(readOnlySpan[i] * ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (sbyte)(readOnlySpan[i] * ret);
+                    }
                 }
             }
         }
@@ -3611,9 +3926,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (sbyte)(readOnlySpan[i] + ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (sbyte)(readOnlySpan[i] + ret);
+                    }
                 }
             }
         }
@@ -3693,9 +4013,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (short)(Math.Max(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (short)(Math.Max(readOnlySpan[i], ret));
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -3752,9 +4077,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (short)(Math.Min(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (short)(Math.Min(readOnlySpan[i], ret));
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -3811,9 +4141,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (short)(readOnlySpan[i] * ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (short)(readOnlySpan[i] * ret);
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -3870,9 +4205,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (short)(readOnlySpan[i] + ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (short)(readOnlySpan[i] + ret);
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -3927,9 +4267,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (short)(Math.Max(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (short)(Math.Max(readOnlySpan[i], ret));
+                    }
                 }
             }
         }
@@ -3964,9 +4309,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (short)(Math.Min(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (short)(Math.Min(readOnlySpan[i], ret));
+                    }
                 }
             }
         }
@@ -4001,9 +4351,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (short)(readOnlySpan[i] * ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (short)(readOnlySpan[i] * ret);
+                    }
                 }
             }
         }
@@ -4038,9 +4393,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (short)(readOnlySpan[i] + ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (short)(readOnlySpan[i] + ret);
+                    }
                 }
             }
         }
@@ -4120,9 +4480,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (uint)(Math.Max(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (uint)(Math.Max(readOnlySpan[i], ret));
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -4179,9 +4544,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (uint)(Math.Min(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (uint)(Math.Min(readOnlySpan[i], ret));
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -4238,9 +4608,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (uint)(readOnlySpan[i] * ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (uint)(readOnlySpan[i] * ret);
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -4297,9 +4672,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (uint)(readOnlySpan[i] + ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (uint)(readOnlySpan[i] + ret);
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -4354,9 +4734,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (uint)(Math.Max(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (uint)(Math.Max(readOnlySpan[i], ret));
+                    }
                 }
             }
         }
@@ -4391,9 +4776,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (uint)(Math.Min(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (uint)(Math.Min(readOnlySpan[i], ret));
+                    }
                 }
             }
         }
@@ -4428,9 +4818,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (uint)(readOnlySpan[i] * ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (uint)(readOnlySpan[i] * ret);
+                    }
                 }
             }
         }
@@ -4465,9 +4860,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (uint)(readOnlySpan[i] + ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (uint)(readOnlySpan[i] + ret);
+                    }
                 }
             }
         }
@@ -4547,9 +4947,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (ulong)(Math.Max(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (ulong)(Math.Max(readOnlySpan[i], ret));
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -4606,9 +5011,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (ulong)(Math.Min(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (ulong)(Math.Min(readOnlySpan[i], ret));
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -4665,9 +5075,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (ulong)(readOnlySpan[i] * ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (ulong)(readOnlySpan[i] * ret);
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -4724,9 +5139,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (ulong)(readOnlySpan[i] + ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (ulong)(readOnlySpan[i] + ret);
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -4781,9 +5201,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (ulong)(Math.Max(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (ulong)(Math.Max(readOnlySpan[i], ret));
+                    }
                 }
             }
         }
@@ -4818,9 +5243,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (ulong)(Math.Min(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (ulong)(Math.Min(readOnlySpan[i], ret));
+                    }
                 }
             }
         }
@@ -4855,9 +5285,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (ulong)(readOnlySpan[i] * ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (ulong)(readOnlySpan[i] * ret);
+                    }
                 }
             }
         }
@@ -4892,9 +5327,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (ulong)(readOnlySpan[i] + ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (ulong)(readOnlySpan[i] + ret);
+                    }
                 }
             }
         }
@@ -4974,9 +5414,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (ushort)(Math.Max(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (ushort)(Math.Max(readOnlySpan[i], ret));
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -5033,9 +5478,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (ushort)(Math.Min(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (ushort)(Math.Min(readOnlySpan[i], ret));
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -5092,9 +5542,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (ushort)(readOnlySpan[i] * ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (ushort)(readOnlySpan[i] * ret);
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -5151,9 +5606,14 @@ namespace Microsoft.Data.Analysis
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (ushort)(readOnlySpan[i] + ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (ushort)(readOnlySpan[i] + ret);
+                    }
                     mutableSpan[i] = ret;
                 }
                 column.Buffers[b] = mutableBuffer;
@@ -5208,9 +5668,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (ushort)(Math.Max(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (ushort)(Math.Max(readOnlySpan[i], ret));
+                    }
                 }
             }
         }
@@ -5245,9 +5710,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (ushort)(Math.Min(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (ushort)(Math.Min(readOnlySpan[i], ret));
+                    }
                 }
             }
         }
@@ -5282,9 +5752,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (ushort)(readOnlySpan[i] * ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (ushort)(readOnlySpan[i] * ret);
+                    }
                 }
             }
         }
@@ -5319,9 +5794,14 @@ namespace Microsoft.Data.Analysis
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-                    ret = (ushort)(readOnlySpan[i] + ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (ushort)(readOnlySpan[i] + ret);
+                    }
                 }
             }
         }

--- a/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumnComputations.tt
+++ b/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumnComputations.tt
@@ -19,7 +19,7 @@ using System.Collections.Generic;
 namespace Microsoft.Data.Analysis
 {
     internal interface IPrimitiveColumnComputation<T>
-        where T : struct
+        where T : unmanaged
     {
 <# foreach (MethodConfiguration compMethod in computationMethodConfiguration) { #>
 <# if (compMethod.MethodType == MethodType.ElementwiseComputation && compMethod.HasReturnValue == false && compMethod.SupportsRowSubsets == true) {#>
@@ -39,7 +39,7 @@ namespace Microsoft.Data.Analysis
     }
 
     internal static class PrimitiveColumnComputation<T>
-        where T : struct
+        where T : unmanaged
     {
         public static IPrimitiveColumnComputation<T> Instance { get; } = PrimitiveColumnComputation.GetComputation<T>();
     }
@@ -47,7 +47,7 @@ namespace Microsoft.Data.Analysis
     internal static class PrimitiveColumnComputation
     {
         public static IPrimitiveColumnComputation<T> GetComputation<T>()
-            where T : struct
+            where T : unmanaged
         {
 <# foreach (TypeConfiguration type in typeConfiguration) { #>
             <#=GenerateIfStatementHeader(type)#>
@@ -202,35 +202,61 @@ namespace Microsoft.Data.Analysis
                 var mutableSpan = mutableBuffer.Span;
 <# } #>
                 var readOnlySpan = buffer.ReadOnlySpan;
+                var readOnlyBitMapSpan = column.NullBitMapBuffers[b].ReadOnlySpan;
+
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
 <# if (method.MethodName == "CumulativeMax") { #>
-                    ret = (<#=type.TypeName#>)(Math.Max(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (<#=type.TypeName#>)(Math.Max(readOnlySpan[i], ret));
+                    }
                     mutableSpan[i] = ret;
 <# } #>
 <# if (method.MethodName == "CumulativeMin") { #>
-                    ret = (<#=type.TypeName#>)(Math.Min(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (<#=type.TypeName#>)(Math.Min(readOnlySpan[i], ret));
+                    }
                     mutableSpan[i] = ret;
 <# } #>
 <# if (method.MethodName == "CumulativeProduct") { #>
-                    ret = (<#=type.TypeName#>)(readOnlySpan[i] * ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (<#=type.TypeName#>)(readOnlySpan[i] * ret);
+                    }
                     mutableSpan[i] = ret;
 <# } #>
 <# if (method.MethodName == "CumulativeSum") { #>
-                    ret = (<#=type.TypeName#>)(readOnlySpan[i] + ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (<#=type.TypeName#>)(readOnlySpan[i] + ret);
+                    }
                     mutableSpan[i] = ret;
 <# } #>
 <# if (method.MethodName == "Max") { #>
-                    ret = (<#=type.TypeName#>)(Math.Max(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (<#=type.TypeName#>)(Math.Max(readOnlySpan[i], ret));
+                    }
 <# } #>
 <# if (method.MethodName == "Min") { #>
-                    ret = (<#=type.TypeName#>)(Math.Min(readOnlySpan[i], ret));
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (<#=type.TypeName#>)(Math.Min(readOnlySpan[i], ret));
+                    }
 <# } #>
 <# if (method.MethodName == "Product") { #>
-                    ret = (<#=type.TypeName#>)(readOnlySpan[i] * ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (<#=type.TypeName#>)(readOnlySpan[i] * ret);
+                    }
 <# } #>
 <# if (method.MethodName == "Sum") { #>
-                    ret = (<#=type.TypeName#>)(readOnlySpan[i] + ret);
+                    if (column.IsValid(readOnlyBitMapSpan, i))
+                    {
+                        ret = (<#=type.TypeName#>)(readOnlySpan[i] + ret);
+                    }
 <# } #>
                 }
 <# if (method.MethodName == "CumulativeMax" || method.MethodName == "CumulativeMin" || method.MethodName == "CumulativeProduct" || method.MethodName == "CumulativeSum") { #>

--- a/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumnComputations.tt
+++ b/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumnComputations.tt
@@ -206,58 +206,37 @@ namespace Microsoft.Data.Analysis
 
                 for (int i = 0; i < readOnlySpan.Length; i++)
                 {
-<# if (method.MethodName == "CumulativeMax") { #>
                     if (column.IsValid(readOnlyBitMapSpan, i))
                     {
+<# if (method.MethodName == "CumulativeMax") { #>
                         ret = (<#=type.TypeName#>)(Math.Max(readOnlySpan[i], ret));
-                    }
-                    mutableSpan[i] = ret;
+                        mutableSpan[i] = ret;
 <# } #>
 <# if (method.MethodName == "CumulativeMin") { #>
-                    if (column.IsValid(readOnlyBitMapSpan, i))
-                    {
                         ret = (<#=type.TypeName#>)(Math.Min(readOnlySpan[i], ret));
-                    }
-                    mutableSpan[i] = ret;
+                        mutableSpan[i] = ret;
 <# } #>
 <# if (method.MethodName == "CumulativeProduct") { #>
-                    if (column.IsValid(readOnlyBitMapSpan, i))
-                    {
                         ret = (<#=type.TypeName#>)(readOnlySpan[i] * ret);
-                    }
-                    mutableSpan[i] = ret;
+                        mutableSpan[i] = ret;
 <# } #>
 <# if (method.MethodName == "CumulativeSum") { #>
-                    if (column.IsValid(readOnlyBitMapSpan, i))
-                    {
                         ret = (<#=type.TypeName#>)(readOnlySpan[i] + ret);
-                    }
-                    mutableSpan[i] = ret;
+                        mutableSpan[i] = ret;
 <# } #>
 <# if (method.MethodName == "Max") { #>
-                    if (column.IsValid(readOnlyBitMapSpan, i))
-                    {
                         ret = (<#=type.TypeName#>)(Math.Max(readOnlySpan[i], ret));
-                    }
 <# } #>
 <# if (method.MethodName == "Min") { #>
-                    if (column.IsValid(readOnlyBitMapSpan, i))
-                    {
                         ret = (<#=type.TypeName#>)(Math.Min(readOnlySpan[i], ret));
-                    }
 <# } #>
 <# if (method.MethodName == "Product") { #>
-                    if (column.IsValid(readOnlyBitMapSpan, i))
-                    {
                         ret = (<#=type.TypeName#>)(readOnlySpan[i] * ret);
-                    }
 <# } #>
 <# if (method.MethodName == "Sum") { #>
-                    if (column.IsValid(readOnlyBitMapSpan, i))
-                    {
                         ret = (<#=type.TypeName#>)(readOnlySpan[i] + ret);
-                    }
 <# } #>
+                    }
                 }
 <# if (method.MethodName == "CumulativeMax" || method.MethodName == "CumulativeMin" || method.MethodName == "CumulativeProduct" || method.MethodName == "CumulativeSum") { #>
                 column.Buffers[b] = mutableBuffer;

--- a/test/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
+++ b/test/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
@@ -844,7 +844,7 @@ namespace Microsoft.Data.Analysis.Tests
             Assert.Equal(100.0, df.Columns["Double"].Max());
             Assert.Equal(-10.0f, df.Columns["Float"].Min());
             Assert.Equal((uint)0, df.Columns["Uint"].Product());
-            Assert.Equal((ushort)140, df.Columns["Ushort"].Sum());
+            Assert.Equal((ushort)130, df.Columns["Ushort"].Sum());
 
             df.Columns["Double"][0] = 100.1;
             Assert.Equal(100.1, df.Columns["Double"][0]);

--- a/test/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
+++ b/test/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
@@ -1013,7 +1013,7 @@ namespace Microsoft.Data.Analysis.Tests
             Assert.Equal(100.0, df.Columns["Double"].Max());
             Assert.Equal(-10.0f, df.Columns["Float"].Min());
             Assert.Equal((uint)0, df.Columns["Uint"].Product());
-            Assert.Equal((ushort)140, df.Columns["Ushort"].Sum());
+            Assert.Equal((ushort)130, df.Columns["Ushort"].Sum());
 
             df.Columns["Double"][0] = 100.1;
             Assert.Equal(100.1, df.Columns["Double"][0]);

--- a/test/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
+++ b/test/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
@@ -3323,5 +3323,15 @@ namespace Microsoft.Data.Analysis.Tests
             Assert.Throws<ArgumentException>(() => dataFrame.Columns.GetSingleColumn("Ushort"));
 
         }
+
+        [Fact]
+        public void TestMeanMedian()
+        {
+            DataFrame df = MakeDataFrameWithNumericColumns(10, true, 0);
+
+            Assert.Equal(40.0 / 9.0, df["Decimal"].Mean());
+            Assert.Equal(4, df["Decimal"].Median());
+
+        }
     }
 }

--- a/test/Microsoft.Data.Analysis.Tests/Microsoft.Data.Analysis.Tests.csproj
+++ b/test/Microsoft.Data.Analysis.Tests/Microsoft.Data.Analysis.Tests.csproj
@@ -16,6 +16,10 @@
             <Generator>TextTemplatingFileGenerator</Generator>
             <LastGenOutput>DataFrameColumn.BinaryOperationTests.cs</LastGenOutput>
         </None>
+        <None Update="PrimitiveDataFrameColumnComputationsTests.tt">
+          <Generator>TextTemplatingFileGenerator</Generator>
+          <LastGenOutput>PrimitiveDataFrameColumnComputationsTests.cs</LastGenOutput>
+        </None>
     </ItemGroup>
 
     <ItemGroup>
@@ -28,11 +32,16 @@
             <AutoGen>True</AutoGen>
             <DependentUpon>DataFrameColumn.BinaryOperationTests.tt</DependentUpon>
         </Compile>
+        <Compile Update="PrimitiveDataFrameColumnComputationsTests.cs">
+          <DesignTime>True</DesignTime>
+          <AutoGen>True</AutoGen>
+          <DependentUpon>PrimitiveDataFrameColumnComputationsTests.tt</DependentUpon>
+        </Compile>
     </ItemGroup>
 
     <ItemGroup>
         <Compile Include="../../src/Microsoft.Data.Analysis/Strings.Designer.cs" />
-        <EmbeddedResource Include="../../src/Microsoft.Data.Analysis/Strings.resx" LogicalName="Microsoft.Data.Analysis.Strings.resources"/>
+        <EmbeddedResource Include="../../src/Microsoft.Data.Analysis/Strings.resx" LogicalName="Microsoft.Data.Analysis.Strings.resources" />
     </ItemGroup>
 
 </Project>

--- a/test/Microsoft.Data.Analysis.Tests/PrimitiveDataFrameColumnComputationsTests.cs
+++ b/test/Microsoft.Data.Analysis.Tests/PrimitiveDataFrameColumnComputationsTests.cs
@@ -1,0 +1,157 @@
+
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// Generated from PrimitiveDataFrameColumnComputationsTests.tt. Do not modify directly
+
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.Data.Analysis.Tests
+{
+    public partial class DataFrameColumnTests
+    {
+        IEnumerable<byte?> ByteValues = new byte?[] { 1, null, 2, 3, 4, null, 6, 7 };
+        IEnumerable<char?> CharValues = new char?[] { (char)1, null, (char)2, (char)3, (char)4, null, (char)6, (char)7 };
+        IEnumerable<decimal?> DecimalValues = new decimal?[] { 1, null, 2, 3, 4, null, 6, 7 };
+        IEnumerable<double?> DoubleValues = new double?[] { 1, null, 2, 3, 4, null, 6, 7 };
+        IEnumerable<float?> SingleValues = new float?[] { 1, null, 2, 3, 4, null, 6, 7 };
+        IEnumerable<int?> Int32Values = new int?[] { 1, null, 2, 3, 4, null, 6, 7 };
+        IEnumerable<long?> Int64Values = new long?[] { 1, null, 2, 3, 4, null, 6, 7 };
+        IEnumerable<sbyte?> SByteValues = new sbyte?[] { 1, null, 2, 3, 4, null, 6, 7 };
+        IEnumerable<short?> Int16Values = new short?[] { 1, null, 2, 3, 4, null, 6, 7 };
+        IEnumerable<uint?> UInt32Values = new uint?[] { 1, null, 2, 3, 4, null, 6, 7 };
+        IEnumerable<ulong?> UInt64Values = new ulong?[] { 1, null, 2, 3, 4, null, 6, 7 };
+        IEnumerable<ushort?> UInt16Values = new ushort?[] { 1, null, 2, 3, 4, null, 6, 7 };
+
+
+        [Fact]
+        public void ByteColumnComputationsTests()
+        {
+
+            var column = new ByteDataFrameColumn("byteValues", ByteValues);
+
+            Assert.Equal(Enumerable.Max(Int32Values), Convert.ToInt32(column.Max()));
+            Assert.Equal(Enumerable.Min(Int32Values), Convert.ToInt32(column.Min()));
+            Assert.Equal(Enumerable.Sum(Int32Values), Convert.ToInt32(column.Sum()));
+        }
+        [Fact]
+        public void CharColumnComputationsTests()
+        {
+
+            var column = new CharDataFrameColumn("charValues", CharValues);
+
+            Assert.Equal(Enumerable.Max(Int32Values), Convert.ToInt32(column.Max()));
+            Assert.Equal(Enumerable.Min(Int32Values), Convert.ToInt32(column.Min()));
+            Assert.Equal(Enumerable.Sum(Int32Values), Convert.ToInt32(column.Sum()));
+        }
+        [Fact]
+        public void DecimalColumnComputationsTests()
+        {
+
+            var column = new DecimalDataFrameColumn("decimalValues", DecimalValues);
+
+            Assert.Equal(Enumerable.Max(Int32Values), Convert.ToInt32(column.Max()));
+            Assert.Equal(Enumerable.Min(Int32Values), Convert.ToInt32(column.Min()));
+            Assert.Equal(Enumerable.Sum(Int32Values), Convert.ToInt32(column.Sum()));
+        }
+        [Fact]
+        public void DoubleColumnComputationsTests()
+        {
+
+            var column = new DoubleDataFrameColumn("doubleValues", DoubleValues);
+
+            Assert.Equal(Enumerable.Max(Int32Values), Convert.ToInt32(column.Max()));
+            Assert.Equal(Enumerable.Min(Int32Values), Convert.ToInt32(column.Min()));
+            Assert.Equal(Enumerable.Sum(Int32Values), Convert.ToInt32(column.Sum()));
+        }
+        [Fact]
+        public void SingleColumnComputationsTests()
+        {
+
+            var column = new SingleDataFrameColumn("floatValues", SingleValues);
+
+            Assert.Equal(Enumerable.Max(Int32Values), Convert.ToInt32(column.Max()));
+            Assert.Equal(Enumerable.Min(Int32Values), Convert.ToInt32(column.Min()));
+            Assert.Equal(Enumerable.Sum(Int32Values), Convert.ToInt32(column.Sum()));
+        }
+        [Fact]
+        public void Int32ColumnComputationsTests()
+        {
+
+            var column = new Int32DataFrameColumn("intValues", Int32Values);
+
+            Assert.Equal(Enumerable.Max(Int32Values), Convert.ToInt32(column.Max()));
+            Assert.Equal(Enumerable.Min(Int32Values), Convert.ToInt32(column.Min()));
+            Assert.Equal(Enumerable.Sum(Int32Values), Convert.ToInt32(column.Sum()));
+        }
+        [Fact]
+        public void Int64ColumnComputationsTests()
+        {
+
+            var column = new Int64DataFrameColumn("longValues", Int64Values);
+
+            Assert.Equal(Enumerable.Max(Int32Values), Convert.ToInt32(column.Max()));
+            Assert.Equal(Enumerable.Min(Int32Values), Convert.ToInt32(column.Min()));
+            Assert.Equal(Enumerable.Sum(Int32Values), Convert.ToInt32(column.Sum()));
+        }
+        [Fact]
+        public void SByteColumnComputationsTests()
+        {
+
+            var column = new SByteDataFrameColumn("sbyteValues", SByteValues);
+
+            Assert.Equal(Enumerable.Max(Int32Values), Convert.ToInt32(column.Max()));
+            Assert.Equal(Enumerable.Min(Int32Values), Convert.ToInt32(column.Min()));
+            Assert.Equal(Enumerable.Sum(Int32Values), Convert.ToInt32(column.Sum()));
+        }
+        [Fact]
+        public void Int16ColumnComputationsTests()
+        {
+
+            var column = new Int16DataFrameColumn("shortValues", Int16Values);
+
+            Assert.Equal(Enumerable.Max(Int32Values), Convert.ToInt32(column.Max()));
+            Assert.Equal(Enumerable.Min(Int32Values), Convert.ToInt32(column.Min()));
+            Assert.Equal(Enumerable.Sum(Int32Values), Convert.ToInt32(column.Sum()));
+        }
+        [Fact]
+        public void UInt32ColumnComputationsTests()
+        {
+
+            var column = new UInt32DataFrameColumn("uintValues", UInt32Values);
+
+            Assert.Equal(Enumerable.Max(Int32Values), Convert.ToInt32(column.Max()));
+            Assert.Equal(Enumerable.Min(Int32Values), Convert.ToInt32(column.Min()));
+            Assert.Equal(Enumerable.Sum(Int32Values), Convert.ToInt32(column.Sum()));
+        }
+        [Fact]
+        public void UInt64ColumnComputationsTests()
+        {
+
+            var column = new UInt64DataFrameColumn("ulongValues", UInt64Values);
+
+            Assert.Equal(Enumerable.Max(Int32Values), Convert.ToInt32(column.Max()));
+            Assert.Equal(Enumerable.Min(Int32Values), Convert.ToInt32(column.Min()));
+            Assert.Equal(Enumerable.Sum(Int32Values), Convert.ToInt32(column.Sum()));
+        }
+        [Fact]
+        public void UInt16ColumnComputationsTests()
+        {
+
+            var column = new UInt16DataFrameColumn("ushortValues", UInt16Values);
+
+            Assert.Equal(Enumerable.Max(Int32Values), Convert.ToInt32(column.Max()));
+            Assert.Equal(Enumerable.Min(Int32Values), Convert.ToInt32(column.Min()));
+            Assert.Equal(Enumerable.Sum(Int32Values), Convert.ToInt32(column.Sum()));
+        }
+    }
+}
+
+
+

--- a/test/Microsoft.Data.Analysis.Tests/PrimitiveDataFrameColumnComputationsTests.tt
+++ b/test/Microsoft.Data.Analysis.Tests/PrimitiveDataFrameColumnComputationsTests.tt
@@ -1,0 +1,73 @@
+<#@ template debug="false" hostspecific="false" language="C#" #>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System.Linq" #>
+<#@ import namespace="System.Text" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ output extension=".cs" #>
+<#@ include file="..\..\src\Microsoft.Data.Analysis\ColumnArithmeticTemplate.ttinclude"#>
+<#@ include file="..\..\src\Microsoft.Data.Analysis\PrimitiveDataFrameColumn.BinaryOperations.Combinations.ttinclude" #>
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// Generated from PrimitiveDataFrameColumnComputationsTests.tt. Do not modify directly
+
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.Data.Analysis.Tests
+{
+    public partial class DataFrameColumnTests
+    {
+        IEnumerable<byte?> ByteValues = new byte?[] { 1, null, 2, 3, 4, null, 6, 7 };
+        IEnumerable<char?> CharValues = new char?[] { (char)1, null, (char)2, (char)3, (char)4, null, (char)6, (char)7 };
+        IEnumerable<decimal?> DecimalValues = new decimal?[] { 1, null, 2, 3, 4, null, 6, 7 };
+        IEnumerable<double?> DoubleValues = new double?[] { 1, null, 2, 3, 4, null, 6, 7 };
+        IEnumerable<float?> SingleValues = new float?[] { 1, null, 2, 3, 4, null, 6, 7 };
+        IEnumerable<int?> Int32Values = new int?[] { 1, null, 2, 3, 4, null, 6, 7 };
+        IEnumerable<long?> Int64Values = new long?[] { 1, null, 2, 3, 4, null, 6, 7 };
+        IEnumerable<sbyte?> SByteValues = new sbyte?[] { 1, null, 2, 3, 4, null, 6, 7 };
+        IEnumerable<short?> Int16Values = new short?[] { 1, null, 2, 3, 4, null, 6, 7 };
+        IEnumerable<uint?> UInt32Values = new uint?[] { 1, null, 2, 3, 4, null, 6, 7 };
+        IEnumerable<ulong?> UInt64Values = new ulong?[] { 1, null, 2, 3, 4, null, 6, 7 };
+        IEnumerable<ushort?> UInt16Values = new ushort?[] { 1, null, 2, 3, 4, null, 6, 7 };
+
+
+<#
+    foreach (TypeConfiguration type in typeConfiguration)
+    {
+        if (type.TypeName == "bool" || type.TypeName == "DateTime") continue;
+#>
+        [Fact]
+        public void <#=GetCapitalizedPrimitiveTypes(type.TypeName)#>ColumnComputationsTests()
+        {
+
+            var column = new <#=GetCapitalizedPrimitiveTypes(type.TypeName)#>DataFrameColumn("<#=type.TypeName#>Values", <#=GetCapitalizedPrimitiveTypes(type.TypeName)#>Values);
+
+<#
+        foreach (MethodConfiguration method in computationMethodConfiguration)
+        {
+#>
+<#          if (method.MethodType == MethodType.Reduction && method.MethodName != "Product" &&  method.IsNumeric && type.SupportsNumeric && !type.UnsupportedMethods.Contains(method.MethodName) ) { 
+            
+                if(method.SupportsRowSubsets){
+#>
+<#
+                }
+                else
+                {
+#>
+            Assert.Equal(Enumerable.<#=method.MethodName#>(Int32Values), Convert.ToInt32(column.<#=method.MethodName#>()));
+<#              } #>
+<#          } #>
+<#      } #>
+        }
+<# } #>
+    }
+}
+
+
+


### PR DESCRIPTION
Update Math logic to filter out `null` instead of treating it as `default`.

Related Issue:

https://github.com/dotnet/machinelearning/issues/6659