### PR TITLE
Clean dataframe math

### DIFF
--- a/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.BinaryOperations.cs
+++ b/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.BinaryOperations.cs
@@ -20,33 +20,33 @@ namespace Microsoft.Data.Analysis
             switch (column)
             {
                 case PrimitiveDataFrameColumn<bool> boolColumn:
-                    return AddImplementation(column as PrimitiveDataFrameColumn<bool>, inPlace);
+                    return AddImplementation(boolColumn, inPlace);
                 case PrimitiveDataFrameColumn<byte> byteColumn:
-                    return AddImplementation(column as PrimitiveDataFrameColumn<byte>, inPlace);
+                    return AddImplementation(byteColumn, inPlace);
                 case PrimitiveDataFrameColumn<char> charColumn:
-                    return AddImplementation(column as PrimitiveDataFrameColumn<char>, inPlace);
+                    return AddImplementation(charColumn, inPlace);
                 case PrimitiveDataFrameColumn<decimal> decimalColumn:
-                    return AddImplementation(column as PrimitiveDataFrameColumn<decimal>, inPlace);
+                    return AddImplementation(decimalColumn, inPlace);
                 case PrimitiveDataFrameColumn<double> doubleColumn:
-                    return AddImplementation(column as PrimitiveDataFrameColumn<double>, inPlace);
+                    return AddImplementation(doubleColumn, inPlace);
                 case PrimitiveDataFrameColumn<float> floatColumn:
-                    return AddImplementation(column as PrimitiveDataFrameColumn<float>, inPlace);
+                    return AddImplementation(floatColumn, inPlace);
                 case PrimitiveDataFrameColumn<int> intColumn:
-                    return AddImplementation(column as PrimitiveDataFrameColumn<int>, inPlace);
+                    return AddImplementation(intColumn, inPlace);
                 case PrimitiveDataFrameColumn<long> longColumn:
-                    return AddImplementation(column as PrimitiveDataFrameColumn<long>, inPlace);
+                    return AddImplementation(longColumn, inPlace);
                 case PrimitiveDataFrameColumn<sbyte> sbyteColumn:
-                    return AddImplementation(column as PrimitiveDataFrameColumn<sbyte>, inPlace);
+                    return AddImplementation(sbyteColumn, inPlace);
                 case PrimitiveDataFrameColumn<short> shortColumn:
-                    return AddImplementation(column as PrimitiveDataFrameColumn<short>, inPlace);
+                    return AddImplementation(shortColumn, inPlace);
                 case PrimitiveDataFrameColumn<uint> uintColumn:
-                    return AddImplementation(column as PrimitiveDataFrameColumn<uint>, inPlace);
+                    return AddImplementation(uintColumn, inPlace);
                 case PrimitiveDataFrameColumn<ulong> ulongColumn:
-                    return AddImplementation(column as PrimitiveDataFrameColumn<ulong>, inPlace);
+                    return AddImplementation(ulongColumn, inPlace);
                 case PrimitiveDataFrameColumn<ushort> ushortColumn:
-                    return AddImplementation(column as PrimitiveDataFrameColumn<ushort>, inPlace);
+                    return AddImplementation(ushortColumn, inPlace);
                 case PrimitiveDataFrameColumn<DateTime> DateTimeColumn:
-                    return AddImplementation(column as PrimitiveDataFrameColumn<DateTime>, inPlace);
+                    return AddImplementation(DateTimeColumn, inPlace);
                 default:
                     throw new NotSupportedException();
             }
@@ -67,33 +67,33 @@ namespace Microsoft.Data.Analysis
             switch (column)
             {
                 case PrimitiveDataFrameColumn<bool> boolColumn:
-                    return SubtractImplementation(column as PrimitiveDataFrameColumn<bool>, inPlace);
+                    return SubtractImplementation(boolColumn, inPlace);
                 case PrimitiveDataFrameColumn<byte> byteColumn:
-                    return SubtractImplementation(column as PrimitiveDataFrameColumn<byte>, inPlace);
+                    return SubtractImplementation(byteColumn, inPlace);
                 case PrimitiveDataFrameColumn<char> charColumn:
-                    return SubtractImplementation(column as PrimitiveDataFrameColumn<char>, inPlace);
+                    return SubtractImplementation(charColumn, inPlace);
                 case PrimitiveDataFrameColumn<decimal> decimalColumn:
-                    return SubtractImplementation(column as PrimitiveDataFrameColumn<decimal>, inPlace);
+                    return SubtractImplementation(decimalColumn, inPlace);
                 case PrimitiveDataFrameColumn<double> doubleColumn:
-                    return SubtractImplementation(column as PrimitiveDataFrameColumn<double>, inPlace);
+                    return SubtractImplementation(doubleColumn, inPlace);
                 case PrimitiveDataFrameColumn<float> floatColumn:
-                    return SubtractImplementation(column as PrimitiveDataFrameColumn<float>, inPlace);
+                    return SubtractImplementation(floatColumn, inPlace);
                 case PrimitiveDataFrameColumn<int> intColumn:
-                    return SubtractImplementation(column as PrimitiveDataFrameColumn<int>, inPlace);
+                    return SubtractImplementation(intColumn, inPlace);
                 case PrimitiveDataFrameColumn<long> longColumn:
-                    return SubtractImplementation(column as PrimitiveDataFrameColumn<long>, inPlace);
+                    return SubtractImplementation(longColumn, inPlace);
                 case PrimitiveDataFrameColumn<sbyte> sbyteColumn:
-                    return SubtractImplementation(column as PrimitiveDataFrameColumn<sbyte>, inPlace);
+                    return SubtractImplementation(sbyteColumn, inPlace);
                 case PrimitiveDataFrameColumn<short> shortColumn:
-                    return SubtractImplementation(column as PrimitiveDataFrameColumn<short>, inPlace);
+                    return SubtractImplementation(shortColumn, inPlace);
                 case PrimitiveDataFrameColumn<uint> uintColumn:
-                    return SubtractImplementation(column as PrimitiveDataFrameColumn<uint>, inPlace);
+                    return SubtractImplementation(uintColumn, inPlace);
                 case PrimitiveDataFrameColumn<ulong> ulongColumn:
-                    return SubtractImplementation(column as PrimitiveDataFrameColumn<ulong>, inPlace);
+                    return SubtractImplementation(ulongColumn, inPlace);
                 case PrimitiveDataFrameColumn<ushort> ushortColumn:
-                    return SubtractImplementation(column as PrimitiveDataFrameColumn<ushort>, inPlace);
+                    return SubtractImplementation(ushortColumn, inPlace);
                 case PrimitiveDataFrameColumn<DateTime> DateTimeColumn:
-                    return SubtractImplementation(column as PrimitiveDataFrameColumn<DateTime>, inPlace);
+                    return SubtractImplementation(DateTimeColumn, inPlace);
                 default:
                     throw new NotSupportedException();
             }
@@ -114,33 +114,33 @@ namespace Microsoft.Data.Analysis
             switch (column)
             {
                 case PrimitiveDataFrameColumn<bool> boolColumn:
-                    return MultiplyImplementation(column as PrimitiveDataFrameColumn<bool>, inPlace);
+                    return MultiplyImplementation(boolColumn, inPlace);
                 case PrimitiveDataFrameColumn<byte> byteColumn:
-                    return MultiplyImplementation(column as PrimitiveDataFrameColumn<byte>, inPlace);
+                    return MultiplyImplementation(byteColumn, inPlace);
                 case PrimitiveDataFrameColumn<char> charColumn:
-                    return MultiplyImplementation(column as PrimitiveDataFrameColumn<char>, inPlace);
+                    return MultiplyImplementation(charColumn, inPlace);
                 case PrimitiveDataFrameColumn<decimal> decimalColumn:
-                    return MultiplyImplementation(column as PrimitiveDataFrameColumn<decimal>, inPlace);
+                    return MultiplyImplementation(decimalColumn, inPlace);
                 case PrimitiveDataFrameColumn<double> doubleColumn:
-                    return MultiplyImplementation(column as PrimitiveDataFrameColumn<double>, inPlace);
+                    return MultiplyImplementation(doubleColumn, inPlace);
                 case PrimitiveDataFrameColumn<float> floatColumn:
-                    return MultiplyImplementation(column as PrimitiveDataFrameColumn<float>, inPlace);
+                    return MultiplyImplementation(floatColumn, inPlace);
                 case PrimitiveDataFrameColumn<int> intColumn:
-                    return MultiplyImplementation(column as PrimitiveDataFrameColumn<int>, inPlace);
+                    return MultiplyImplementation(intColumn, inPlace);
                 case PrimitiveDataFrameColumn<long> longColumn:
-                    return MultiplyImplementation(column as PrimitiveDataFrameColumn<long>, inPlace);
+                    return MultiplyImplementation(longColumn, inPlace);
                 case PrimitiveDataFrameColumn<sbyte> sbyteColumn:
-                    return MultiplyImplementation(column as PrimitiveDataFrameColumn<sbyte>, inPlace);
+                    return MultiplyImplementation(sbyteColumn, inPlace);
                 case PrimitiveDataFrameColumn<short> shortColumn:
-                    return MultiplyImplementation(column as PrimitiveDataFrameColumn<short>, inPlace);
+                    return MultiplyImplementation(shortColumn, inPlace);
                 case PrimitiveDataFrameColumn<uint> uintColumn:
-                    return MultiplyImplementation(column as PrimitiveDataFrameColumn<uint>, inPlace);
+                    return MultiplyImplementation(uintColumn, inPlace);
                 case PrimitiveDataFrameColumn<ulong> ulongColumn:
-                    return MultiplyImplementation(column as PrimitiveDataFrameColumn<ulong>, inPlace);
+                    return MultiplyImplementation(ulongColumn, inPlace);
                 case PrimitiveDataFrameColumn<ushort> ushortColumn:
-                    return MultiplyImplementation(column as PrimitiveDataFrameColumn<ushort>, inPlace);
+                    return MultiplyImplementation(ushortColumn, inPlace);
                 case PrimitiveDataFrameColumn<DateTime> DateTimeColumn:
-                    return MultiplyImplementation(column as PrimitiveDataFrameColumn<DateTime>, inPlace);
+                    return MultiplyImplementation(DateTimeColumn, inPlace);
                 default:
                     throw new NotSupportedException();
             }
