### PR TITLE
Remove redundant column names collection from DataFrameColumnCollection

### DIFF
--- a/src/Microsoft.Data.Analysis/DataFrameColumnCollection.cs
+++ b/src/Microsoft.Data.Analysis/DataFrameColumnCollection.cs
@@ -14,9 +14,6 @@ namespace Microsoft.Data.Analysis
     public class DataFrameColumnCollection : Collection<DataFrameColumn>
     {
         private readonly Action ColumnsChanged;
-
-        private readonly List<string> _columnNames = new List<string>();
-
         private readonly Dictionary<string, int> _columnNameToIndexDictionary = new Dictionary<string, int>(StringComparer.Ordinal);
 
         internal long RowCount { get; set; }
@@ -46,7 +43,6 @@ namespace Microsoft.Data.Analysis
             string currentName = column.Name;
             int currentIndex = _columnNameToIndexDictionary[currentName];
             column.SetName(newName);
-            _columnNames[currentIndex] = newName;
             _columnNameToIndexDictionary.Remove(currentName);
             _columnNameToIndexDictionary.Add(newName, currentIndex);
             ColumnsChanged?.Invoke();
@@ -77,11 +73,10 @@ namespace Microsoft.Data.Analysis
                 throw new ArgumentException(string.Format(Strings.DuplicateColumnName, column.Name), nameof(column));
             }
             RowCount = column.Length;
-            _columnNames.Insert(columnIndex, column.Name);
             _columnNameToIndexDictionary[column.Name] = columnIndex;
             for (int i = columnIndex + 1; i < Count; i++)
             {
-                _columnNameToIndexDictionary[_columnNames[i]]++;
+                _columnNameToIndexDictionary[this[i].Name]++;
             }
             base.InsertItem(columnIndex, column);
             ColumnsChanged?.Invoke();
@@ -99,8 +94,7 @@ namespace Microsoft.Data.Analysis
             {
                 throw new ArgumentException(string.Format(Strings.DuplicateColumnName, column.Name), nameof(column));
             }
-            _columnNameToIndexDictionary.Remove(_columnNames[columnIndex]);
-            _columnNames[columnIndex] = column.Name;
+            _columnNameToIndexDictionary.Remove(this[columnIndex].Name);
             _columnNameToIndexDictionary[column.Name] = columnIndex;
             base.SetItem(columnIndex, column);
             ColumnsChanged?.Invoke();
@@ -108,12 +102,11 @@ namespace Microsoft.Data.Analysis
 
         protected override void RemoveItem(int columnIndex)
         {
-            _columnNameToIndexDictionary.Remove(_columnNames[columnIndex]);
+            _columnNameToIndexDictionary.Remove(this[columnIndex].Name);
             for (int i = columnIndex + 1; i < Count; i++)
             {
-                _columnNameToIndexDictionary[_columnNames[i]]--;
+                _columnNameToIndexDictionary[this[i].Name]--;
             }
-            _columnNames.RemoveAt(columnIndex);
             base.RemoveItem(columnIndex);
             ColumnsChanged?.Invoke();
         }
@@ -144,7 +137,6 @@ namespace Microsoft.Data.Analysis
         {
             base.ClearItems();
             ColumnsChanged?.Invoke();
-            _columnNames.Clear();
             _columnNameToIndexDictionary.Clear();
         }
 


### PR DESCRIPTION
column names collection was used to get column name by column index. As DataFrameColumnCollection is already collection of columns that can be accessed by index - this[i].Name can be used instead to get name. Storing dedicated collection of names is excessive, 

