### PR TITLE
Fix non-thread-safe use of Random in tokenizers

### DIFF
--- a/src/Microsoft.ML.Tokenizers/Model/Word.cs
+++ b/src/Microsoft.ML.Tokenizers/Model/Word.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Linq;
 using System.Collections.Generic;
 using System.Text;
 
@@ -11,7 +10,8 @@ namespace Microsoft.ML.Tokenizers
 {
     internal struct Word
     {
-        private static readonly Random _random = new Random();
+        [ThreadStatic]
+        private static Random? _random;
         private Vec<Symbol> _symbols;
 
         public Word() => _symbols = new Vec<Symbol>();
@@ -115,7 +115,7 @@ namespace Microsoft.ML.Tokenizers
             while (queue.Count > 0)
             {
                 Merge top = queue.Dequeue();
-                if (dropout.HasValue && _random.NextDouble() < dropout)
+                if (dropout.HasValue && (_random ??= new()).NextDouble() < dropout)
                 {
                     skip.Push(top);
                 }


### PR DESCRIPTION
`System.Random` is not thread-safe, but Microsoft.ML.Tokenizers.Word has a static Random instance that's used without synchronization from an instance method that could end up being used concurrently from multiple threads.  This fixes it by making the `Random` be a thread-static instead of a static.  Once this component targets .NET 6+ instead of .NET Standard 2.0, this can switch to just use `Random.Shared`.