@@ -161,33 +161,33 @@ namespace Microsoft.Data.Analysis
             switch (column)
             {
                 case PrimitiveDataFrameColumn<bool> boolColumn:
-                    return DivideImplementation(column as PrimitiveDataFrameColumn<bool>, inPlace);
+                    return DivideImplementation(boolColumn, inPlace);
                 case PrimitiveDataFrameColumn<byte> byteColumn:
-                    return DivideImplementation(column as PrimitiveDataFrameColumn<byte>, inPlace);
+                    return DivideImplementation(byteColumn, inPlace);
                 case PrimitiveDataFrameColumn<char> charColumn:
-                    return DivideImplementation(column as PrimitiveDataFrameColumn<char>, inPlace);
+                    return DivideImplementation(charColumn, inPlace);
                 case PrimitiveDataFrameColumn<decimal> decimalColumn:
-                    return DivideImplementation(column as PrimitiveDataFrameColumn<decimal>, inPlace);
+                    return DivideImplementation(decimalColumn, inPlace);
                 case PrimitiveDataFrameColumn<double> doubleColumn:
-                    return DivideImplementation(column as PrimitiveDataFrameColumn<double>, inPlace);
+                    return DivideImplementation(doubleColumn, inPlace);
                 case PrimitiveDataFrameColumn<float> floatColumn:
-                    return DivideImplementation(column as PrimitiveDataFrameColumn<float>, inPlace);
+                    return DivideImplementation(floatColumn, inPlace);
                 case PrimitiveDataFrameColumn<int> intColumn:
-                    return DivideImplementation(column as PrimitiveDataFrameColumn<int>, inPlace);
+                    return DivideImplementation(intColumn, inPlace);
                 case PrimitiveDataFrameColumn<long> longColumn:
-                    return DivideImplementation(column as PrimitiveDataFrameColumn<long>, inPlace);
+                    return DivideImplementation(longColumn, inPlace);
                 case PrimitiveDataFrameColumn<sbyte> sbyteColumn:
-                    return DivideImplementation(column as PrimitiveDataFrameColumn<sbyte>, inPlace);
+                    return DivideImplementation(sbyteColumn, inPlace);
                 case PrimitiveDataFrameColumn<short> shortColumn:
-                    return DivideImplementation(column as PrimitiveDataFrameColumn<short>, inPlace);
+                    return DivideImplementation(shortColumn, inPlace);
                 case PrimitiveDataFrameColumn<uint> uintColumn:
-                    return DivideImplementation(column as PrimitiveDataFrameColumn<uint>, inPlace);
+                    return DivideImplementation(uintColumn, inPlace);
                 case PrimitiveDataFrameColumn<ulong> ulongColumn:
-                    return DivideImplementation(column as PrimitiveDataFrameColumn<ulong>, inPlace);
+                    return DivideImplementation(ulongColumn, inPlace);
                 case PrimitiveDataFrameColumn<ushort> ushortColumn:
-                    return DivideImplementation(column as PrimitiveDataFrameColumn<ushort>, inPlace);
+                    return DivideImplementation(ushortColumn, inPlace);
                 case PrimitiveDataFrameColumn<DateTime> DateTimeColumn:
-                    return DivideImplementation(column as PrimitiveDataFrameColumn<DateTime>, inPlace);
+                    return DivideImplementation(DateTimeColumn, inPlace);
                 default:
                     throw new NotSupportedException();
             }
@@ -208,33 +208,33 @@ namespace Microsoft.Data.Analysis
             switch (column)
             {
                 case PrimitiveDataFrameColumn<bool> boolColumn:
-                    return ModuloImplementation(column as PrimitiveDataFrameColumn<bool>, inPlace);
+                    return ModuloImplementation(boolColumn, inPlace);
                 case PrimitiveDataFrameColumn<byte> byteColumn:
-                    return ModuloImplementation(column as PrimitiveDataFrameColumn<byte>, inPlace);
+                    return ModuloImplementation(byteColumn, inPlace);
                 case PrimitiveDataFrameColumn<char> charColumn:
-                    return ModuloImplementation(column as PrimitiveDataFrameColumn<char>, inPlace);
+                    return ModuloImplementation(charColumn, inPlace);
                 case PrimitiveDataFrameColumn<decimal> decimalColumn:
-                    return ModuloImplementation(column as PrimitiveDataFrameColumn<decimal>, inPlace);
+                    return ModuloImplementation(decimalColumn, inPlace);
                 case PrimitiveDataFrameColumn<double> doubleColumn:
-                    return ModuloImplementation(column as PrimitiveDataFrameColumn<double>, inPlace);
+                    return ModuloImplementation(doubleColumn, inPlace);
                 case PrimitiveDataFrameColumn<float> floatColumn:
-                    return ModuloImplementation(column as PrimitiveDataFrameColumn<float>, inPlace);
+                    return ModuloImplementation(floatColumn, inPlace);
                 case PrimitiveDataFrameColumn<int> intColumn:
-                    return ModuloImplementation(column as PrimitiveDataFrameColumn<int>, inPlace);
+                    return ModuloImplementation(intColumn, inPlace);
                 case PrimitiveDataFrameColumn<long> longColumn:
-                    return ModuloImplementation(column as PrimitiveDataFrameColumn<long>, inPlace);
+                    return ModuloImplementation(longColumn, inPlace);
                 case PrimitiveDataFrameColumn<sbyte> sbyteColumn:
-                    return ModuloImplementation(column as PrimitiveDataFrameColumn<sbyte>, inPlace);
+                    return ModuloImplementation(sbyteColumn, inPlace);
                 case PrimitiveDataFrameColumn<short> shortColumn:
-                    return ModuloImplementation(column as PrimitiveDataFrameColumn<short>, inPlace);
+                    return ModuloImplementation(shortColumn, inPlace);
                 case PrimitiveDataFrameColumn<uint> uintColumn:
-                    return ModuloImplementation(column as PrimitiveDataFrameColumn<uint>, inPlace);
+                    return ModuloImplementation(uintColumn, inPlace);
                 case PrimitiveDataFrameColumn<ulong> ulongColumn:
-                    return ModuloImplementation(column as PrimitiveDataFrameColumn<ulong>, inPlace);
+                    return ModuloImplementation(ulongColumn, inPlace);
                 case PrimitiveDataFrameColumn<ushort> ushortColumn:
-                    return ModuloImplementation(column as PrimitiveDataFrameColumn<ushort>, inPlace);
+                    return ModuloImplementation(ushortColumn, inPlace);
                 case PrimitiveDataFrameColumn<DateTime> DateTimeColumn:
-                    return ModuloImplementation(column as PrimitiveDataFrameColumn<DateTime>, inPlace);
+                    return ModuloImplementation(DateTimeColumn, inPlace);
                 default:
                     throw new NotSupportedException();
             }
