### PR TITLE
Continue training on OOM error && add subsampling support for trainValidationDatasetManager

### DIFF
--- a/src/Microsoft.ML.AutoML/API/AutoMLExperimentExtension.cs
+++ b/src/Microsoft.ML.AutoML/API/AutoMLExperimentExtension.cs
@@ -67,13 +67,7 @@ namespace Microsoft.ML.AutoML
         /// <returns><see cref="AutoMLExperiment"/></returns>
         public static AutoMLExperiment SetDataset(this AutoMLExperiment experiment, IDataView dataset, int fold = 10, string samplingKeyColumnName = null)
         {
-            var datasetManager = new CrossValidateDatasetManager()
-            {
-                Dataset = dataset,
-                Fold = fold,
-                SamplingKeyColumnName = samplingKeyColumnName,
-            };
-
+            var datasetManager = new CrossValidateDatasetManager(dataset, fold, samplingKeyColumnName);
             experiment.ServiceCollection.AddSingleton<IDatasetManager>(datasetManager);
             experiment.ServiceCollection.AddSingleton(datasetManager);
 

--- a/src/Microsoft.ML.AutoML/API/BinaryClassificationExperiment.cs
+++ b/src/Microsoft.ML.AutoML/API/BinaryClassificationExperiment.cs
@@ -391,7 +391,7 @@ namespace Microsoft.ML.AutoML
                 {
                     var stopWatch = new Stopwatch();
                     stopWatch.Start();
-                    var fold = datasetManager.Fold ?? 5;
+                    var fold = datasetManager.Fold;
                     var metrics = _context.BinaryClassification.CrossValidateNonCalibrated(datasetManager.Dataset, pipeline, fold, metricManager.LabelColumn);
 
                     // now we just randomly pick a model, but a better way is to provide option to pick a model which score is the cloest to average or the best.

--- a/src/Microsoft.ML.AutoML/API/BinaryClassificationExperiment.cs
+++ b/src/Microsoft.ML.AutoML/API/BinaryClassificationExperiment.cs
@@ -420,8 +420,8 @@ namespace Microsoft.ML.AutoML
                 {
                     var stopWatch = new Stopwatch();
                     stopWatch.Start();
-                    var model = pipeline.Fit(trainTestDatasetManager.TrainDataset);
-                    var eval = model.Transform(trainTestDatasetManager.ValidateDataset);
+                    var model = pipeline.Fit(trainTestDatasetManager.LoadTrainDataset(_context, settings));
+                    var eval = model.Transform(trainTestDatasetManager.LoadValidateDataset(_context, settings));
                     var metrics = _context.BinaryClassification.EvaluateNonCalibrated(eval, metricManager.LabelColumn, predictedLabelColumnName: metricManager.PredictedColumn);
                     var metric = GetMetric(metricManager.Metric, metrics);
                     var loss = metricManager.IsMaximize ? -metric : metric;

--- a/src/Microsoft.ML.AutoML/API/MulticlassClassificationExperiment.cs
+++ b/src/Microsoft.ML.AutoML/API/MulticlassClassificationExperiment.cs
@@ -398,8 +398,8 @@ namespace Microsoft.ML.AutoML
                 {
                     var stopWatch = new Stopwatch();
                     stopWatch.Start();
-                    var model = pipeline.Fit(trainTestDatasetManager.TrainDataset);
-                    var eval = model.Transform(trainTestDatasetManager.ValidateDataset);
+                    var model = pipeline.Fit(trainTestDatasetManager.LoadTrainDataset(_context, settings));
+                    var eval = model.Transform(trainTestDatasetManager.LoadValidateDataset(_context, settings));
                     var metrics = _context.MulticlassClassification.Evaluate(eval, metricManager.LabelColumn, predictedLabelColumnName: metricManager.PredictedColumn);
                     var metric = GetMetric(metricManager.Metric, metrics);
                     var loss = metricManager.IsMaximize ? -metric : metric;

--- a/src/Microsoft.ML.AutoML/API/MulticlassClassificationExperiment.cs
+++ b/src/Microsoft.ML.AutoML/API/MulticlassClassificationExperiment.cs
@@ -369,7 +369,7 @@ namespace Microsoft.ML.AutoML
                 {
                     var stopWatch = new Stopwatch();
                     stopWatch.Start();
-                    var fold = datasetManager.Fold ?? 5;
+                    var fold = datasetManager.Fold;
                     var metrics = _context.MulticlassClassification.CrossValidate(datasetManager.Dataset, pipeline, fold, metricManager.LabelColumn);
 
                     // now we just randomly pick a model, but a better way is to provide option to pick a model which score is the cloest to average or the best.

--- a/src/Microsoft.ML.AutoML/API/RegressionExperiment.cs
+++ b/src/Microsoft.ML.AutoML/API/RegressionExperiment.cs
@@ -425,8 +425,8 @@ namespace Microsoft.ML.AutoML
                         {
                             var stopWatch = new Stopwatch();
                             stopWatch.Start();
-                            var model = pipeline.Fit(trainTestDatasetManager.TrainDataset);
-                            var eval = model.Transform(trainTestDatasetManager.ValidateDataset);
+                            var model = pipeline.Fit(trainTestDatasetManager.LoadTrainDataset(_context, settings));
+                            var eval = model.Transform(trainTestDatasetManager.LoadValidateDataset(_context, settings));
                             var metrics = _context.Regression.Evaluate(eval, metricManager.LabelColumn, scoreColumnName: metricManager.ScoreColumn);
                             var metric = GetMetric(metricManager.Metric, metrics);
                             var loss = metricManager.IsMaximize ? -metric : metric;

--- a/src/Microsoft.ML.AutoML/API/RegressionExperiment.cs
+++ b/src/Microsoft.ML.AutoML/API/RegressionExperiment.cs
@@ -396,7 +396,7 @@ namespace Microsoft.ML.AutoML
                         {
                             var stopWatch = new Stopwatch();
                             stopWatch.Start();
-                            var fold = datasetManager.Fold ?? 5;
+                            var fold = datasetManager.Fold;
                             var metrics = _context.Regression.CrossValidate(datasetManager.Dataset, pipeline, fold, metricManager.LabelColumn);
 
                             // now we just randomly pick a model, but a better way is to provide option to pick a model which score is the cloest to average or the best.

--- a/src/Microsoft.ML.AutoML/AutoMLExperiment/AutoMLExperiment.cs
+++ b/src/Microsoft.ML.AutoML/AutoMLExperiment/AutoMLExperiment.cs
@@ -315,7 +315,7 @@ Abandoning Trial {trialSettings.TrialId} and continue training.
                     trialResultManager?.AddOrUpdateTrialResult(trialResult);
                     aggregateTrainingStopManager.Update(trialResult);
 
-                    if (ex is not OperationCanceledException && _bestTrialResult == null)
+                    if (ex is not OperationCanceledException && ex is not OutOfMemoryException && _bestTrialResult == null)
                     {
                         logger.Trace($"trial fatal error - {JsonSerializer.Serialize(trialSettings)}, stop training");
 

--- a/src/Microsoft.ML.AutoML/AutoMLExperiment/IDatasetManager.cs
+++ b/src/Microsoft.ML.AutoML/AutoMLExperiment/IDatasetManager.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+#nullable enable
 
 using Microsoft.ML.SearchSpace;
 
@@ -18,16 +19,16 @@ namespace Microsoft.ML.AutoML
     {
         int? Fold { get; set; }
 
-        IDataView Dataset { get; set; }
+        IDataView? Dataset { get; set; }
 
-        string SamplingKeyColumnName { get; set; }
+        string? SamplingKeyColumnName { get; set; }
     }
 
     public interface ITrainValidateDatasetManager
     {
-        IDataView LoadTrainDataset(MLContext context, TrialSettings settings);
+        IDataView LoadTrainDataset(MLContext context, TrialSettings? settings);
 
-        IDataView LoadValidateDataset(MLContext context, TrialSettings settings);
+        IDataView LoadValidateDataset(MLContext context, TrialSettings? settings);
     }
 
     internal class TrainValidateDatasetManager : IDatasetManager, ITrainValidateDatasetManager
@@ -37,7 +38,7 @@ namespace Microsoft.ML.AutoML
         private readonly IDataView _validateDataset;
         private readonly string _subSamplingKey = "TrainValidateDatasetSubsamplingKey";
         private bool _isInitialized = false;
-        public TrainValidateDatasetManager(IDataView trainDataset, IDataView validateDataset, string subSamplingKey = null)
+        public TrainValidateDatasetManager(IDataView trainDataset, IDataView validateDataset, string? subSamplingKey = null)
         {
             _trainDataset = trainDataset;
             _validateDataset = validateDataset;
@@ -46,22 +47,20 @@ namespace Microsoft.ML.AutoML
 
         public string SubSamplingKey => _subSamplingKey;
 
-        public IDataView TrainDataset { get; set; }
-
-        public IDataView ValidateDataset { get; set; }
-
         /// <summary>
         /// Load Train Dataset. If <see cref="TrialSettings.Parameter"/> contains <see cref="_subSamplingKey"/> then the train dataset will be subsampled.
         /// </summary>
+        /// <param name="context">MLContext.</param>
+        /// <param name="settings">trial settings. If null, return entire train dataset.</param>
         /// <returns>train dataset.</returns>
-        public IDataView LoadTrainDataset(MLContext context, TrialSettings settings)
+        public IDataView LoadTrainDataset(MLContext context, TrialSettings? settings)
         {
             if (!_isInitialized)
             {
                 InitializeTrainDataset(context);
                 _isInitialized = true;
             }
-            var trainTestSplitParameter = settings.Parameter.ContainsKey(nameof(TrainValidateDatasetManager)) ? settings.Parameter[nameof(TrainValidateDatasetManager)] : null;
+            var trainTestSplitParameter = settings?.Parameter.ContainsKey(nameof(TrainValidateDatasetManager)) is true ? settings.Parameter[nameof(TrainValidateDatasetManager)] : null;
             if (trainTestSplitParameter is Parameter parameter)
             {
                 var subSampleRatio = parameter.ContainsKey(_subSamplingKey) ? parameter[_subSamplingKey].AsType<double>() : 1;
@@ -75,7 +74,7 @@ namespace Microsoft.ML.AutoML
             return _trainDataset;
         }
 
-        public IDataView LoadValidateDataset(MLContext context, TrialSettings settings)
+        public IDataView LoadValidateDataset(MLContext context, TrialSettings? settings)
         {
             return _validateDataset;
         }
@@ -89,10 +88,10 @@ namespace Microsoft.ML.AutoML
 
     internal class CrossValidateDatasetManager : IDatasetManager, ICrossValidateDatasetManager
     {
-        public IDataView Dataset { get; set; }
+        public IDataView? Dataset { get; set; }
 
         public int? Fold { get; set; }
 
-        public string SamplingKeyColumnName { get; set; }
+        public string? SamplingKeyColumnName { get; set; }
     }
 }

--- a/src/Microsoft.ML.AutoML/AutoMLExperiment/IDatasetManager.cs
+++ b/src/Microsoft.ML.AutoML/AutoMLExperiment/IDatasetManager.cs
@@ -15,16 +15,28 @@ namespace Microsoft.ML.AutoML
     {
     }
 
-    public interface ICrossValidateDatasetManager
+    /// <summary>
+    /// Inferface for cross validate dataset manager.
+    /// </summary>
+    public interface ICrossValidateDatasetManager : IDatasetManager
     {
-        int? Fold { get; set; }
+        /// <summary>
+        /// Cross validate fold.
+        /// </summary>
+        int Fold { get; set; }
 
-        IDataView? Dataset { get; set; }
+        /// <summary>
+        /// The dataset to cross validate.
+        /// </summary>
+        IDataView Dataset { get; set; }
 
+        /// <summary>
+        /// The dataset column used for grouping rows.
+        /// </summary>
         string? SamplingKeyColumnName { get; set; }
     }
 
-    public interface ITrainValidateDatasetManager
+    public interface ITrainValidateDatasetManager : IDatasetManager
     {
         IDataView LoadTrainDataset(MLContext context, TrialSettings? settings);
 
@@ -88,9 +100,16 @@ namespace Microsoft.ML.AutoML
 
     internal class CrossValidateDatasetManager : IDatasetManager, ICrossValidateDatasetManager
     {
-        public IDataView? Dataset { get; set; }
+        public CrossValidateDatasetManager(IDataView dataset, int fold, string? samplingKeyColumnName = null)
+        {
+            Dataset = dataset;
+            Fold = fold;
+            SamplingKeyColumnName = samplingKeyColumnName;
+        }
 
-        public int? Fold { get; set; }
+        public IDataView Dataset { get; set; }
+
+        public int Fold { get; set; }
 
         public string? SamplingKeyColumnName { get; set; }
     }

--- a/src/Microsoft.ML.AutoML/AutoMLExperiment/Runner/SweepablePipelineRunner.cs
+++ b/src/Microsoft.ML.AutoML/AutoMLExperiment/Runner/SweepablePipelineRunner.cs
@@ -68,8 +68,8 @@ namespace Microsoft.ML.AutoML
 
             if (_datasetManager is ITrainValidateDatasetManager trainTestDatasetManager)
             {
-                var model = mlnetPipeline.Fit(trainTestDatasetManager.LoadTrainDataset(_mLContext, settings));
-                var eval = model.Transform(trainTestDatasetManager.LoadValidateDataset(_mLContext, settings));
+                var model = mlnetPipeline.Fit(trainTestDatasetManager.LoadTrainDataset(_mLContext!, settings));
+                var eval = model.Transform(trainTestDatasetManager.LoadValidateDataset(_mLContext!, settings));
                 var metric = _metricManager.Evaluate(_mLContext, eval);
                 stopWatch.Stop();
                 var loss = _metricManager.IsMaximize ? -metric : metric;

--- a/src/Microsoft.ML.AutoML/AutoMLExperiment/Runner/SweepablePipelineRunner.cs
+++ b/src/Microsoft.ML.AutoML/AutoMLExperiment/Runner/SweepablePipelineRunner.cs
@@ -68,8 +68,8 @@ namespace Microsoft.ML.AutoML
 
             if (_datasetManager is ITrainValidateDatasetManager trainTestDatasetManager)
             {
-                var model = mlnetPipeline.Fit(trainTestDatasetManager.TrainDataset);
-                var eval = model.Transform(trainTestDatasetManager.ValidateDataset);
+                var model = mlnetPipeline.Fit(trainTestDatasetManager.LoadTrainDataset(_mLContext, settings));
+                var eval = model.Transform(trainTestDatasetManager.LoadValidateDataset(_mLContext, settings));
                 var metric = _metricManager.Evaluate(_mLContext, eval);
                 stopWatch.Stop();
                 var loss = _metricManager.IsMaximize ? -metric : metric;

--- a/src/Microsoft.ML.AutoML/AutoMLExperiment/Runner/SweepablePipelineRunner.cs
+++ b/src/Microsoft.ML.AutoML/AutoMLExperiment/Runner/SweepablePipelineRunner.cs
@@ -40,7 +40,7 @@ namespace Microsoft.ML.AutoML
             var mlnetPipeline = _pipeline.BuildFromOption(_mLContext, parameter);
             if (_datasetManager is ICrossValidateDatasetManager crossValidateDatasetManager)
             {
-                var datasetSplit = _mLContext!.Data.CrossValidationSplit(crossValidateDatasetManager.Dataset, crossValidateDatasetManager.Fold ?? 5, crossValidateDatasetManager.SamplingKeyColumnName);
+                var datasetSplit = _mLContext!.Data.CrossValidationSplit(crossValidateDatasetManager.Dataset, crossValidateDatasetManager.Fold, crossValidateDatasetManager.SamplingKeyColumnName);
                 var metrics = new List<double>();
                 var models = new List<ITransformer>();
                 foreach (var split in datasetSplit)

--- a/src/Microsoft.ML.Fairlearn/AutoML/AutoMLExperimentExtension.cs
+++ b/src/Microsoft.ML.Fairlearn/AutoML/AutoMLExperimentExtension.cs
@@ -70,8 +70,9 @@ namespace Microsoft.ML.Fairlearn.AutoML
                 var moment = serviceProvider.GetRequiredService<ClassificationMoment>();
                 var datasetManager = serviceProvider.GetRequiredService<TrainValidateDatasetManager>();
                 var pipeline = serviceProvider.GetRequiredService<SweepablePipeline>();
-                return new GridSearchTrailRunner(context, datasetManager.TrainDataset, datasetManager.ValidateDataset, labelColumn, sensitiveColumnName, pipeline, moment);
+                return new GridSearchTrailRunner(context, datasetManager, labelColumn, sensitiveColumnName, pipeline, moment);
             });
+
             experiment.SetRandomSearchTuner();
 
             return experiment;

--- a/test/Microsoft.ML.AutoML.Tests/AutoMLExperimentTests.cs
+++ b/test/Microsoft.ML.AutoML.Tests/AutoMLExperimentTests.cs
@@ -369,7 +369,7 @@ namespace Microsoft.ML.AutoML.Test
             result = await experiment.RunAsync();
             result.Metric.Should().BeGreaterThan(0.5);
             result.TrialSettings.Parameter[nameof(TrainValidateDatasetManager)]["TrainValidateDatasetSubsamplingKey"]
-                .AsType<double>().Should().Be(0.1);
+                .AsType<float>().Should().Be(0.1f);
         }
 
         [Fact]

--- a/test/Microsoft.ML.AutoML.Tests/AutoMLExperimentTests.cs
+++ b/test/Microsoft.ML.AutoML.Tests/AutoMLExperimentTests.cs
@@ -359,6 +359,17 @@ namespace Microsoft.ML.AutoML.Test
 
             var result = await experiment.RunAsync();
             result.Metric.Should().BeGreaterThan(0.5);
+
+            // test subsamping
+            experiment = context.Auto().CreateExperiment();
+            experiment.SetDataset(train, test, true)
+                    .SetRegressionMetric(RegressionMetric.RSquared, label)
+                    .SetPipeline(pipeline)
+                    .SetMaxModelToExplore(1);
+            result = await experiment.RunAsync();
+            result.Metric.Should().BeGreaterThan(0.5);
+            result.TrialSettings.Parameter[nameof(TrainValidateDatasetManager)]["TrainValidateDatasetSubsamplingKey"]
+                .AsType<double>().Should().Be(0.1);
         }
 
         [Fact]

--- a/test/Microsoft.ML.AutoML.Tests/TrainValidaionDatasetManagerTest.cs
+++ b/test/Microsoft.ML.AutoML.Tests/TrainValidaionDatasetManagerTest.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.ML.AutoML.Test;
+using Microsoft.ML.SearchSpace;
+using Microsoft.ML.TestFramework;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.ML.AutoML.Test
+{
+    public class TrainValidaionDatasetManagerTest : BaseTestClass
+    {
+        public TrainValidaionDatasetManagerTest(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void TrainValidationDatasetManagerSubSamplingTest()
+        {
+            var context = new MLContext(1);
+            var dataPath = DatasetUtil.GetUciAdultDataset();
+            var columnInference = context.Auto().InferColumns(dataPath, DatasetUtil.UciAdultLabel);
+            var textLoader = context.Data.CreateTextLoader(columnInference.TextLoaderOptions);
+            var trainData = textLoader.Load(dataPath);
+
+            var trainDataLength = DatasetDimensionsUtil.CountRows(trainData, ulong.MaxValue);
+            trainDataLength.Should().Be(500);
+
+            var trainValidationDatasetManager = new TrainValidateDatasetManager(trainData, trainData, "SubSampleKey");
+
+            var parameter = Parameter.CreateNestedParameter();
+            parameter[nameof(TrainValidateDatasetManager)] = Parameter.CreateNestedParameter();
+            parameter[nameof(TrainValidateDatasetManager)][trainValidationDatasetManager.SubSamplingKey] = Parameter.FromDouble(0.3);
+            var setting = new TrialSettings
+            {
+                Parameter = parameter,
+            };
+
+            var subSampleTrainData = trainValidationDatasetManager.LoadTrainDataset(context, setting);
+            var subSampleTrainDataLength = DatasetDimensionsUtil.CountRows(subSampleTrainData, ulong.MaxValue);
+            subSampleTrainDataLength.Should().Be(150);
+        }
+    }
+}

--- a/test/Microsoft.ML.Tests/TrainerEstimators/TreeEstimators.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/TreeEstimators.cs
@@ -21,8 +21,6 @@ using Microsoft.ML.Transforms;
 using Xunit;
 using FluentAssertions;
 using System.IO;
-using static Microsoft.ML.DataOperationsCatalog;
-using System.Data;
 
 namespace Microsoft.ML.Tests.TrainerEstimators
 {
@@ -50,60 +48,6 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             var transformedDataView = pipe.Fit(dataView).Transform(dataView);
             var model = trainer.Fit(transformedDataView, transformedDataView);
             Done();
-        }
-
-        [Fact]
-        public void FastTreeBinaryEstimatorOnLongLengthArray()
-        {
-            var dataset = ML.Data.LoadFromEnumerable(GenerateIEnumerableWithMaxLongLength());
-            var trainer = ML.BinaryClassification.Trainers.FastTree(
-                new FastTreeBinaryTrainer.Options
-                {
-                    NumberOfThreads = 1,
-                    NumberOfTrees = 10,
-                    NumberOfLeaves = 5,
-                    DiskTranspose = true,
-                    LabelColumnName = nameof(SingleFeatureWithBooleanLabel.Label),
-                    FeatureColumnName = nameof(SingleFeatureWithBooleanLabel.Feature)
-                });
-            TestEstimatorCore(trainer, dataset);
-            Done();
-        }
-
-        class SingleFeatureWithBooleanLabel
-        {
-            public bool Label { get; set; }
-
-            [VectorType(1)]
-            public float[] Feature { get; set; }
-        }
-
-        private IEnumerable<SingleFeatureWithBooleanLabel> GenerateIEnumerableWithMaxLongLength()
-        {
-            var currentLabel = true;
-            var currentFloat = 0f;
-            var length = 0L;
-            var bufferLength = 2 >> 15;
-            var featureBuffer = new float[bufferLength];
-            var labelBuffer = new bool[bufferLength];
-            while (length < int.MaxValue / 2)
-            {
-                for (int i = 0; i < bufferLength; i++)
-                {
-                    featureBuffer[i] = currentFloat;
-                    labelBuffer[i] = currentLabel;
-                    currentFloat++;
-                    currentLabel = !currentLabel;
-                }
-
-                var buffer = Enumerable.Zip(featureBuffer, labelBuffer, (f, l) => new SingleFeatureWithBooleanLabel { Feature = new float[] { f }, Label = l });
-                foreach (var item in buffer)
-                {
-                    yield return item;
-                }
-
-                length += bufferLength;
-            }
         }
 
         [LightGBMFact]


### PR DESCRIPTION
We are excited to review your PR.

So we can do the best job, please check:

- [x] There's a descriptive title that will make sense to other developers some time from now. 
- [x] There's associated issues. All PR's should have issue(s) associated - unless a trivial self-evident change such as fixing a typo. You can use the format `Fixes #nnnn` in your description to cause GitHub to automatically close the issue(s) when your PR is merged.
- [x] Your change description explains what the change does, why you chose your approach, and anything else that reviewers should know.
- [x] You have included any necessary tests in the same PR.

Training on a sub-set of train dataset will help mitigate `OOM` error.
This will be helpful if the training dataset is huge, in which case subsampling won't hurt metric a lot.
Because this feature is mostly useful for massive training dataset, crossValidationDatasetManger won't need it so the subsampling strategy is only added to trainValidationDatasetManager.

fix #https://github.com/dotnet/machinelearning-modelbuilder/issues/2645

