### PR TITLE
Fix ML.Fairlean using ToList on Row Collection with Count more than Max.Int

### DIFF
--- a/src/Microsoft.ML.Fairlearn/Reductions/UtilityParity.cs
+++ b/src/Microsoft.ML.Fairlearn/Reductions/UtilityParity.cs
@@ -122,7 +122,7 @@ namespace Microsoft.ML.Fairlearn
             dfNeg["sign"].FillNulls("-", inPlace: true);
 
             // stack the temp dataframe dfNeg to the bottom dataframe that we want to return
-            dfNeg.Rows.ToList<DataFrameRow>().ForEach(row => { gSigned.Append(row, inPlace: true); });
+            gSigned.Append(dfNeg.Rows, inPlace: true);
 
             return gSigned;
         }


### PR DESCRIPTION
Using ToList() method on DataFrame.Rows fails in case of DataFrame.Rows.Count is greater than Max.Int (and as it has Count type long - it's possible). 
Instead DataFrame.Append(IEnumerable<DataFrameRow> rows, bool inPlace = false) method should be used.