@@ -255,33 +255,33 @@ namespace Microsoft.Data.Analysis
             switch (column)
             {
                 case PrimitiveDataFrameColumn<bool> boolColumn:
-                    return AndImplementation(column as PrimitiveDataFrameColumn<bool>, inPlace);
+                    return AndImplementation(boolColumn, inPlace);
                 case PrimitiveDataFrameColumn<byte> byteColumn:
-                    return AndImplementation(column as PrimitiveDataFrameColumn<byte>, inPlace);
+                    return AndImplementation(byteColumn, inPlace);
                 case PrimitiveDataFrameColumn<char> charColumn:
-                    return AndImplementation(column as PrimitiveDataFrameColumn<char>, inPlace);
+                    return AndImplementation(charColumn, inPlace);
                 case PrimitiveDataFrameColumn<decimal> decimalColumn:
-                    return AndImplementation(column as PrimitiveDataFrameColumn<decimal>, inPlace);
+                    return AndImplementation(decimalColumn, inPlace);
                 case PrimitiveDataFrameColumn<double> doubleColumn:
-                    return AndImplementation(column as PrimitiveDataFrameColumn<double>, inPlace);
+                    return AndImplementation(doubleColumn, inPlace);
                 case PrimitiveDataFrameColumn<float> floatColumn:
-                    return AndImplementation(column as PrimitiveDataFrameColumn<float>, inPlace);
+                    return AndImplementation(floatColumn, inPlace);
                 case PrimitiveDataFrameColumn<int> intColumn:
-                    return AndImplementation(column as PrimitiveDataFrameColumn<int>, inPlace);
+                    return AndImplementation(intColumn, inPlace);
                 case PrimitiveDataFrameColumn<long> longColumn:
-                    return AndImplementation(column as PrimitiveDataFrameColumn<long>, inPlace);
+                    return AndImplementation(longColumn, inPlace);
                 case PrimitiveDataFrameColumn<sbyte> sbyteColumn:
-                    return AndImplementation(column as PrimitiveDataFrameColumn<sbyte>, inPlace);
+                    return AndImplementation(sbyteColumn, inPlace);
                 case PrimitiveDataFrameColumn<short> shortColumn:
-                    return AndImplementation(column as PrimitiveDataFrameColumn<short>, inPlace);
+                    return AndImplementation(shortColumn, inPlace);
                 case PrimitiveDataFrameColumn<uint> uintColumn:
-                    return AndImplementation(column as PrimitiveDataFrameColumn<uint>, inPlace);
+                    return AndImplementation(uintColumn, inPlace);
                 case PrimitiveDataFrameColumn<ulong> ulongColumn:
-                    return AndImplementation(column as PrimitiveDataFrameColumn<ulong>, inPlace);
+                    return AndImplementation(ulongColumn, inPlace);
                 case PrimitiveDataFrameColumn<ushort> ushortColumn:
-                    return AndImplementation(column as PrimitiveDataFrameColumn<ushort>, inPlace);
+                    return AndImplementation(ushortColumn, inPlace);
                 case PrimitiveDataFrameColumn<DateTime> DateTimeColumn:
-                    return AndImplementation(column as PrimitiveDataFrameColumn<DateTime>, inPlace);
+                    return AndImplementation(DateTimeColumn, inPlace);
                 default:
                     throw new NotSupportedException();
             }
@@ -297,33 +297,33 @@ namespace Microsoft.Data.Analysis
             switch (column)
             {
                 case PrimitiveDataFrameColumn<bool> boolColumn:
-                    return OrImplementation(column as PrimitiveDataFrameColumn<bool>, inPlace);
+                    return OrImplementation(boolColumn, inPlace);
                 case PrimitiveDataFrameColumn<byte> byteColumn:
-                    return OrImplementation(column as PrimitiveDataFrameColumn<byte>, inPlace);
+                    return OrImplementation(byteColumn, inPlace);
                 case PrimitiveDataFrameColumn<char> charColumn:
-                    return OrImplementation(column as PrimitiveDataFrameColumn<char>, inPlace);
+                    return OrImplementation(charColumn, inPlace);
                 case PrimitiveDataFrameColumn<decimal> decimalColumn:
-                    return OrImplementation(column as PrimitiveDataFrameColumn<decimal>, inPlace);
+                    return OrImplementation(decimalColumn, inPlace);
                 case PrimitiveDataFrameColumn<double> doubleColumn:
-                    return OrImplementation(column as PrimitiveDataFrameColumn<double>, inPlace);
+                    return OrImplementation(doubleColumn, inPlace);
                 case PrimitiveDataFrameColumn<float> floatColumn:
-                    return OrImplementation(column as PrimitiveDataFrameColumn<float>, inPlace);
+                    return OrImplementation(floatColumn, inPlace);
                 case PrimitiveDataFrameColumn<int> intColumn:
-                    return OrImplementation(column as PrimitiveDataFrameColumn<int>, inPlace);
+                    return OrImplementation(intColumn, inPlace);
                 case PrimitiveDataFrameColumn<long> longColumn:
-                    return OrImplementation(column as PrimitiveDataFrameColumn<long>, inPlace);
+                    return OrImplementation(longColumn, inPlace);
                 case PrimitiveDataFrameColumn<sbyte> sbyteColumn:
-                    return OrImplementation(column as PrimitiveDataFrameColumn<sbyte>, inPlace);
+                    return OrImplementation(sbyteColumn, inPlace);
                 case PrimitiveDataFrameColumn<short> shortColumn:
-                    return OrImplementation(column as PrimitiveDataFrameColumn<short>, inPlace);
+                    return OrImplementation(shortColumn, inPlace);
                 case PrimitiveDataFrameColumn<uint> uintColumn:
-                    return OrImplementation(column as PrimitiveDataFrameColumn<uint>, inPlace);
+                    return OrImplementation(uintColumn, inPlace);
                 case PrimitiveDataFrameColumn<ulong> ulongColumn:
-                    return OrImplementation(column as PrimitiveDataFrameColumn<ulong>, inPlace);
+                    return OrImplementation(ulongColumn, inPlace);
                 case PrimitiveDataFrameColumn<ushort> ushortColumn:
-                    return OrImplementation(column as PrimitiveDataFrameColumn<ushort>, inPlace);
+                    return OrImplementation(ushortColumn, inPlace);
                 case PrimitiveDataFrameColumn<DateTime> DateTimeColumn:
-                    return OrImplementation(column as PrimitiveDataFrameColumn<DateTime>, inPlace);
+                    return OrImplementation(DateTimeColumn, inPlace);
                 default:
                     throw new NotSupportedException();
             }
@@ -339,33 +339,33 @@ namespace Microsoft.Data.Analysis
             switch (column)
             {
                 case PrimitiveDataFrameColumn<bool> boolColumn:
-                    return XorImplementation(column as PrimitiveDataFrameColumn<bool>, inPlace);
+                    return XorImplementation(boolColumn, inPlace);
                 case PrimitiveDataFrameColumn<byte> byteColumn:
-                    return XorImplementation(column as PrimitiveDataFrameColumn<byte>, inPlace);
+                    return XorImplementation(byteColumn, inPlace);
                 case PrimitiveDataFrameColumn<char> charColumn:
-                    return XorImplementation(column as PrimitiveDataFrameColumn<char>, inPlace);
+                    return XorImplementation(charColumn, inPlace);
                 case PrimitiveDataFrameColumn<decimal> decimalColumn:
-                    return XorImplementation(column as PrimitiveDataFrameColumn<decimal>, inPlace);
+                    return XorImplementation(decimalColumn, inPlace);
                 case PrimitiveDataFrameColumn<double> doubleColumn:
-                    return XorImplementation(column as PrimitiveDataFrameColumn<double>, inPlace);
+                    return XorImplementation(doubleColumn, inPlace);
                 case PrimitiveDataFrameColumn<float> floatColumn:
-                    return XorImplementation(column as PrimitiveDataFrameColumn<float>, inPlace);
+                    return XorImplementation(floatColumn, inPlace);
                 case PrimitiveDataFrameColumn<int> intColumn:
-                    return XorImplementation(column as PrimitiveDataFrameColumn<int>, inPlace);
+                    return XorImplementation(intColumn, inPlace);
                 case PrimitiveDataFrameColumn<long> longColumn:
-                    return XorImplementation(column as PrimitiveDataFrameColumn<long>, inPlace);
+                    return XorImplementation(longColumn, inPlace);
                 case PrimitiveDataFrameColumn<sbyte> sbyteColumn:
-                    return XorImplementation(column as PrimitiveDataFrameColumn<sbyte>, inPlace);
+                    return XorImplementation(sbyteColumn, inPlace);
                 case PrimitiveDataFrameColumn<short> shortColumn:
-                    return XorImplementation(column as PrimitiveDataFrameColumn<short>, inPlace);
+                    return XorImplementation(shortColumn, inPlace);
                 case PrimitiveDataFrameColumn<uint> uintColumn:
-                    return XorImplementation(column as PrimitiveDataFrameColumn<uint>, inPlace);
+                    return XorImplementation(uintColumn, inPlace);
                 case PrimitiveDataFrameColumn<ulong> ulongColumn:
-                    return XorImplementation(column as PrimitiveDataFrameColumn<ulong>, inPlace);
+                    return XorImplementation(ulongColumn, inPlace);
                 case PrimitiveDataFrameColumn<ushort> ushortColumn:
-                    return XorImplementation(column as PrimitiveDataFrameColumn<ushort>, inPlace);
+                    return XorImplementation(ushortColumn, inPlace);
                 case PrimitiveDataFrameColumn<DateTime> DateTimeColumn:
-                    return XorImplementation(column as PrimitiveDataFrameColumn<DateTime>, inPlace);
+                    return XorImplementation(DateTimeColumn, inPlace);
                 default:
                     throw new NotSupportedException();
             }
