### PR TITLE
Fix DataFrame to allow to store columns with size more than 2 Gb

### DIFF
--- a/src/Microsoft.Data.Analysis/DataFrameBuffer.cs
+++ b/src/Microsoft.Data.Analysis/DataFrameBuffer.cs
@@ -66,7 +66,10 @@ namespace Microsoft.Data.Analysis
 
             if (newLength > Capacity)
             {
-                var newCapacity = Math.Max(newLength * Size, ReadOnlyBuffer.Length * 2);
+                //Double buffer size, but not higher than MaxByteCapacity
+                var doubledSize = (int)Math.Min((long)ReadOnlyBuffer.Length * 2, MaxCapacityInBytes);
+                var newCapacity = Math.Max(newLength * Size, doubledSize);
+
                 var memory = new Memory<byte>(new byte[newCapacity]);
                 _memory.CopyTo(memory);
                 _memory = memory;

--- a/src/Microsoft.Data.Analysis/PrimitiveColumnContainer.cs
+++ b/src/Microsoft.Data.Analysis/PrimitiveColumnContainer.cs
@@ -181,7 +181,9 @@ namespace Microsoft.Data.Analysis
                 }
 
                 DataFrameBuffer<T> mutableLastBuffer = Buffers.GetOrCreateMutable(Buffers.Count - 1);
-                int allocatable = (int)Math.Min(remaining, ReadOnlyDataFrameBuffer<T>.MaxCapacity);
+
+                //Calculate how many values we can additionaly allocate and not exceed the MaxCapacity
+                int allocatable = (int)Math.Min(remaining, ReadOnlyDataFrameBuffer<T>.MaxCapacity - mutableLastBuffer.Length);
                 mutableLastBuffer.EnsureCapacity(allocatable);
 
                 DataFrameBuffer<byte> lastNullBitMapBuffer = NullBitMapBuffers.GetOrCreateMutable(NullBitMapBuffers.Count - 1);
@@ -204,7 +206,6 @@ namespace Microsoft.Data.Analysis
                     }
                     _modifyNullCountWhileIndexing = true;
                 }
-
 
                 remaining -= allocatable;
             }

--- a/src/Microsoft.Data.Analysis/ReadOnlyDataFrameBuffer.cs
+++ b/src/Microsoft.Data.Analysis/ReadOnlyDataFrameBuffer.cs
@@ -36,8 +36,11 @@ namespace Microsoft.Data.Analysis
 
         protected int Capacity => ReadOnlyBuffer.Length / Size;
 
+        //The maximum size in any single dimension for byte array is 0x7FFFFFc7 - 2147483591
+        //See https://learn.microsoft.com/en-us/dotnet/framework/configure-apps/file-schema/runtime/gcallowverylargeobjects-element
+        public const int MaxCapacityInBytes = 2147483591;
 
-        public static int MaxCapacity => Int32.MaxValue / Size;
+        public static int MaxCapacity => MaxCapacityInBytes / Size;
 
         public ReadOnlySpan<T> ReadOnlySpan
         {

--- a/test/Microsoft.Data.Analysis.Tests/BufferTests.cs
+++ b/test/Microsoft.Data.Analysis.Tests/BufferTests.cs
@@ -188,6 +188,28 @@ namespace Microsoft.Data.Analysis.Tests
                 Assert.Null(clone[i]);
         }
 
+        /* Don't run tests during build as they fail, because build if build machine doesn't have enought memory
+        [Fact]
+        public void TestAppend_SizeMoreThanMaxBufferCapacity()
+        {
+            //Check appending value, than can increase buffer size over MaxCapacity (default strategy is to double buffer capacity)
+            PrimitiveDataFrameColumn<byte> intColumn = new PrimitiveDataFrameColumn<byte>("Byte1", int.MaxValue / 2 - 1);
+            intColumn.Append(10);
+        }
+
+        [Fact]
+        public void TestAppendMany_SizeMoreThanMaxBufferCapacity()
+        {
+            const int MaxCapacityInBytes = 2147483591;
+
+            //Check appending values with extending column size over MaxCapacity of ReadOnlyDataFrameBuffer
+            PrimitiveDataFrameColumn<byte> intColumn = new PrimitiveDataFrameColumn<byte>("Byte1", MaxCapacityInBytes - 5);
+            intColumn.AppendMany(5, 10);
+
+            Assert.Equal(MaxCapacityInBytes + 5, intColumn.Length);
+        }
+        */
+
         //#if !NETFRAMEWORK // https://github.com/dotnet/corefxlab/issues/2796
         //        [Fact]
         //        public void TestPrimitiveColumnGetReadOnlyBuffers()

--- a/test/Microsoft.Data.Analysis.Tests/BufferTests.cs
+++ b/test/Microsoft.Data.Analysis.Tests/BufferTests.cs
@@ -134,18 +134,6 @@ namespace Microsoft.Data.Analysis.Tests
         }
 
         [Fact]
-        public void TestAppendMany_SizeMoreThanMaxBufferCapacity()
-        {
-            const int MaxCapacityInBytes = 2147483591;
-
-            //Check appending values with extending column size over MaxCapacity of ReadOnlyDataFrameBuffer
-            PrimitiveDataFrameColumn<byte> intColumn = new PrimitiveDataFrameColumn<byte>("Byte1", MaxCapacityInBytes - 5);
-            intColumn.AppendMany(5, 10);
-
-            Assert.Equal(MaxCapacityInBytes + 5, intColumn.Length);
-        }
-
-        [Fact]
         public void TestBasicArrowStringColumn()
         {
             StringArray strArray = new StringArray.Builder().Append("foo").Append("bar").Build();

--- a/test/Microsoft.Data.Analysis.Tests/BufferTests.cs
+++ b/test/Microsoft.Data.Analysis.Tests/BufferTests.cs
@@ -134,6 +134,18 @@ namespace Microsoft.Data.Analysis.Tests
         }
 
         [Fact]
+        public void TestAppendMany_SizeMoreThanMaxBufferCapacity()
+        {
+            const int MaxCapacityInBytes = 2147483591;
+
+            //Check appending values with extending column size over MaxCapacity of ReadOnlyDataFrameBuffer
+            PrimitiveDataFrameColumn<byte> intColumn = new PrimitiveDataFrameColumn<byte>("Byte1", MaxCapacityInBytes - 5);
+            intColumn.AppendMany(5, 10);
+
+            Assert.Equal(MaxCapacityInBytes + 5, intColumn.Length);
+        }
+
+        [Fact]
         public void TestBasicArrowStringColumn()
         {
             StringArray strArray = new StringArray.Builder().Append("foo").Append("bar").Build();


### PR DESCRIPTION
Fixes #6699 

1) Decrease limit from Int.Max value on buffer size to the maximum amount of bytes supported by .Net Arrays
2) Fix calculation of items amount for filling remaining capacity of fully allocated chunk
3) Fix calculation of buffer size during default growing strategy (double the initial size)