@@ -391,33 +391,33 @@ namespace Microsoft.Data.Analysis
             switch (column)
             {
                 case PrimitiveDataFrameColumn<bool> boolColumn:
-                    return ElementwiseEqualsImplementation(column as PrimitiveDataFrameColumn<bool>);
+                    return ElementwiseEqualsImplementation(boolColumn);
                 case PrimitiveDataFrameColumn<byte> byteColumn:
-                    return ElementwiseEqualsImplementation(column as PrimitiveDataFrameColumn<byte>);
+                    return ElementwiseEqualsImplementation(byteColumn);
                 case PrimitiveDataFrameColumn<char> charColumn:
-                    return ElementwiseEqualsImplementation(column as PrimitiveDataFrameColumn<char>);
+                    return ElementwiseEqualsImplementation(charColumn);
                 case PrimitiveDataFrameColumn<decimal> decimalColumn:
-                    return ElementwiseEqualsImplementation(column as PrimitiveDataFrameColumn<decimal>);
+                    return ElementwiseEqualsImplementation(decimalColumn);
                 case PrimitiveDataFrameColumn<double> doubleColumn:
-                    return ElementwiseEqualsImplementation(column as PrimitiveDataFrameColumn<double>);
+                    return ElementwiseEqualsImplementation(doubleColumn);
                 case PrimitiveDataFrameColumn<float> floatColumn:
-                    return ElementwiseEqualsImplementation(column as PrimitiveDataFrameColumn<float>);
+                    return ElementwiseEqualsImplementation(floatColumn);
                 case PrimitiveDataFrameColumn<int> intColumn:
-                    return ElementwiseEqualsImplementation(column as PrimitiveDataFrameColumn<int>);
+                    return ElementwiseEqualsImplementation(intColumn);
                 case PrimitiveDataFrameColumn<long> longColumn:
-                    return ElementwiseEqualsImplementation(column as PrimitiveDataFrameColumn<long>);
+                    return ElementwiseEqualsImplementation(longColumn);
                 case PrimitiveDataFrameColumn<sbyte> sbyteColumn:
-                    return ElementwiseEqualsImplementation(column as PrimitiveDataFrameColumn<sbyte>);
+                    return ElementwiseEqualsImplementation(sbyteColumn);
                 case PrimitiveDataFrameColumn<short> shortColumn:
-                    return ElementwiseEqualsImplementation(column as PrimitiveDataFrameColumn<short>);
+                    return ElementwiseEqualsImplementation(shortColumn);
                 case PrimitiveDataFrameColumn<uint> uintColumn:
-                    return ElementwiseEqualsImplementation(column as PrimitiveDataFrameColumn<uint>);
+                    return ElementwiseEqualsImplementation(uintColumn);
                 case PrimitiveDataFrameColumn<ulong> ulongColumn:
-                    return ElementwiseEqualsImplementation(column as PrimitiveDataFrameColumn<ulong>);
+                    return ElementwiseEqualsImplementation(ulongColumn);
                 case PrimitiveDataFrameColumn<ushort> ushortColumn:
-                    return ElementwiseEqualsImplementation(column as PrimitiveDataFrameColumn<ushort>);
+                    return ElementwiseEqualsImplementation(ushortColumn);
                 case PrimitiveDataFrameColumn<DateTime> DateTimeColumn:
-                    return ElementwiseEqualsImplementation(column as PrimitiveDataFrameColumn<DateTime>);
+                    return ElementwiseEqualsImplementation(DateTimeColumn);
                 default:
                     throw new NotSupportedException();
             }
@@ -438,33 +438,33 @@ namespace Microsoft.Data.Analysis
             switch (column)
             {
                 case PrimitiveDataFrameColumn<bool> boolColumn:
-                    return ElementwiseNotEqualsImplementation(column as PrimitiveDataFrameColumn<bool>);
+                    return ElementwiseNotEqualsImplementation(boolColumn);
                 case PrimitiveDataFrameColumn<byte> byteColumn:
-                    return ElementwiseNotEqualsImplementation(column as PrimitiveDataFrameColumn<byte>);
+                    return ElementwiseNotEqualsImplementation(byteColumn);
                 case PrimitiveDataFrameColumn<char> charColumn:
-                    return ElementwiseNotEqualsImplementation(column as PrimitiveDataFrameColumn<char>);
+                    return ElementwiseNotEqualsImplementation(charColumn);
                 case PrimitiveDataFrameColumn<decimal> decimalColumn:
-                    return ElementwiseNotEqualsImplementation(column as PrimitiveDataFrameColumn<decimal>);
+                    return ElementwiseNotEqualsImplementation(decimalColumn);
                 case PrimitiveDataFrameColumn<double> doubleColumn:
-                    return ElementwiseNotEqualsImplementation(column as PrimitiveDataFrameColumn<double>);
+                    return ElementwiseNotEqualsImplementation(doubleColumn);
                 case PrimitiveDataFrameColumn<float> floatColumn:
-                    return ElementwiseNotEqualsImplementation(column as PrimitiveDataFrameColumn<float>);
+                    return ElementwiseNotEqualsImplementation(floatColumn);
                 case PrimitiveDataFrameColumn<int> intColumn:
-                    return ElementwiseNotEqualsImplementation(column as PrimitiveDataFrameColumn<int>);
+                    return ElementwiseNotEqualsImplementation(intColumn);
                 case PrimitiveDataFrameColumn<long> longColumn:
-                    return ElementwiseNotEqualsImplementation(column as PrimitiveDataFrameColumn<long>);
+                    return ElementwiseNotEqualsImplementation(longColumn);
                 case PrimitiveDataFrameColumn<sbyte> sbyteColumn:
-                    return ElementwiseNotEqualsImplementation(column as PrimitiveDataFrameColumn<sbyte>);
+                    return ElementwiseNotEqualsImplementation(sbyteColumn);
                 case PrimitiveDataFrameColumn<short> shortColumn:
-                    return ElementwiseNotEqualsImplementation(column as PrimitiveDataFrameColumn<short>);
+                    return ElementwiseNotEqualsImplementation(shortColumn);
                 case PrimitiveDataFrameColumn<uint> uintColumn:
-                    return ElementwiseNotEqualsImplementation(column as PrimitiveDataFrameColumn<uint>);
+                    return ElementwiseNotEqualsImplementation(uintColumn);
                 case PrimitiveDataFrameColumn<ulong> ulongColumn:
-                    return ElementwiseNotEqualsImplementation(column as PrimitiveDataFrameColumn<ulong>);
+                    return ElementwiseNotEqualsImplementation(ulongColumn);
                 case PrimitiveDataFrameColumn<ushort> ushortColumn:
-                    return ElementwiseNotEqualsImplementation(column as PrimitiveDataFrameColumn<ushort>);
+                    return ElementwiseNotEqualsImplementation(ushortColumn);
                 case PrimitiveDataFrameColumn<DateTime> DateTimeColumn:
-                    return ElementwiseNotEqualsImplementation(column as PrimitiveDataFrameColumn<DateTime>);
+                    return ElementwiseNotEqualsImplementation(DateTimeColumn);
                 default:
                     throw new NotSupportedException();
             }
@@ -485,33 +485,33 @@ namespace Microsoft.Data.Analysis
             switch (column)
             {
                 case PrimitiveDataFrameColumn<bool> boolColumn:
-                    return ElementwiseGreaterThanOrEqualImplementation(column as PrimitiveDataFrameColumn<bool>);
+                    return ElementwiseGreaterThanOrEqualImplementation(boolColumn);
                 case PrimitiveDataFrameColumn<byte> byteColumn:
-                    return ElementwiseGreaterThanOrEqualImplementation(column as PrimitiveDataFrameColumn<byte>);
+                    return ElementwiseGreaterThanOrEqualImplementation(byteColumn);
                 case PrimitiveDataFrameColumn<char> charColumn:
-                    return ElementwiseGreaterThanOrEqualImplementation(column as PrimitiveDataFrameColumn<char>);
+                    return ElementwiseGreaterThanOrEqualImplementation(charColumn);
                 case PrimitiveDataFrameColumn<decimal> decimalColumn:
-                    return ElementwiseGreaterThanOrEqualImplementation(column as PrimitiveDataFrameColumn<decimal>);
+                    return ElementwiseGreaterThanOrEqualImplementation(decimalColumn);
                 case PrimitiveDataFrameColumn<double> doubleColumn:
-                    return ElementwiseGreaterThanOrEqualImplementation(column as PrimitiveDataFrameColumn<double>);
+                    return ElementwiseGreaterThanOrEqualImplementation(doubleColumn);
                 case PrimitiveDataFrameColumn<float> floatColumn:
-                    return ElementwiseGreaterThanOrEqualImplementation(column as PrimitiveDataFrameColumn<float>);
+                    return ElementwiseGreaterThanOrEqualImplementation(floatColumn);
                 case PrimitiveDataFrameColumn<int> intColumn:
-                    return ElementwiseGreaterThanOrEqualImplementation(column as PrimitiveDataFrameColumn<int>);
+                    return ElementwiseGreaterThanOrEqualImplementation(intColumn);
                 case PrimitiveDataFrameColumn<long> longColumn:
-                    return ElementwiseGreaterThanOrEqualImplementation(column as PrimitiveDataFrameColumn<long>);
+                    return ElementwiseGreaterThanOrEqualImplementation(longColumn);
                 case PrimitiveDataFrameColumn<sbyte> sbyteColumn:
-                    return ElementwiseGreaterThanOrEqualImplementation(column as PrimitiveDataFrameColumn<sbyte>);
+                    return ElementwiseGreaterThanOrEqualImplementation(sbyteColumn);
                 case PrimitiveDataFrameColumn<short> shortColumn:
-                    return ElementwiseGreaterThanOrEqualImplementation(column as PrimitiveDataFrameColumn<short>);
+                    return ElementwiseGreaterThanOrEqualImplementation(shortColumn);
                 case PrimitiveDataFrameColumn<uint> uintColumn:
-                    return ElementwiseGreaterThanOrEqualImplementation(column as PrimitiveDataFrameColumn<uint>);
+                    return ElementwiseGreaterThanOrEqualImplementation(uintColumn);
                 case PrimitiveDataFrameColumn<ulong> ulongColumn:
-                    return ElementwiseGreaterThanOrEqualImplementation(column as PrimitiveDataFrameColumn<ulong>);
+                    return ElementwiseGreaterThanOrEqualImplementation(ulongColumn);
                 case PrimitiveDataFrameColumn<ushort> ushortColumn:
-                    return ElementwiseGreaterThanOrEqualImplementation(column as PrimitiveDataFrameColumn<ushort>);
+                    return ElementwiseGreaterThanOrEqualImplementation(ushortColumn);
                 case PrimitiveDataFrameColumn<DateTime> DateTimeColumn:
-                    return ElementwiseGreaterThanOrEqualImplementation(column as PrimitiveDataFrameColumn<DateTime>);
+                    return ElementwiseGreaterThanOrEqualImplementation(DateTimeColumn);
                 default:
                     throw new NotSupportedException();
             }
@@ -532,33 +532,33 @@ namespace Microsoft.Data.Analysis
             switch (column)
             {
                 case PrimitiveDataFrameColumn<bool> boolColumn:
-                    return ElementwiseLessThanOrEqualImplementation(column as PrimitiveDataFrameColumn<bool>);
+                    return ElementwiseLessThanOrEqualImplementation(boolColumn);
                 case PrimitiveDataFrameColumn<byte> byteColumn:
-                    return ElementwiseLessThanOrEqualImplementation(column as PrimitiveDataFrameColumn<byte>);
+                    return ElementwiseLessThanOrEqualImplementation(byteColumn);
                 case PrimitiveDataFrameColumn<char> charColumn:
-                    return ElementwiseLessThanOrEqualImplementation(column as PrimitiveDataFrameColumn<char>);
+                    return ElementwiseLessThanOrEqualImplementation(charColumn);
                 case PrimitiveDataFrameColumn<decimal> decimalColumn:
-                    return ElementwiseLessThanOrEqualImplementation(column as PrimitiveDataFrameColumn<decimal>);
+                    return ElementwiseLessThanOrEqualImplementation(decimalColumn);
                 case PrimitiveDataFrameColumn<double> doubleColumn:
-                    return ElementwiseLessThanOrEqualImplementation(column as PrimitiveDataFrameColumn<double>);
+                    return ElementwiseLessThanOrEqualImplementation(doubleColumn);
                 case PrimitiveDataFrameColumn<float> floatColumn:
-                    return ElementwiseLessThanOrEqualImplementation(column as PrimitiveDataFrameColumn<float>);
+                    return ElementwiseLessThanOrEqualImplementation(floatColumn);
                 case PrimitiveDataFrameColumn<int> intColumn:
-                    return ElementwiseLessThanOrEqualImplementation(column as PrimitiveDataFrameColumn<int>);
+                    return ElementwiseLessThanOrEqualImplementation(intColumn);
                 case PrimitiveDataFrameColumn<long> longColumn:
-                    return ElementwiseLessThanOrEqualImplementation(column as PrimitiveDataFrameColumn<long>);
+                    return ElementwiseLessThanOrEqualImplementation(longColumn);
                 case PrimitiveDataFrameColumn<sbyte> sbyteColumn:
-                    return ElementwiseLessThanOrEqualImplementation(column as PrimitiveDataFrameColumn<sbyte>);
+                    return ElementwiseLessThanOrEqualImplementation(sbyteColumn);
                 case PrimitiveDataFrameColumn<short> shortColumn:
-                    return ElementwiseLessThanOrEqualImplementation(column as PrimitiveDataFrameColumn<short>);
+                    return ElementwiseLessThanOrEqualImplementation(shortColumn);
                 case PrimitiveDataFrameColumn<uint> uintColumn:
-                    return ElementwiseLessThanOrEqualImplementation(column as PrimitiveDataFrameColumn<uint>);
+                    return ElementwiseLessThanOrEqualImplementation(uintColumn);
                 case PrimitiveDataFrameColumn<ulong> ulongColumn:
-                    return ElementwiseLessThanOrEqualImplementation(column as PrimitiveDataFrameColumn<ulong>);
+                    return ElementwiseLessThanOrEqualImplementation(ulongColumn);
                 case PrimitiveDataFrameColumn<ushort> ushortColumn:
-                    return ElementwiseLessThanOrEqualImplementation(column as PrimitiveDataFrameColumn<ushort>);
+                    return ElementwiseLessThanOrEqualImplementation(ushortColumn);
                 case PrimitiveDataFrameColumn<DateTime> DateTimeColumn:
-                    return ElementwiseLessThanOrEqualImplementation(column as PrimitiveDataFrameColumn<DateTime>);
+                    return ElementwiseLessThanOrEqualImplementation(DateTimeColumn);
                 default:
                     throw new NotSupportedException();
             }
@@ -579,33 +579,33 @@ namespace Microsoft.Data.Analysis
             switch (column)
             {
                 case PrimitiveDataFrameColumn<bool> boolColumn:
-                    return ElementwiseGreaterThanImplementation(column as PrimitiveDataFrameColumn<bool>);
+                    return ElementwiseGreaterThanImplementation(boolColumn);
                 case PrimitiveDataFrameColumn<byte> byteColumn:
-                    return ElementwiseGreaterThanImplementation(column as PrimitiveDataFrameColumn<byte>);
+                    return ElementwiseGreaterThanImplementation(byteColumn);
                 case PrimitiveDataFrameColumn<char> charColumn:
-                    return ElementwiseGreaterThanImplementation(column as PrimitiveDataFrameColumn<char>);
+                    return ElementwiseGreaterThanImplementation(charColumn);
                 case PrimitiveDataFrameColumn<decimal> decimalColumn:
-                    return ElementwiseGreaterThanImplementation(column as PrimitiveDataFrameColumn<decimal>);
+                    return ElementwiseGreaterThanImplementation(decimalColumn);
                 case PrimitiveDataFrameColumn<double> doubleColumn:
-                    return ElementwiseGreaterThanImplementation(column as PrimitiveDataFrameColumn<double>);
+                    return ElementwiseGreaterThanImplementation(doubleColumn);
                 case PrimitiveDataFrameColumn<float> floatColumn:
-                    return ElementwiseGreaterThanImplementation(column as PrimitiveDataFrameColumn<float>);
+                    return ElementwiseGreaterThanImplementation(floatColumn);
                 case PrimitiveDataFrameColumn<int> intColumn:
-                    return ElementwiseGreaterThanImplementation(column as PrimitiveDataFrameColumn<int>);
+                    return ElementwiseGreaterThanImplementation(intColumn);
                 case PrimitiveDataFrameColumn<long> longColumn:
-                    return ElementwiseGreaterThanImplementation(column as PrimitiveDataFrameColumn<long>);
+                    return ElementwiseGreaterThanImplementation(longColumn);
                 case PrimitiveDataFrameColumn<sbyte> sbyteColumn:
-                    return ElementwiseGreaterThanImplementation(column as PrimitiveDataFrameColumn<sbyte>);
+                    return ElementwiseGreaterThanImplementation(sbyteColumn);
                 case PrimitiveDataFrameColumn<short> shortColumn:
-                    return ElementwiseGreaterThanImplementation(column as PrimitiveDataFrameColumn<short>);
+                    return ElementwiseGreaterThanImplementation(shortColumn);
                 case PrimitiveDataFrameColumn<uint> uintColumn:
-                    return ElementwiseGreaterThanImplementation(column as PrimitiveDataFrameColumn<uint>);
+                    return ElementwiseGreaterThanImplementation(uintColumn);
                 case PrimitiveDataFrameColumn<ulong> ulongColumn:
-                    return ElementwiseGreaterThanImplementation(column as PrimitiveDataFrameColumn<ulong>);
+                    return ElementwiseGreaterThanImplementation(ulongColumn);
                 case PrimitiveDataFrameColumn<ushort> ushortColumn:
-                    return ElementwiseGreaterThanImplementation(column as PrimitiveDataFrameColumn<ushort>);
+                    return ElementwiseGreaterThanImplementation(ushortColumn);
                 case PrimitiveDataFrameColumn<DateTime> DateTimeColumn:
-                    return ElementwiseGreaterThanImplementation(column as PrimitiveDataFrameColumn<DateTime>);
+                    return ElementwiseGreaterThanImplementation(DateTimeColumn);
                 default:
                     throw new NotSupportedException();
             }
@@ -626,33 +626,33 @@ namespace Microsoft.Data.Analysis
             switch (column)
             {
                 case PrimitiveDataFrameColumn<bool> boolColumn:
-                    return ElementwiseLessThanImplementation(column as PrimitiveDataFrameColumn<bool>);
+                    return ElementwiseLessThanImplementation(boolColumn);
                 case PrimitiveDataFrameColumn<byte> byteColumn:
-                    return ElementwiseLessThanImplementation(column as PrimitiveDataFrameColumn<byte>);
+                    return ElementwiseLessThanImplementation(byteColumn);
                 case PrimitiveDataFrameColumn<char> charColumn:
-                    return ElementwiseLessThanImplementation(column as PrimitiveDataFrameColumn<char>);
+                    return ElementwiseLessThanImplementation(charColumn);
                 case PrimitiveDataFrameColumn<decimal> decimalColumn:
-                    return ElementwiseLessThanImplementation(column as PrimitiveDataFrameColumn<decimal>);
+                    return ElementwiseLessThanImplementation(decimalColumn);
                 case PrimitiveDataFrameColumn<double> doubleColumn:
-                    return ElementwiseLessThanImplementation(column as PrimitiveDataFrameColumn<double>);
+                    return ElementwiseLessThanImplementation(doubleColumn);
                 case PrimitiveDataFrameColumn<float> floatColumn:
-                    return ElementwiseLessThanImplementation(column as PrimitiveDataFrameColumn<float>);
+                    return ElementwiseLessThanImplementation(floatColumn);
                 case PrimitiveDataFrameColumn<int> intColumn:
-                    return ElementwiseLessThanImplementation(column as PrimitiveDataFrameColumn<int>);
+                    return ElementwiseLessThanImplementation(intColumn);
                 case PrimitiveDataFrameColumn<long> longColumn:
-                    return ElementwiseLessThanImplementation(column as PrimitiveDataFrameColumn<long>);
+                    return ElementwiseLessThanImplementation(longColumn);
                 case PrimitiveDataFrameColumn<sbyte> sbyteColumn:
-                    return ElementwiseLessThanImplementation(column as PrimitiveDataFrameColumn<sbyte>);
+                    return ElementwiseLessThanImplementation(sbyteColumn);
                 case PrimitiveDataFrameColumn<short> shortColumn:
-                    return ElementwiseLessThanImplementation(column as PrimitiveDataFrameColumn<short>);
+                    return ElementwiseLessThanImplementation(shortColumn);
                 case PrimitiveDataFrameColumn<uint> uintColumn:
-                    return ElementwiseLessThanImplementation(column as PrimitiveDataFrameColumn<uint>);
+                    return ElementwiseLessThanImplementation(uintColumn);
                 case PrimitiveDataFrameColumn<ulong> ulongColumn:
-                    return ElementwiseLessThanImplementation(column as PrimitiveDataFrameColumn<ulong>);
+                    return ElementwiseLessThanImplementation(ulongColumn);
                 case PrimitiveDataFrameColumn<ushort> ushortColumn:
-                    return ElementwiseLessThanImplementation(column as PrimitiveDataFrameColumn<ushort>);
+                    return ElementwiseLessThanImplementation(ushortColumn);
                 case PrimitiveDataFrameColumn<DateTime> DateTimeColumn:
-                    return ElementwiseLessThanImplementation(column as PrimitiveDataFrameColumn<DateTime>);
+                    return ElementwiseLessThanImplementation(DateTimeColumn);
                 default:
                     throw new NotSupportedException();
             }

--- a/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.BinaryOperations.tt
+++ b/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.BinaryOperations.tt
@@ -35,9 +35,9 @@ namespace Microsoft.Data.Analysis
 <# foreach (TypeConfiguration type in typeConfiguration) { #>
                 case PrimitiveDataFrameColumn<<#=type.TypeName#>> <#=type.TypeName#>Column:
 <# if (method.MethodType == MethodType.Binary) {#>
-                    return <#=method.MethodName#>Implementation(column as PrimitiveDataFrameColumn<<#=type.TypeName#>>, inPlace);
+                    return <#=method.MethodName#>Implementation(<#=type.TypeName#>Column, inPlace);
 <# } else { #>
-                    return <#=method.MethodName#>Implementation(column as PrimitiveDataFrameColumn<<#=type.TypeName#>>);
+                    return <#=method.MethodName#>Implementation(<#=type.TypeName#>Column);
 <# } #>
 <# } #>
                 default:

--- a/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumnArithmetic.cs
+++ b/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumnArithmetic.cs
@@ -309,8 +309,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -322,8 +321,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] == scalar);
@@ -334,8 +332,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -347,8 +344,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] != scalar);
@@ -714,8 +710,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -727,8 +722,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] == scalar);
@@ -739,8 +733,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -752,8 +745,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] != scalar);
@@ -764,8 +756,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -777,8 +768,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] >= scalar);
@@ -789,8 +779,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -802,8 +791,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] <= scalar);
@@ -814,8 +802,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -827,8 +814,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] > scalar);
@@ -839,8 +825,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -852,8 +837,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] < scalar);
@@ -1187,8 +1171,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1200,8 +1183,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] == scalar);
@@ -1212,8 +1194,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1225,8 +1206,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] != scalar);
@@ -1237,8 +1217,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1250,8 +1229,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] >= scalar);
@@ -1262,8 +1240,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1275,8 +1252,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] <= scalar);
@@ -1287,8 +1263,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1300,8 +1275,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] > scalar);
@@ -1312,8 +1286,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1325,8 +1298,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] < scalar);
@@ -1569,8 +1541,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1582,8 +1553,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] == scalar);
@@ -1594,8 +1564,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1607,8 +1576,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] != scalar);
@@ -1619,8 +1587,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1632,8 +1599,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] >= scalar);
@@ -1644,8 +1610,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1657,8 +1622,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] <= scalar);
@@ -1669,8 +1633,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1682,8 +1645,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] > scalar);
@@ -1694,8 +1656,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1707,8 +1668,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] < scalar);
@@ -1951,8 +1911,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1964,8 +1923,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] == scalar);
@@ -1976,8 +1934,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1989,8 +1946,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] != scalar);
@@ -2001,8 +1957,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2014,8 +1969,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] >= scalar);
@@ -2026,8 +1980,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2039,8 +1992,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] <= scalar);
@@ -2051,8 +2003,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2064,8 +2015,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] > scalar);
@@ -2076,8 +2026,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2089,8 +2038,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] < scalar);
@@ -2333,8 +2281,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2346,8 +2293,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] == scalar);
@@ -2358,8 +2304,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2371,8 +2316,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] != scalar);
@@ -2383,8 +2327,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2396,8 +2339,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] >= scalar);
@@ -2408,8 +2350,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2421,8 +2362,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] <= scalar);
@@ -2433,8 +2373,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2446,8 +2385,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] > scalar);
@@ -2458,8 +2396,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2471,8 +2408,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] < scalar);
@@ -2806,8 +2742,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2819,8 +2754,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] == scalar);
@@ -2831,8 +2765,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2844,8 +2777,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] != scalar);
@@ -2856,8 +2788,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2869,8 +2800,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] >= scalar);
@@ -2881,8 +2811,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2894,8 +2823,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] <= scalar);
@@ -2906,8 +2834,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2919,8 +2846,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] > scalar);
@@ -2931,8 +2857,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2944,8 +2869,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] < scalar);
@@ -3279,8 +3203,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3292,8 +3215,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] == scalar);
@@ -3304,8 +3226,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3317,8 +3238,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] != scalar);
@@ -3329,8 +3249,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3342,8 +3261,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] >= scalar);
@@ -3354,8 +3272,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3367,8 +3284,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] <= scalar);
@@ -3379,8 +3295,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3392,8 +3307,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] > scalar);
@@ -3404,8 +3318,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3417,8 +3330,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] < scalar);
@@ -3752,8 +3664,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3765,8 +3676,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] == scalar);
@@ -3777,8 +3687,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3790,8 +3699,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] != scalar);
@@ -3802,8 +3710,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3815,8 +3722,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] >= scalar);
@@ -3827,8 +3733,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3840,8 +3745,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] <= scalar);
@@ -3852,8 +3756,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3865,8 +3768,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] > scalar);
@@ -3877,8 +3779,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3890,8 +3791,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] < scalar);
@@ -4225,8 +4125,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4238,8 +4137,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] == scalar);
@@ -4250,8 +4148,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4263,8 +4160,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] != scalar);
@@ -4275,8 +4171,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4288,8 +4183,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] >= scalar);
@@ -4300,8 +4194,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4313,8 +4206,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] <= scalar);
@@ -4325,8 +4217,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4338,8 +4229,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] > scalar);
@@ -4350,8 +4240,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4363,8 +4252,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] < scalar);
@@ -4698,8 +4586,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4711,8 +4598,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] == scalar);
@@ -4723,8 +4609,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4736,8 +4621,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] != scalar);
@@ -4748,8 +4632,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4761,8 +4644,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] >= scalar);
@@ -4773,8 +4655,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4786,8 +4667,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] <= scalar);
@@ -4798,8 +4678,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4811,8 +4690,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] > scalar);
@@ -4823,8 +4701,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4836,8 +4713,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] < scalar);
@@ -5171,8 +5047,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5184,8 +5059,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] == scalar);
@@ -5196,8 +5070,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5209,8 +5082,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] != scalar);
@@ -5221,8 +5093,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5234,8 +5105,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] >= scalar);
@@ -5246,8 +5116,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5259,8 +5128,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] <= scalar);
@@ -5271,8 +5139,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5284,8 +5151,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] > scalar);
@@ -5296,8 +5162,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5309,8 +5174,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] < scalar);
@@ -5644,8 +5508,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5657,8 +5520,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] == scalar);
@@ -5669,8 +5531,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5682,8 +5543,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] != scalar);
@@ -5694,8 +5554,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5707,8 +5566,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] >= scalar);
@@ -5719,8 +5577,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5732,8 +5589,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] <= scalar);
@@ -5744,8 +5600,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5757,8 +5612,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] > scalar);
@@ -5769,8 +5623,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5782,8 +5635,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] < scalar);
@@ -5901,8 +5753,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5914,8 +5765,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] == scalar);
@@ -5926,8 +5776,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5939,8 +5788,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
-                var span = mutableBuffer.Span;
+                var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] != scalar);

--- a/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumnArithmetic.cs
+++ b/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumnArithmetic.cs
@@ -190,9 +190,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<bool>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -205,9 +203,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<bool>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -219,9 +215,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<bool>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -233,9 +227,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<bool>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -248,9 +240,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<bool>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -262,9 +252,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<bool>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -276,9 +264,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<bool>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -291,9 +277,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<bool>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -305,9 +289,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<bool>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -327,9 +309,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<bool>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -342,9 +322,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<bool>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -356,9 +334,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<bool>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -371,9 +347,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<bool>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -420,9 +394,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -435,9 +407,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -449,9 +419,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -463,9 +431,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -478,9 +444,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -492,9 +456,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -506,9 +468,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -521,9 +481,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -535,9 +493,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -549,9 +505,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -564,9 +518,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -578,9 +530,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -592,9 +542,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -607,9 +555,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -621,9 +567,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -635,9 +579,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -650,9 +592,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -664,9 +604,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -678,9 +616,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -693,9 +629,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -707,9 +641,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -721,9 +653,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -736,9 +666,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -750,9 +678,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -764,9 +690,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -778,9 +702,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -792,9 +714,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -807,9 +727,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -821,9 +739,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -836,9 +752,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -850,9 +764,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -865,9 +777,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -879,9 +789,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -894,9 +802,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -908,9 +814,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -923,9 +827,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -937,9 +839,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -952,9 +852,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -969,9 +867,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -984,9 +880,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -998,9 +892,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1012,9 +904,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -1027,9 +917,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1041,9 +929,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1055,9 +941,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -1070,9 +954,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1084,9 +966,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1098,9 +978,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -1113,9 +991,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1127,9 +1003,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1141,9 +1015,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -1156,9 +1028,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1170,9 +1040,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1184,9 +1052,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -1199,9 +1065,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1213,9 +1077,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1227,9 +1089,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -1242,9 +1102,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1256,9 +1114,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1270,9 +1126,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -1285,9 +1139,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1299,9 +1151,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1313,9 +1163,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1327,9 +1175,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1341,9 +1187,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -1356,9 +1200,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1370,9 +1212,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -1385,9 +1225,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1399,9 +1237,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -1414,9 +1250,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1428,9 +1262,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -1443,9 +1275,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1457,9 +1287,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -1472,9 +1300,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1486,9 +1312,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -1501,9 +1325,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1518,9 +1340,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -1533,9 +1353,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1547,9 +1365,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1561,9 +1377,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -1576,9 +1390,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1590,9 +1402,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1604,9 +1414,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -1619,9 +1427,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1633,9 +1439,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1647,9 +1451,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -1662,9 +1464,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1676,9 +1476,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1690,9 +1488,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -1705,9 +1501,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1719,9 +1513,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1777,9 +1569,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -1792,9 +1582,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1806,9 +1594,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -1821,9 +1607,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1835,9 +1619,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -1850,9 +1632,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1864,9 +1644,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -1879,9 +1657,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1893,9 +1669,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -1908,9 +1682,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1922,9 +1694,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -1937,9 +1707,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1954,9 +1722,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -1969,9 +1735,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1983,9 +1747,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -1997,9 +1759,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -2012,9 +1772,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2026,9 +1784,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2040,9 +1796,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -2055,9 +1809,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2069,9 +1821,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2083,9 +1833,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -2098,9 +1846,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2112,9 +1858,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2126,9 +1870,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -2141,9 +1883,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2155,9 +1895,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2213,9 +1951,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -2228,9 +1964,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2242,9 +1976,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -2257,9 +1989,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2271,9 +2001,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -2286,9 +2014,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2300,9 +2026,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -2315,9 +2039,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2329,9 +2051,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -2344,9 +2064,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2358,9 +2076,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -2373,9 +2089,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2390,9 +2104,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -2405,9 +2117,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2419,9 +2129,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2433,9 +2141,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -2448,9 +2154,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2462,9 +2166,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2476,9 +2178,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -2491,9 +2191,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2505,9 +2203,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2519,9 +2215,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -2534,9 +2228,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2548,9 +2240,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2562,9 +2252,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -2577,9 +2265,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2591,9 +2277,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2649,9 +2333,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -2664,9 +2346,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2678,9 +2358,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -2693,9 +2371,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2707,9 +2383,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -2722,9 +2396,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2736,9 +2408,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -2751,9 +2421,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2765,9 +2433,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -2780,9 +2446,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2794,9 +2458,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -2809,9 +2471,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2826,9 +2486,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -2841,9 +2499,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2855,9 +2511,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2869,9 +2523,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -2884,9 +2536,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2898,9 +2548,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2912,9 +2560,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -2927,9 +2573,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2941,9 +2585,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2955,9 +2597,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -2970,9 +2610,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2984,9 +2622,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -2998,9 +2634,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -3013,9 +2647,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3027,9 +2659,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3041,9 +2671,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -3056,9 +2684,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3070,9 +2696,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3084,9 +2708,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -3099,9 +2721,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3113,9 +2733,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3127,9 +2745,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -3142,9 +2758,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3156,9 +2770,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3170,9 +2782,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3184,9 +2794,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3198,9 +2806,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -3213,9 +2819,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3227,9 +2831,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -3242,9 +2844,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3256,9 +2856,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -3271,9 +2869,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3285,9 +2881,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -3300,9 +2894,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3314,9 +2906,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -3329,9 +2919,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3343,9 +2931,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -3358,9 +2944,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3375,9 +2959,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -3390,9 +2972,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3404,9 +2984,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3418,9 +2996,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -3433,9 +3009,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3447,9 +3021,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3461,9 +3033,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -3476,9 +3046,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3490,9 +3058,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3504,9 +3070,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -3519,9 +3083,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3533,9 +3095,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3547,9 +3107,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -3562,9 +3120,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3576,9 +3132,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3590,9 +3144,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -3605,9 +3157,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3619,9 +3169,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3633,9 +3181,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -3648,9 +3194,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3662,9 +3206,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3676,9 +3218,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -3691,9 +3231,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3705,9 +3243,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3719,9 +3255,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3733,9 +3267,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3747,9 +3279,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -3762,9 +3292,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3776,9 +3304,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -3791,9 +3317,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3805,9 +3329,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -3820,9 +3342,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3834,9 +3354,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -3849,9 +3367,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3863,9 +3379,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -3878,9 +3392,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3892,9 +3404,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -3907,9 +3417,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3924,9 +3432,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -3939,9 +3445,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3953,9 +3457,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3967,9 +3469,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -3982,9 +3482,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -3996,9 +3494,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4010,9 +3506,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -4025,9 +3519,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4039,9 +3531,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4053,9 +3543,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -4068,9 +3556,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4082,9 +3568,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4096,9 +3580,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -4111,9 +3593,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4125,9 +3605,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4139,9 +3617,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -4154,9 +3630,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4168,9 +3642,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4182,9 +3654,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -4197,9 +3667,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4211,9 +3679,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4225,9 +3691,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -4240,9 +3704,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4254,9 +3716,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4268,9 +3728,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4282,9 +3740,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4296,9 +3752,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -4311,9 +3765,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4325,9 +3777,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -4340,9 +3790,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4354,9 +3802,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -4369,9 +3815,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4383,9 +3827,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -4398,9 +3840,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4412,9 +3852,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -4427,9 +3865,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4441,9 +3877,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -4456,9 +3890,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4473,9 +3905,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -4488,9 +3918,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4502,9 +3930,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4516,9 +3942,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -4531,9 +3955,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4545,9 +3967,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4559,9 +3979,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -4574,9 +3992,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4588,9 +4004,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4602,9 +4016,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -4617,9 +4029,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4631,9 +4041,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4645,9 +4053,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -4660,9 +4066,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4674,9 +4078,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4688,9 +4090,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -4703,9 +4103,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4717,9 +4115,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4731,9 +4127,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -4746,9 +4140,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4760,9 +4152,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4774,9 +4164,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -4789,9 +4177,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4803,9 +4189,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4817,9 +4201,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4831,9 +4213,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4845,9 +4225,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -4860,9 +4238,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4874,9 +4250,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -4889,9 +4263,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4903,9 +4275,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -4918,9 +4288,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4932,9 +4300,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -4947,9 +4313,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4961,9 +4325,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -4976,9 +4338,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -4990,9 +4350,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -5005,9 +4363,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5022,9 +4378,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -5037,9 +4391,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5051,9 +4403,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5065,9 +4415,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -5080,9 +4428,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5094,9 +4440,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5108,9 +4452,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -5123,9 +4465,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5137,9 +4477,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5151,9 +4489,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -5166,9 +4502,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5180,9 +4514,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5194,9 +4526,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -5209,9 +4539,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5223,9 +4551,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5237,9 +4563,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -5252,9 +4576,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5266,9 +4588,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5280,9 +4600,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -5295,9 +4613,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5309,9 +4625,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5323,9 +4637,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -5338,9 +4650,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5352,9 +4662,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5366,9 +4674,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5380,9 +4686,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5394,9 +4698,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -5409,9 +4711,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5423,9 +4723,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -5438,9 +4736,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5452,9 +4748,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -5467,9 +4761,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5481,9 +4773,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -5496,9 +4786,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5510,9 +4798,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -5525,9 +4811,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5539,9 +4823,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -5554,9 +4836,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5571,9 +4851,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -5586,9 +4864,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5600,9 +4876,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5614,9 +4888,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -5629,9 +4901,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5643,9 +4913,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5657,9 +4925,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -5672,9 +4938,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5686,9 +4950,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5700,9 +4962,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -5715,9 +4975,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5729,9 +4987,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5743,9 +4999,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -5758,9 +5012,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5772,9 +5024,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5786,9 +5036,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -5801,9 +5049,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5815,9 +5061,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5829,9 +5073,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -5844,9 +5086,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5858,9 +5098,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5872,9 +5110,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -5887,9 +5123,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5901,9 +5135,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5915,9 +5147,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5929,9 +5159,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5943,9 +5171,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -5958,9 +5184,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -5972,9 +5196,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -5987,9 +5209,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -6001,9 +5221,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -6016,9 +5234,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -6030,9 +5246,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -6045,9 +5259,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -6059,9 +5271,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -6074,9 +5284,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -6088,9 +5296,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -6103,9 +5309,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -6120,9 +5324,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -6135,9 +5337,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -6149,9 +5349,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -6163,9 +5361,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -6178,9 +5374,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -6192,9 +5386,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -6206,9 +5398,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -6221,9 +5411,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -6235,9 +5423,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -6249,9 +5435,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -6264,9 +5448,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -6278,9 +5460,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -6292,9 +5472,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -6307,9 +5485,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -6321,9 +5497,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -6335,9 +5509,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -6350,9 +5522,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -6364,9 +5534,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -6378,9 +5546,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -6393,9 +5559,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -6407,9 +5571,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -6421,9 +5583,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -6436,9 +5596,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -6450,9 +5608,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -6464,9 +5620,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -6478,9 +5632,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -6492,9 +5644,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -6507,9 +5657,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -6521,9 +5669,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -6536,9 +5682,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -6550,9 +5694,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -6565,9 +5707,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -6579,9 +5719,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -6594,9 +5732,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -6608,9 +5744,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -6623,9 +5757,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -6637,9 +5769,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -6652,9 +5782,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -6773,9 +5901,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<DateTime>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -6788,9 +5914,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<DateTime>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -6802,9 +5926,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<DateTime>.GetMutableBuffer(buffer);
-                left.Buffers[b] = mutableBuffer;
+                var mutableBuffer = left.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
@@ -6817,9 +5939,7 @@ namespace Microsoft.Data.Analysis
         {
             for (int b = 0; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<DateTime>.GetMutableBuffer(buffer);
-                column.Buffers[b] = mutableBuffer;
+                var mutableBuffer = column.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {

--- a/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumnArithmetic.tt
+++ b/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumnArithmetic.tt
@@ -18,7 +18,7 @@ using System;
 namespace Microsoft.Data.Analysis
 {
     internal interface IPrimitiveDataFrameColumnArithmetic<T>
-        where T : struct
+        where T : unmanaged
     {
 <# foreach (MethodConfiguration method in methodConfiguration) { #>
         <#= method.GetMethodSignature("PrimitiveColumnContainer", "T")#>;
@@ -29,7 +29,7 @@ namespace Microsoft.Data.Analysis
     }
 
     internal static class PrimitiveDataFrameColumnArithmetic<T>
-        where T : struct
+        where T : unmanaged
     {
         public static IPrimitiveDataFrameColumnArithmetic<T> Instance { get; } = PrimitiveDataFrameColumnArithmetic.GetArithmetic<T>();
     }
@@ -37,7 +37,7 @@ namespace Microsoft.Data.Analysis
     internal static class PrimitiveDataFrameColumnArithmetic
     {
         public static IPrimitiveDataFrameColumnArithmetic<T> GetArithmetic<T>()
-            where T : struct
+            where T : unmanaged
         {
 <# foreach (TypeConfiguration type in typeConfiguration) { #>
             <#=GenerateIfStatementHeader(type)#>
@@ -60,9 +60,7 @@ namespace Microsoft.Data.Analysis
 <# } else if (method.Operator != null) { #>
             for (int b = 0; b < <#= method.Op1Name #>.Buffers.Count; b++)
             {
-                var buffer = <#= method.Op1Name #>.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<<#=type.TypeName#>>.GetMutableBuffer(buffer);
-                <#= method.Op1Name #>.Buffers[b] = mutableBuffer;
+                var mutableBuffer = <#= method.Op1Name #>.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
 <# if (method.MethodType == MethodType.Binary || method.MethodType == MethodType.Comparison) { #>
                 var otherSpan = <#=method.Op2Name#>.Buffers[b].ReadOnlySpan;
@@ -92,9 +90,7 @@ namespace Microsoft.Data.Analysis
 <# } else if (method.Operator != null) { #>
             for (int b = 0; b < <#= method.Op1Name #>.Buffers.Count; b++)
             {
-                var buffer = <#= method.Op1Name #>.Buffers[b];
-                var mutableBuffer = DataFrameBuffer<<#=type.TypeName#>>.GetMutableBuffer(buffer);
-                <#= method.Op1Name #>.Buffers[b] = mutableBuffer;
+                var mutableBuffer = <#= method.Op1Name #>.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
 <# if (method.MethodType == MethodType.Binary || method.MethodType == MethodType.Comparison) { #>
                 var otherSpan = <#=method.Op2Name#>.Buffers[b].ReadOnlySpan;

--- a/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumnArithmetic.tt
+++ b/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumnArithmetic.tt
@@ -60,10 +60,17 @@ namespace Microsoft.Data.Analysis
 <# } else if (method.Operator != null) { #>
             for (int b = 0; b < <#= method.Op1Name #>.Buffers.Count; b++)
             {
+<# if (method.MethodType == MethodType.Comparison) { #>
+                var span = <#= method.Op1Name #>.Buffers[b].ReadOnlySpan;
+                var otherSpan = <#=method.Op2Name#>.Buffers[b].ReadOnlySpan;
+<# } else if (method.MethodType == MethodType.ComparisonScalar){#>
+                var span = <#= method.Op1Name #>.Buffers[b].ReadOnlySpan;
+<# } else {#>
                 var mutableBuffer = <#= method.Op1Name #>.Buffers.GetOrCreateMutable(b);
                 var span = mutableBuffer.Span;
-<# if (method.MethodType == MethodType.Binary || method.MethodType == MethodType.Comparison) { #>
+<# if (method.MethodType == MethodType.Binary) { #>
                 var otherSpan = <#=method.Op2Name#>.Buffers[b].ReadOnlySpan;
+<# } #>
 <# } #>
                 for (int i = 0; i < span.Length; i++)
                 {


### PR DESCRIPTION
1) Remove redundant code from PrimitiveDataFrameColumn.BinaryOperations  and PrimitiveDataFrameColumnArithmetic to make it more readable
2) Remove extra cast to slightly improve performance in PrimitiveDataFrameColumn.BinaryOperations
3) Remove converting to mutable buffers (involves memory coping) for operations where it's not necessary to increase performance in PrimitiveDataFrameColumnArithmetic

This is preliminary work for #6110
