### PR TITLE
Fix dataframe arithmetics for columns having several value buffers (column size is more than 2 Gb)

### DIFF
--- a/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumnArithmetic.cs
+++ b/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumnArithmetic.cs
@@ -313,7 +313,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] == otherSpan[i]);
+                    ret[i + b] = (span[i] == otherSpan[i]);
                 }
             }
         }
@@ -324,7 +324,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] == scalar);
+                    ret[i + b] = (span[i] == scalar);
                 }
             }
         }
@@ -336,7 +336,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] != otherSpan[i]);
+                    ret[i + b] = (span[i] != otherSpan[i]);
                 }
             }
         }
@@ -347,7 +347,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] != scalar);
+                    ret[i + b] = (span[i] != scalar);
                 }
             }
         }
@@ -714,7 +714,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] == otherSpan[i]);
+                    ret[i + b] = (span[i] == otherSpan[i]);
                 }
             }
         }
@@ -725,7 +725,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] == scalar);
+                    ret[i + b] = (span[i] == scalar);
                 }
             }
         }
@@ -737,7 +737,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] != otherSpan[i]);
+                    ret[i + b] = (span[i] != otherSpan[i]);
                 }
             }
         }
@@ -748,7 +748,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] != scalar);
+                    ret[i + b] = (span[i] != scalar);
                 }
             }
         }
@@ -760,7 +760,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] >= otherSpan[i]);
+                    ret[i + b] = (span[i] >= otherSpan[i]);
                 }
             }
         }
@@ -771,7 +771,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] >= scalar);
+                    ret[i + b] = (span[i] >= scalar);
                 }
             }
         }
@@ -783,7 +783,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] <= otherSpan[i]);
+                    ret[i + b] = (span[i] <= otherSpan[i]);
                 }
             }
         }
@@ -794,7 +794,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] <= scalar);
+                    ret[i + b] = (span[i] <= scalar);
                 }
             }
         }
@@ -806,7 +806,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] > otherSpan[i]);
+                    ret[i + b] = (span[i] > otherSpan[i]);
                 }
             }
         }
@@ -817,7 +817,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] > scalar);
+                    ret[i + b] = (span[i] > scalar);
                 }
             }
         }
@@ -829,7 +829,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] < otherSpan[i]);
+                    ret[i + b] = (span[i] < otherSpan[i]);
                 }
             }
         }
@@ -840,7 +840,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] < scalar);
+                    ret[i + b] = (span[i] < scalar);
                 }
             }
         }
@@ -1175,7 +1175,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] == otherSpan[i]);
+                    ret[i + b] = (span[i] == otherSpan[i]);
                 }
             }
         }
@@ -1186,7 +1186,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] == scalar);
+                    ret[i + b] = (span[i] == scalar);
                 }
             }
         }
@@ -1198,7 +1198,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] != otherSpan[i]);
+                    ret[i + b] = (span[i] != otherSpan[i]);
                 }
             }
         }
@@ -1209,7 +1209,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] != scalar);
+                    ret[i + b] = (span[i] != scalar);
                 }
             }
         }
@@ -1221,7 +1221,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] >= otherSpan[i]);
+                    ret[i + b] = (span[i] >= otherSpan[i]);
                 }
             }
         }
@@ -1232,7 +1232,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] >= scalar);
+                    ret[i + b] = (span[i] >= scalar);
                 }
             }
         }
@@ -1244,7 +1244,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] <= otherSpan[i]);
+                    ret[i + b] = (span[i] <= otherSpan[i]);
                 }
             }
         }
@@ -1255,7 +1255,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] <= scalar);
+                    ret[i + b] = (span[i] <= scalar);
                 }
             }
         }
@@ -1267,7 +1267,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] > otherSpan[i]);
+                    ret[i + b] = (span[i] > otherSpan[i]);
                 }
             }
         }
@@ -1278,7 +1278,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] > scalar);
+                    ret[i + b] = (span[i] > scalar);
                 }
             }
         }
@@ -1290,7 +1290,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] < otherSpan[i]);
+                    ret[i + b] = (span[i] < otherSpan[i]);
                 }
             }
         }
@@ -1301,7 +1301,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] < scalar);
+                    ret[i + b] = (span[i] < scalar);
                 }
             }
         }
@@ -1545,7 +1545,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] == otherSpan[i]);
+                    ret[i + b] = (span[i] == otherSpan[i]);
                 }
             }
         }
@@ -1556,7 +1556,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] == scalar);
+                    ret[i + b] = (span[i] == scalar);
                 }
             }
         }
@@ -1568,7 +1568,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] != otherSpan[i]);
+                    ret[i + b] = (span[i] != otherSpan[i]);
                 }
             }
         }
@@ -1579,7 +1579,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] != scalar);
+                    ret[i + b] = (span[i] != scalar);
                 }
             }
         }
@@ -1591,7 +1591,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] >= otherSpan[i]);
+                    ret[i + b] = (span[i] >= otherSpan[i]);
                 }
             }
         }
@@ -1602,7 +1602,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] >= scalar);
+                    ret[i + b] = (span[i] >= scalar);
                 }
             }
         }
@@ -1614,7 +1614,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] <= otherSpan[i]);
+                    ret[i + b] = (span[i] <= otherSpan[i]);
                 }
             }
         }
@@ -1625,7 +1625,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] <= scalar);
+                    ret[i + b] = (span[i] <= scalar);
                 }
             }
         }
@@ -1637,7 +1637,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] > otherSpan[i]);
+                    ret[i + b] = (span[i] > otherSpan[i]);
                 }
             }
         }
@@ -1648,7 +1648,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] > scalar);
+                    ret[i + b] = (span[i] > scalar);
                 }
             }
         }
@@ -1660,7 +1660,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] < otherSpan[i]);
+                    ret[i + b] = (span[i] < otherSpan[i]);
                 }
             }
         }
@@ -1671,7 +1671,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] < scalar);
+                    ret[i + b] = (span[i] < scalar);
                 }
             }
         }
@@ -1915,7 +1915,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] == otherSpan[i]);
+                    ret[i + b] = (span[i] == otherSpan[i]);
                 }
             }
         }
@@ -1926,7 +1926,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] == scalar);
+                    ret[i + b] = (span[i] == scalar);
                 }
             }
         }
@@ -1938,7 +1938,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] != otherSpan[i]);
+                    ret[i + b] = (span[i] != otherSpan[i]);
                 }
             }
         }
@@ -1949,7 +1949,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] != scalar);
+                    ret[i + b] = (span[i] != scalar);
                 }
             }
         }
@@ -1961,7 +1961,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] >= otherSpan[i]);
+                    ret[i + b] = (span[i] >= otherSpan[i]);
                 }
             }
         }
@@ -1972,7 +1972,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] >= scalar);
+                    ret[i + b] = (span[i] >= scalar);
                 }
             }
         }
@@ -1984,7 +1984,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] <= otherSpan[i]);
+                    ret[i + b] = (span[i] <= otherSpan[i]);
                 }
             }
         }
@@ -1995,7 +1995,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] <= scalar);
+                    ret[i + b] = (span[i] <= scalar);
                 }
             }
         }
@@ -2007,7 +2007,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] > otherSpan[i]);
+                    ret[i + b] = (span[i] > otherSpan[i]);
                 }
             }
         }
@@ -2018,7 +2018,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] > scalar);
+                    ret[i + b] = (span[i] > scalar);
                 }
             }
         }
@@ -2030,7 +2030,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] < otherSpan[i]);
+                    ret[i + b] = (span[i] < otherSpan[i]);
                 }
             }
         }
@@ -2041,7 +2041,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] < scalar);
+                    ret[i + b] = (span[i] < scalar);
                 }
             }
         }
@@ -2285,7 +2285,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] == otherSpan[i]);
+                    ret[i + b] = (span[i] == otherSpan[i]);
                 }
             }
         }
@@ -2296,7 +2296,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] == scalar);
+                    ret[i + b] = (span[i] == scalar);
                 }
             }
         }
@@ -2308,7 +2308,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] != otherSpan[i]);
+                    ret[i + b] = (span[i] != otherSpan[i]);
                 }
             }
         }
@@ -2319,7 +2319,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] != scalar);
+                    ret[i + b] = (span[i] != scalar);
                 }
             }
         }
@@ -2331,7 +2331,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] >= otherSpan[i]);
+                    ret[i + b] = (span[i] >= otherSpan[i]);
                 }
             }
         }
@@ -2342,7 +2342,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] >= scalar);
+                    ret[i + b] = (span[i] >= scalar);
                 }
             }
         }
@@ -2354,7 +2354,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] <= otherSpan[i]);
+                    ret[i + b] = (span[i] <= otherSpan[i]);
                 }
             }
         }
@@ -2365,7 +2365,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] <= scalar);
+                    ret[i + b] = (span[i] <= scalar);
                 }
             }
         }
@@ -2377,7 +2377,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] > otherSpan[i]);
+                    ret[i + b] = (span[i] > otherSpan[i]);
                 }
             }
         }
@@ -2388,7 +2388,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] > scalar);
+                    ret[i + b] = (span[i] > scalar);
                 }
             }
         }
@@ -2400,7 +2400,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] < otherSpan[i]);
+                    ret[i + b] = (span[i] < otherSpan[i]);
                 }
             }
         }
@@ -2411,7 +2411,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] < scalar);
+                    ret[i + b] = (span[i] < scalar);
                 }
             }
         }
@@ -2746,7 +2746,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] == otherSpan[i]);
+                    ret[i + b] = (span[i] == otherSpan[i]);
                 }
             }
         }
@@ -2757,7 +2757,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] == scalar);
+                    ret[i + b] = (span[i] == scalar);
                 }
             }
         }
@@ -2769,7 +2769,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] != otherSpan[i]);
+                    ret[i + b] = (span[i] != otherSpan[i]);
                 }
             }
         }
@@ -2780,7 +2780,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] != scalar);
+                    ret[i + b] = (span[i] != scalar);
                 }
             }
         }
@@ -2792,7 +2792,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] >= otherSpan[i]);
+                    ret[i + b] = (span[i] >= otherSpan[i]);
                 }
             }
         }
@@ -2803,7 +2803,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] >= scalar);
+                    ret[i + b] = (span[i] >= scalar);
                 }
             }
         }
@@ -2815,7 +2815,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] <= otherSpan[i]);
+                    ret[i + b] = (span[i] <= otherSpan[i]);
                 }
             }
         }
@@ -2826,7 +2826,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] <= scalar);
+                    ret[i + b] = (span[i] <= scalar);
                 }
             }
         }
@@ -2838,7 +2838,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] > otherSpan[i]);
+                    ret[i + b] = (span[i] > otherSpan[i]);
                 }
             }
         }
@@ -2849,7 +2849,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] > scalar);
+                    ret[i + b] = (span[i] > scalar);
                 }
             }
         }
@@ -2861,7 +2861,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] < otherSpan[i]);
+                    ret[i + b] = (span[i] < otherSpan[i]);
                 }
             }
         }
@@ -2872,7 +2872,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] < scalar);
+                    ret[i + b] = (span[i] < scalar);
                 }
             }
         }
@@ -3207,7 +3207,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] == otherSpan[i]);
+                    ret[i + b] = (span[i] == otherSpan[i]);
                 }
             }
         }
@@ -3218,7 +3218,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] == scalar);
+                    ret[i + b] = (span[i] == scalar);
                 }
             }
         }
@@ -3230,7 +3230,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] != otherSpan[i]);
+                    ret[i + b] = (span[i] != otherSpan[i]);
                 }
             }
         }
@@ -3241,7 +3241,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] != scalar);
+                    ret[i + b] = (span[i] != scalar);
                 }
             }
         }
@@ -3253,7 +3253,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] >= otherSpan[i]);
+                    ret[i + b] = (span[i] >= otherSpan[i]);
                 }
             }
         }
@@ -3264,7 +3264,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] >= scalar);
+                    ret[i + b] = (span[i] >= scalar);
                 }
             }
         }
@@ -3276,7 +3276,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] <= otherSpan[i]);
+                    ret[i + b] = (span[i] <= otherSpan[i]);
                 }
             }
         }
@@ -3287,7 +3287,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] <= scalar);
+                    ret[i + b] = (span[i] <= scalar);
                 }
             }
         }
@@ -3299,7 +3299,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] > otherSpan[i]);
+                    ret[i + b] = (span[i] > otherSpan[i]);
                 }
             }
         }
@@ -3310,7 +3310,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] > scalar);
+                    ret[i + b] = (span[i] > scalar);
                 }
             }
         }
@@ -3322,7 +3322,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] < otherSpan[i]);
+                    ret[i + b] = (span[i] < otherSpan[i]);
                 }
             }
         }
@@ -3333,7 +3333,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] < scalar);
+                    ret[i + b] = (span[i] < scalar);
                 }
             }
         }
@@ -3668,7 +3668,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] == otherSpan[i]);
+                    ret[i + b] = (span[i] == otherSpan[i]);
                 }
             }
         }
@@ -3679,7 +3679,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] == scalar);
+                    ret[i + b] = (span[i] == scalar);
                 }
             }
         }
@@ -3691,7 +3691,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] != otherSpan[i]);
+                    ret[i + b] = (span[i] != otherSpan[i]);
                 }
             }
         }
@@ -3702,7 +3702,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] != scalar);
+                    ret[i + b] = (span[i] != scalar);
                 }
             }
         }
@@ -3714,7 +3714,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] >= otherSpan[i]);
+                    ret[i + b] = (span[i] >= otherSpan[i]);
                 }
             }
         }
@@ -3725,7 +3725,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] >= scalar);
+                    ret[i + b] = (span[i] >= scalar);
                 }
             }
         }
@@ -3737,7 +3737,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] <= otherSpan[i]);
+                    ret[i + b] = (span[i] <= otherSpan[i]);
                 }
             }
         }
@@ -3748,7 +3748,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] <= scalar);
+                    ret[i + b] = (span[i] <= scalar);
                 }
             }
         }
@@ -3760,7 +3760,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] > otherSpan[i]);
+                    ret[i + b] = (span[i] > otherSpan[i]);
                 }
             }
         }
@@ -3771,7 +3771,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] > scalar);
+                    ret[i + b] = (span[i] > scalar);
                 }
             }
         }
@@ -3783,7 +3783,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] < otherSpan[i]);
+                    ret[i + b] = (span[i] < otherSpan[i]);
                 }
             }
         }
@@ -3794,7 +3794,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] < scalar);
+                    ret[i + b] = (span[i] < scalar);
                 }
             }
         }
@@ -4129,7 +4129,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] == otherSpan[i]);
+                    ret[i + b] = (span[i] == otherSpan[i]);
                 }
             }
         }
@@ -4140,7 +4140,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] == scalar);
+                    ret[i + b] = (span[i] == scalar);
                 }
             }
         }
@@ -4152,7 +4152,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] != otherSpan[i]);
+                    ret[i + b] = (span[i] != otherSpan[i]);
                 }
             }
         }
@@ -4163,7 +4163,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] != scalar);
+                    ret[i + b] = (span[i] != scalar);
                 }
             }
         }
@@ -4175,7 +4175,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] >= otherSpan[i]);
+                    ret[i + b] = (span[i] >= otherSpan[i]);
                 }
             }
         }
@@ -4186,7 +4186,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] >= scalar);
+                    ret[i + b] = (span[i] >= scalar);
                 }
             }
         }
@@ -4198,7 +4198,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] <= otherSpan[i]);
+                    ret[i + b] = (span[i] <= otherSpan[i]);
                 }
             }
         }
@@ -4209,7 +4209,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] <= scalar);
+                    ret[i + b] = (span[i] <= scalar);
                 }
             }
         }
@@ -4221,7 +4221,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] > otherSpan[i]);
+                    ret[i + b] = (span[i] > otherSpan[i]);
                 }
             }
         }
@@ -4232,7 +4232,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] > scalar);
+                    ret[i + b] = (span[i] > scalar);
                 }
             }
         }
@@ -4244,7 +4244,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] < otherSpan[i]);
+                    ret[i + b] = (span[i] < otherSpan[i]);
                 }
             }
         }
@@ -4255,7 +4255,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] < scalar);
+                    ret[i + b] = (span[i] < scalar);
                 }
             }
         }
@@ -4590,7 +4590,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] == otherSpan[i]);
+                    ret[i + b] = (span[i] == otherSpan[i]);
                 }
             }
         }
@@ -4601,7 +4601,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] == scalar);
+                    ret[i + b] = (span[i] == scalar);
                 }
             }
         }
@@ -4613,7 +4613,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] != otherSpan[i]);
+                    ret[i + b] = (span[i] != otherSpan[i]);
                 }
             }
         }
@@ -4624,7 +4624,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] != scalar);
+                    ret[i + b] = (span[i] != scalar);
                 }
             }
         }
@@ -4636,7 +4636,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] >= otherSpan[i]);
+                    ret[i + b] = (span[i] >= otherSpan[i]);
                 }
             }
         }
@@ -4647,7 +4647,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] >= scalar);
+                    ret[i + b] = (span[i] >= scalar);
                 }
             }
         }
@@ -4659,7 +4659,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] <= otherSpan[i]);
+                    ret[i + b] = (span[i] <= otherSpan[i]);
                 }
             }
         }
@@ -4670,7 +4670,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] <= scalar);
+                    ret[i + b] = (span[i] <= scalar);
                 }
             }
         }
@@ -4682,7 +4682,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] > otherSpan[i]);
+                    ret[i + b] = (span[i] > otherSpan[i]);
                 }
             }
         }
@@ -4693,7 +4693,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] > scalar);
+                    ret[i + b] = (span[i] > scalar);
                 }
             }
         }
@@ -4705,7 +4705,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] < otherSpan[i]);
+                    ret[i + b] = (span[i] < otherSpan[i]);
                 }
             }
         }
@@ -4716,7 +4716,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] < scalar);
+                    ret[i + b] = (span[i] < scalar);
                 }
             }
         }
@@ -5051,7 +5051,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] == otherSpan[i]);
+                    ret[i + b] = (span[i] == otherSpan[i]);
                 }
             }
         }
@@ -5062,7 +5062,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] == scalar);
+                    ret[i + b] = (span[i] == scalar);
                 }
             }
         }
@@ -5074,7 +5074,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] != otherSpan[i]);
+                    ret[i + b] = (span[i] != otherSpan[i]);
                 }
             }
         }
@@ -5085,7 +5085,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] != scalar);
+                    ret[i + b] = (span[i] != scalar);
                 }
             }
         }
@@ -5097,7 +5097,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] >= otherSpan[i]);
+                    ret[i + b] = (span[i] >= otherSpan[i]);
                 }
             }
         }
@@ -5108,7 +5108,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] >= scalar);
+                    ret[i + b] = (span[i] >= scalar);
                 }
             }
         }
@@ -5120,7 +5120,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] <= otherSpan[i]);
+                    ret[i + b] = (span[i] <= otherSpan[i]);
                 }
             }
         }
@@ -5131,7 +5131,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] <= scalar);
+                    ret[i + b] = (span[i] <= scalar);
                 }
             }
         }
@@ -5143,7 +5143,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] > otherSpan[i]);
+                    ret[i + b] = (span[i] > otherSpan[i]);
                 }
             }
         }
@@ -5154,7 +5154,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] > scalar);
+                    ret[i + b] = (span[i] > scalar);
                 }
             }
         }
@@ -5166,7 +5166,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] < otherSpan[i]);
+                    ret[i + b] = (span[i] < otherSpan[i]);
                 }
             }
         }
@@ -5177,7 +5177,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] < scalar);
+                    ret[i + b] = (span[i] < scalar);
                 }
             }
         }
@@ -5512,7 +5512,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] == otherSpan[i]);
+                    ret[i + b] = (span[i] == otherSpan[i]);
                 }
             }
         }
@@ -5523,7 +5523,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] == scalar);
+                    ret[i + b] = (span[i] == scalar);
                 }
             }
         }
@@ -5535,7 +5535,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] != otherSpan[i]);
+                    ret[i + b] = (span[i] != otherSpan[i]);
                 }
             }
         }
@@ -5546,7 +5546,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] != scalar);
+                    ret[i + b] = (span[i] != scalar);
                 }
             }
         }
@@ -5558,7 +5558,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] >= otherSpan[i]);
+                    ret[i + b] = (span[i] >= otherSpan[i]);
                 }
             }
         }
@@ -5569,7 +5569,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] >= scalar);
+                    ret[i + b] = (span[i] >= scalar);
                 }
             }
         }
@@ -5581,7 +5581,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] <= otherSpan[i]);
+                    ret[i + b] = (span[i] <= otherSpan[i]);
                 }
             }
         }
@@ -5592,7 +5592,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] <= scalar);
+                    ret[i + b] = (span[i] <= scalar);
                 }
             }
         }
@@ -5604,7 +5604,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] > otherSpan[i]);
+                    ret[i + b] = (span[i] > otherSpan[i]);
                 }
             }
         }
@@ -5615,7 +5615,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] > scalar);
+                    ret[i + b] = (span[i] > scalar);
                 }
             }
         }
@@ -5627,7 +5627,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] < otherSpan[i]);
+                    ret[i + b] = (span[i] < otherSpan[i]);
                 }
             }
         }
@@ -5638,7 +5638,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] < scalar);
+                    ret[i + b] = (span[i] < scalar);
                 }
             }
         }
@@ -5757,7 +5757,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] == otherSpan[i]);
+                    ret[i + b] = (span[i] == otherSpan[i]);
                 }
             }
         }
@@ -5768,7 +5768,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] == scalar);
+                    ret[i + b] = (span[i] == scalar);
                 }
             }
         }
@@ -5780,7 +5780,7 @@ namespace Microsoft.Data.Analysis
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] != otherSpan[i]);
+                    ret[i + b] = (span[i] != otherSpan[i]);
                 }
             }
         }
@@ -5791,7 +5791,7 @@ namespace Microsoft.Data.Analysis
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i] = (span[i] != scalar);
+                    ret[i + b] = (span[i] != scalar);
                 }
             }
         }

--- a/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumnArithmetic.cs
+++ b/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumnArithmetic.cs
@@ -307,47 +307,51 @@ namespace Microsoft.Data.Analysis
         }
         public void ElementwiseEquals(PrimitiveColumnContainer<bool> left, PrimitiveColumnContainer<bool> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] == otherSpan[i]);
+                    ret[index++] = (span[i] == otherSpan[i]);
                 }
             }
         }
         public void ElementwiseEquals(PrimitiveColumnContainer<bool> column, bool scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] == scalar);
+                    ret[index++] = (span[i] == scalar);
                 }
             }
         }
         public void ElementwiseNotEquals(PrimitiveColumnContainer<bool> left, PrimitiveColumnContainer<bool> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] != otherSpan[i]);
+                    ret[index++] = (span[i] != otherSpan[i]);
                 }
             }
         }
         public void ElementwiseNotEquals(PrimitiveColumnContainer<bool> column, bool scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] != scalar);
+                    ret[index++] = (span[i] != scalar);
                 }
             }
         }
@@ -708,139 +712,151 @@ namespace Microsoft.Data.Analysis
         }
         public void ElementwiseEquals(PrimitiveColumnContainer<byte> left, PrimitiveColumnContainer<byte> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] == otherSpan[i]);
+                    ret[index++] = (span[i] == otherSpan[i]);
                 }
             }
         }
         public void ElementwiseEquals(PrimitiveColumnContainer<byte> column, byte scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] == scalar);
+                    ret[index++] = (span[i] == scalar);
                 }
             }
         }
         public void ElementwiseNotEquals(PrimitiveColumnContainer<byte> left, PrimitiveColumnContainer<byte> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] != otherSpan[i]);
+                    ret[index++] = (span[i] != otherSpan[i]);
                 }
             }
         }
         public void ElementwiseNotEquals(PrimitiveColumnContainer<byte> column, byte scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] != scalar);
+                    ret[index++] = (span[i] != scalar);
                 }
             }
         }
         public void ElementwiseGreaterThanOrEqual(PrimitiveColumnContainer<byte> left, PrimitiveColumnContainer<byte> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] >= otherSpan[i]);
+                    ret[index++] = (span[i] >= otherSpan[i]);
                 }
             }
         }
         public void ElementwiseGreaterThanOrEqual(PrimitiveColumnContainer<byte> column, byte scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] >= scalar);
+                    ret[index++] = (span[i] >= scalar);
                 }
             }
         }
         public void ElementwiseLessThanOrEqual(PrimitiveColumnContainer<byte> left, PrimitiveColumnContainer<byte> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] <= otherSpan[i]);
+                    ret[index++] = (span[i] <= otherSpan[i]);
                 }
             }
         }
         public void ElementwiseLessThanOrEqual(PrimitiveColumnContainer<byte> column, byte scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] <= scalar);
+                    ret[index++] = (span[i] <= scalar);
                 }
             }
         }
         public void ElementwiseGreaterThan(PrimitiveColumnContainer<byte> left, PrimitiveColumnContainer<byte> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] > otherSpan[i]);
+                    ret[index++] = (span[i] > otherSpan[i]);
                 }
             }
         }
         public void ElementwiseGreaterThan(PrimitiveColumnContainer<byte> column, byte scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] > scalar);
+                    ret[index++] = (span[i] > scalar);
                 }
             }
         }
         public void ElementwiseLessThan(PrimitiveColumnContainer<byte> left, PrimitiveColumnContainer<byte> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] < otherSpan[i]);
+                    ret[index++] = (span[i] < otherSpan[i]);
                 }
             }
         }
         public void ElementwiseLessThan(PrimitiveColumnContainer<byte> column, byte scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] < scalar);
+                    ret[index++] = (span[i] < scalar);
                 }
             }
         }
@@ -1169,139 +1185,151 @@ namespace Microsoft.Data.Analysis
         }
         public void ElementwiseEquals(PrimitiveColumnContainer<char> left, PrimitiveColumnContainer<char> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] == otherSpan[i]);
+                    ret[index++] = (span[i] == otherSpan[i]);
                 }
             }
         }
         public void ElementwiseEquals(PrimitiveColumnContainer<char> column, char scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] == scalar);
+                    ret[index++] = (span[i] == scalar);
                 }
             }
         }
         public void ElementwiseNotEquals(PrimitiveColumnContainer<char> left, PrimitiveColumnContainer<char> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] != otherSpan[i]);
+                    ret[index++] = (span[i] != otherSpan[i]);
                 }
             }
         }
         public void ElementwiseNotEquals(PrimitiveColumnContainer<char> column, char scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] != scalar);
+                    ret[index++] = (span[i] != scalar);
                 }
             }
         }
         public void ElementwiseGreaterThanOrEqual(PrimitiveColumnContainer<char> left, PrimitiveColumnContainer<char> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] >= otherSpan[i]);
+                    ret[index++] = (span[i] >= otherSpan[i]);
                 }
             }
         }
         public void ElementwiseGreaterThanOrEqual(PrimitiveColumnContainer<char> column, char scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] >= scalar);
+                    ret[index++] = (span[i] >= scalar);
                 }
             }
         }
         public void ElementwiseLessThanOrEqual(PrimitiveColumnContainer<char> left, PrimitiveColumnContainer<char> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] <= otherSpan[i]);
+                    ret[index++] = (span[i] <= otherSpan[i]);
                 }
             }
         }
         public void ElementwiseLessThanOrEqual(PrimitiveColumnContainer<char> column, char scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] <= scalar);
+                    ret[index++] = (span[i] <= scalar);
                 }
             }
         }
         public void ElementwiseGreaterThan(PrimitiveColumnContainer<char> left, PrimitiveColumnContainer<char> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] > otherSpan[i]);
+                    ret[index++] = (span[i] > otherSpan[i]);
                 }
             }
         }
         public void ElementwiseGreaterThan(PrimitiveColumnContainer<char> column, char scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] > scalar);
+                    ret[index++] = (span[i] > scalar);
                 }
             }
         }
         public void ElementwiseLessThan(PrimitiveColumnContainer<char> left, PrimitiveColumnContainer<char> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] < otherSpan[i]);
+                    ret[index++] = (span[i] < otherSpan[i]);
                 }
             }
         }
         public void ElementwiseLessThan(PrimitiveColumnContainer<char> column, char scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] < scalar);
+                    ret[index++] = (span[i] < scalar);
                 }
             }
         }
@@ -1539,139 +1567,151 @@ namespace Microsoft.Data.Analysis
         }
         public void ElementwiseEquals(PrimitiveColumnContainer<decimal> left, PrimitiveColumnContainer<decimal> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] == otherSpan[i]);
+                    ret[index++] = (span[i] == otherSpan[i]);
                 }
             }
         }
         public void ElementwiseEquals(PrimitiveColumnContainer<decimal> column, decimal scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] == scalar);
+                    ret[index++] = (span[i] == scalar);
                 }
             }
         }
         public void ElementwiseNotEquals(PrimitiveColumnContainer<decimal> left, PrimitiveColumnContainer<decimal> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] != otherSpan[i]);
+                    ret[index++] = (span[i] != otherSpan[i]);
                 }
             }
         }
         public void ElementwiseNotEquals(PrimitiveColumnContainer<decimal> column, decimal scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] != scalar);
+                    ret[index++] = (span[i] != scalar);
                 }
             }
         }
         public void ElementwiseGreaterThanOrEqual(PrimitiveColumnContainer<decimal> left, PrimitiveColumnContainer<decimal> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] >= otherSpan[i]);
+                    ret[index++] = (span[i] >= otherSpan[i]);
                 }
             }
         }
         public void ElementwiseGreaterThanOrEqual(PrimitiveColumnContainer<decimal> column, decimal scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] >= scalar);
+                    ret[index++] = (span[i] >= scalar);
                 }
             }
         }
         public void ElementwiseLessThanOrEqual(PrimitiveColumnContainer<decimal> left, PrimitiveColumnContainer<decimal> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] <= otherSpan[i]);
+                    ret[index++] = (span[i] <= otherSpan[i]);
                 }
             }
         }
         public void ElementwiseLessThanOrEqual(PrimitiveColumnContainer<decimal> column, decimal scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] <= scalar);
+                    ret[index++] = (span[i] <= scalar);
                 }
             }
         }
         public void ElementwiseGreaterThan(PrimitiveColumnContainer<decimal> left, PrimitiveColumnContainer<decimal> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] > otherSpan[i]);
+                    ret[index++] = (span[i] > otherSpan[i]);
                 }
             }
         }
         public void ElementwiseGreaterThan(PrimitiveColumnContainer<decimal> column, decimal scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] > scalar);
+                    ret[index++] = (span[i] > scalar);
                 }
             }
         }
         public void ElementwiseLessThan(PrimitiveColumnContainer<decimal> left, PrimitiveColumnContainer<decimal> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] < otherSpan[i]);
+                    ret[index++] = (span[i] < otherSpan[i]);
                 }
             }
         }
         public void ElementwiseLessThan(PrimitiveColumnContainer<decimal> column, decimal scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] < scalar);
+                    ret[index++] = (span[i] < scalar);
                 }
             }
         }
@@ -1909,139 +1949,151 @@ namespace Microsoft.Data.Analysis
         }
         public void ElementwiseEquals(PrimitiveColumnContainer<double> left, PrimitiveColumnContainer<double> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] == otherSpan[i]);
+                    ret[index++] = (span[i] == otherSpan[i]);
                 }
             }
         }
         public void ElementwiseEquals(PrimitiveColumnContainer<double> column, double scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] == scalar);
+                    ret[index++] = (span[i] == scalar);
                 }
             }
         }
         public void ElementwiseNotEquals(PrimitiveColumnContainer<double> left, PrimitiveColumnContainer<double> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] != otherSpan[i]);
+                    ret[index++] = (span[i] != otherSpan[i]);
                 }
             }
         }
         public void ElementwiseNotEquals(PrimitiveColumnContainer<double> column, double scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] != scalar);
+                    ret[index++] = (span[i] != scalar);
                 }
             }
         }
         public void ElementwiseGreaterThanOrEqual(PrimitiveColumnContainer<double> left, PrimitiveColumnContainer<double> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] >= otherSpan[i]);
+                    ret[index++] = (span[i] >= otherSpan[i]);
                 }
             }
         }
         public void ElementwiseGreaterThanOrEqual(PrimitiveColumnContainer<double> column, double scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] >= scalar);
+                    ret[index++] = (span[i] >= scalar);
                 }
             }
         }
         public void ElementwiseLessThanOrEqual(PrimitiveColumnContainer<double> left, PrimitiveColumnContainer<double> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] <= otherSpan[i]);
+                    ret[index++] = (span[i] <= otherSpan[i]);
                 }
             }
         }
         public void ElementwiseLessThanOrEqual(PrimitiveColumnContainer<double> column, double scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] <= scalar);
+                    ret[index++] = (span[i] <= scalar);
                 }
             }
         }
         public void ElementwiseGreaterThan(PrimitiveColumnContainer<double> left, PrimitiveColumnContainer<double> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] > otherSpan[i]);
+                    ret[index++] = (span[i] > otherSpan[i]);
                 }
             }
         }
         public void ElementwiseGreaterThan(PrimitiveColumnContainer<double> column, double scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] > scalar);
+                    ret[index++] = (span[i] > scalar);
                 }
             }
         }
         public void ElementwiseLessThan(PrimitiveColumnContainer<double> left, PrimitiveColumnContainer<double> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] < otherSpan[i]);
+                    ret[index++] = (span[i] < otherSpan[i]);
                 }
             }
         }
         public void ElementwiseLessThan(PrimitiveColumnContainer<double> column, double scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] < scalar);
+                    ret[index++] = (span[i] < scalar);
                 }
             }
         }
@@ -2279,139 +2331,151 @@ namespace Microsoft.Data.Analysis
         }
         public void ElementwiseEquals(PrimitiveColumnContainer<float> left, PrimitiveColumnContainer<float> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] == otherSpan[i]);
+                    ret[index++] = (span[i] == otherSpan[i]);
                 }
             }
         }
         public void ElementwiseEquals(PrimitiveColumnContainer<float> column, float scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] == scalar);
+                    ret[index++] = (span[i] == scalar);
                 }
             }
         }
         public void ElementwiseNotEquals(PrimitiveColumnContainer<float> left, PrimitiveColumnContainer<float> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] != otherSpan[i]);
+                    ret[index++] = (span[i] != otherSpan[i]);
                 }
             }
         }
         public void ElementwiseNotEquals(PrimitiveColumnContainer<float> column, float scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] != scalar);
+                    ret[index++] = (span[i] != scalar);
                 }
             }
         }
         public void ElementwiseGreaterThanOrEqual(PrimitiveColumnContainer<float> left, PrimitiveColumnContainer<float> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] >= otherSpan[i]);
+                    ret[index++] = (span[i] >= otherSpan[i]);
                 }
             }
         }
         public void ElementwiseGreaterThanOrEqual(PrimitiveColumnContainer<float> column, float scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] >= scalar);
+                    ret[index++] = (span[i] >= scalar);
                 }
             }
         }
         public void ElementwiseLessThanOrEqual(PrimitiveColumnContainer<float> left, PrimitiveColumnContainer<float> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] <= otherSpan[i]);
+                    ret[index++] = (span[i] <= otherSpan[i]);
                 }
             }
         }
         public void ElementwiseLessThanOrEqual(PrimitiveColumnContainer<float> column, float scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] <= scalar);
+                    ret[index++] = (span[i] <= scalar);
                 }
             }
         }
         public void ElementwiseGreaterThan(PrimitiveColumnContainer<float> left, PrimitiveColumnContainer<float> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] > otherSpan[i]);
+                    ret[index++] = (span[i] > otherSpan[i]);
                 }
             }
         }
         public void ElementwiseGreaterThan(PrimitiveColumnContainer<float> column, float scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] > scalar);
+                    ret[index++] = (span[i] > scalar);
                 }
             }
         }
         public void ElementwiseLessThan(PrimitiveColumnContainer<float> left, PrimitiveColumnContainer<float> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] < otherSpan[i]);
+                    ret[index++] = (span[i] < otherSpan[i]);
                 }
             }
         }
         public void ElementwiseLessThan(PrimitiveColumnContainer<float> column, float scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] < scalar);
+                    ret[index++] = (span[i] < scalar);
                 }
             }
         }
@@ -2740,139 +2804,151 @@ namespace Microsoft.Data.Analysis
         }
         public void ElementwiseEquals(PrimitiveColumnContainer<int> left, PrimitiveColumnContainer<int> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] == otherSpan[i]);
+                    ret[index++] = (span[i] == otherSpan[i]);
                 }
             }
         }
         public void ElementwiseEquals(PrimitiveColumnContainer<int> column, int scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] == scalar);
+                    ret[index++] = (span[i] == scalar);
                 }
             }
         }
         public void ElementwiseNotEquals(PrimitiveColumnContainer<int> left, PrimitiveColumnContainer<int> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] != otherSpan[i]);
+                    ret[index++] = (span[i] != otherSpan[i]);
                 }
             }
         }
         public void ElementwiseNotEquals(PrimitiveColumnContainer<int> column, int scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] != scalar);
+                    ret[index++] = (span[i] != scalar);
                 }
             }
         }
         public void ElementwiseGreaterThanOrEqual(PrimitiveColumnContainer<int> left, PrimitiveColumnContainer<int> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] >= otherSpan[i]);
+                    ret[index++] = (span[i] >= otherSpan[i]);
                 }
             }
         }
         public void ElementwiseGreaterThanOrEqual(PrimitiveColumnContainer<int> column, int scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] >= scalar);
+                    ret[index++] = (span[i] >= scalar);
                 }
             }
         }
         public void ElementwiseLessThanOrEqual(PrimitiveColumnContainer<int> left, PrimitiveColumnContainer<int> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] <= otherSpan[i]);
+                    ret[index++] = (span[i] <= otherSpan[i]);
                 }
             }
         }
         public void ElementwiseLessThanOrEqual(PrimitiveColumnContainer<int> column, int scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] <= scalar);
+                    ret[index++] = (span[i] <= scalar);
                 }
             }
         }
         public void ElementwiseGreaterThan(PrimitiveColumnContainer<int> left, PrimitiveColumnContainer<int> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] > otherSpan[i]);
+                    ret[index++] = (span[i] > otherSpan[i]);
                 }
             }
         }
         public void ElementwiseGreaterThan(PrimitiveColumnContainer<int> column, int scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] > scalar);
+                    ret[index++] = (span[i] > scalar);
                 }
             }
         }
         public void ElementwiseLessThan(PrimitiveColumnContainer<int> left, PrimitiveColumnContainer<int> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] < otherSpan[i]);
+                    ret[index++] = (span[i] < otherSpan[i]);
                 }
             }
         }
         public void ElementwiseLessThan(PrimitiveColumnContainer<int> column, int scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] < scalar);
+                    ret[index++] = (span[i] < scalar);
                 }
             }
         }
@@ -3201,139 +3277,151 @@ namespace Microsoft.Data.Analysis
         }
         public void ElementwiseEquals(PrimitiveColumnContainer<long> left, PrimitiveColumnContainer<long> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] == otherSpan[i]);
+                    ret[index++] = (span[i] == otherSpan[i]);
                 }
             }
         }
         public void ElementwiseEquals(PrimitiveColumnContainer<long> column, long scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] == scalar);
+                    ret[index++] = (span[i] == scalar);
                 }
             }
         }
         public void ElementwiseNotEquals(PrimitiveColumnContainer<long> left, PrimitiveColumnContainer<long> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] != otherSpan[i]);
+                    ret[index++] = (span[i] != otherSpan[i]);
                 }
             }
         }
         public void ElementwiseNotEquals(PrimitiveColumnContainer<long> column, long scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] != scalar);
+                    ret[index++] = (span[i] != scalar);
                 }
             }
         }
         public void ElementwiseGreaterThanOrEqual(PrimitiveColumnContainer<long> left, PrimitiveColumnContainer<long> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] >= otherSpan[i]);
+                    ret[index++] = (span[i] >= otherSpan[i]);
                 }
             }
         }
         public void ElementwiseGreaterThanOrEqual(PrimitiveColumnContainer<long> column, long scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] >= scalar);
+                    ret[index++] = (span[i] >= scalar);
                 }
             }
         }
         public void ElementwiseLessThanOrEqual(PrimitiveColumnContainer<long> left, PrimitiveColumnContainer<long> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] <= otherSpan[i]);
+                    ret[index++] = (span[i] <= otherSpan[i]);
                 }
             }
         }
         public void ElementwiseLessThanOrEqual(PrimitiveColumnContainer<long> column, long scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] <= scalar);
+                    ret[index++] = (span[i] <= scalar);
                 }
             }
         }
         public void ElementwiseGreaterThan(PrimitiveColumnContainer<long> left, PrimitiveColumnContainer<long> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] > otherSpan[i]);
+                    ret[index++] = (span[i] > otherSpan[i]);
                 }
             }
         }
         public void ElementwiseGreaterThan(PrimitiveColumnContainer<long> column, long scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] > scalar);
+                    ret[index++] = (span[i] > scalar);
                 }
             }
         }
         public void ElementwiseLessThan(PrimitiveColumnContainer<long> left, PrimitiveColumnContainer<long> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] < otherSpan[i]);
+                    ret[index++] = (span[i] < otherSpan[i]);
                 }
             }
         }
         public void ElementwiseLessThan(PrimitiveColumnContainer<long> column, long scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] < scalar);
+                    ret[index++] = (span[i] < scalar);
                 }
             }
         }
@@ -3662,139 +3750,151 @@ namespace Microsoft.Data.Analysis
         }
         public void ElementwiseEquals(PrimitiveColumnContainer<sbyte> left, PrimitiveColumnContainer<sbyte> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] == otherSpan[i]);
+                    ret[index++] = (span[i] == otherSpan[i]);
                 }
             }
         }
         public void ElementwiseEquals(PrimitiveColumnContainer<sbyte> column, sbyte scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] == scalar);
+                    ret[index++] = (span[i] == scalar);
                 }
             }
         }
         public void ElementwiseNotEquals(PrimitiveColumnContainer<sbyte> left, PrimitiveColumnContainer<sbyte> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] != otherSpan[i]);
+                    ret[index++] = (span[i] != otherSpan[i]);
                 }
             }
         }
         public void ElementwiseNotEquals(PrimitiveColumnContainer<sbyte> column, sbyte scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] != scalar);
+                    ret[index++] = (span[i] != scalar);
                 }
             }
         }
         public void ElementwiseGreaterThanOrEqual(PrimitiveColumnContainer<sbyte> left, PrimitiveColumnContainer<sbyte> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] >= otherSpan[i]);
+                    ret[index++] = (span[i] >= otherSpan[i]);
                 }
             }
         }
         public void ElementwiseGreaterThanOrEqual(PrimitiveColumnContainer<sbyte> column, sbyte scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] >= scalar);
+                    ret[index++] = (span[i] >= scalar);
                 }
             }
         }
         public void ElementwiseLessThanOrEqual(PrimitiveColumnContainer<sbyte> left, PrimitiveColumnContainer<sbyte> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] <= otherSpan[i]);
+                    ret[index++] = (span[i] <= otherSpan[i]);
                 }
             }
         }
         public void ElementwiseLessThanOrEqual(PrimitiveColumnContainer<sbyte> column, sbyte scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] <= scalar);
+                    ret[index++] = (span[i] <= scalar);
                 }
             }
         }
         public void ElementwiseGreaterThan(PrimitiveColumnContainer<sbyte> left, PrimitiveColumnContainer<sbyte> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] > otherSpan[i]);
+                    ret[index++] = (span[i] > otherSpan[i]);
                 }
             }
         }
         public void ElementwiseGreaterThan(PrimitiveColumnContainer<sbyte> column, sbyte scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] > scalar);
+                    ret[index++] = (span[i] > scalar);
                 }
             }
         }
         public void ElementwiseLessThan(PrimitiveColumnContainer<sbyte> left, PrimitiveColumnContainer<sbyte> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] < otherSpan[i]);
+                    ret[index++] = (span[i] < otherSpan[i]);
                 }
             }
         }
         public void ElementwiseLessThan(PrimitiveColumnContainer<sbyte> column, sbyte scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] < scalar);
+                    ret[index++] = (span[i] < scalar);
                 }
             }
         }
@@ -4123,139 +4223,151 @@ namespace Microsoft.Data.Analysis
         }
         public void ElementwiseEquals(PrimitiveColumnContainer<short> left, PrimitiveColumnContainer<short> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] == otherSpan[i]);
+                    ret[index++] = (span[i] == otherSpan[i]);
                 }
             }
         }
         public void ElementwiseEquals(PrimitiveColumnContainer<short> column, short scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] == scalar);
+                    ret[index++] = (span[i] == scalar);
                 }
             }
         }
         public void ElementwiseNotEquals(PrimitiveColumnContainer<short> left, PrimitiveColumnContainer<short> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] != otherSpan[i]);
+                    ret[index++] = (span[i] != otherSpan[i]);
                 }
             }
         }
         public void ElementwiseNotEquals(PrimitiveColumnContainer<short> column, short scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] != scalar);
+                    ret[index++] = (span[i] != scalar);
                 }
             }
         }
         public void ElementwiseGreaterThanOrEqual(PrimitiveColumnContainer<short> left, PrimitiveColumnContainer<short> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] >= otherSpan[i]);
+                    ret[index++] = (span[i] >= otherSpan[i]);
                 }
             }
         }
         public void ElementwiseGreaterThanOrEqual(PrimitiveColumnContainer<short> column, short scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] >= scalar);
+                    ret[index++] = (span[i] >= scalar);
                 }
             }
         }
         public void ElementwiseLessThanOrEqual(PrimitiveColumnContainer<short> left, PrimitiveColumnContainer<short> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] <= otherSpan[i]);
+                    ret[index++] = (span[i] <= otherSpan[i]);
                 }
             }
         }
         public void ElementwiseLessThanOrEqual(PrimitiveColumnContainer<short> column, short scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] <= scalar);
+                    ret[index++] = (span[i] <= scalar);
                 }
             }
         }
         public void ElementwiseGreaterThan(PrimitiveColumnContainer<short> left, PrimitiveColumnContainer<short> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] > otherSpan[i]);
+                    ret[index++] = (span[i] > otherSpan[i]);
                 }
             }
         }
         public void ElementwiseGreaterThan(PrimitiveColumnContainer<short> column, short scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] > scalar);
+                    ret[index++] = (span[i] > scalar);
                 }
             }
         }
         public void ElementwiseLessThan(PrimitiveColumnContainer<short> left, PrimitiveColumnContainer<short> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] < otherSpan[i]);
+                    ret[index++] = (span[i] < otherSpan[i]);
                 }
             }
         }
         public void ElementwiseLessThan(PrimitiveColumnContainer<short> column, short scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] < scalar);
+                    ret[index++] = (span[i] < scalar);
                 }
             }
         }
@@ -4584,139 +4696,151 @@ namespace Microsoft.Data.Analysis
         }
         public void ElementwiseEquals(PrimitiveColumnContainer<uint> left, PrimitiveColumnContainer<uint> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] == otherSpan[i]);
+                    ret[index++] = (span[i] == otherSpan[i]);
                 }
             }
         }
         public void ElementwiseEquals(PrimitiveColumnContainer<uint> column, uint scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] == scalar);
+                    ret[index++] = (span[i] == scalar);
                 }
             }
         }
         public void ElementwiseNotEquals(PrimitiveColumnContainer<uint> left, PrimitiveColumnContainer<uint> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] != otherSpan[i]);
+                    ret[index++] = (span[i] != otherSpan[i]);
                 }
             }
         }
         public void ElementwiseNotEquals(PrimitiveColumnContainer<uint> column, uint scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] != scalar);
+                    ret[index++] = (span[i] != scalar);
                 }
             }
         }
         public void ElementwiseGreaterThanOrEqual(PrimitiveColumnContainer<uint> left, PrimitiveColumnContainer<uint> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] >= otherSpan[i]);
+                    ret[index++] = (span[i] >= otherSpan[i]);
                 }
             }
         }
         public void ElementwiseGreaterThanOrEqual(PrimitiveColumnContainer<uint> column, uint scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] >= scalar);
+                    ret[index++] = (span[i] >= scalar);
                 }
             }
         }
         public void ElementwiseLessThanOrEqual(PrimitiveColumnContainer<uint> left, PrimitiveColumnContainer<uint> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] <= otherSpan[i]);
+                    ret[index++] = (span[i] <= otherSpan[i]);
                 }
             }
         }
         public void ElementwiseLessThanOrEqual(PrimitiveColumnContainer<uint> column, uint scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] <= scalar);
+                    ret[index++] = (span[i] <= scalar);
                 }
             }
         }
         public void ElementwiseGreaterThan(PrimitiveColumnContainer<uint> left, PrimitiveColumnContainer<uint> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] > otherSpan[i]);
+                    ret[index++] = (span[i] > otherSpan[i]);
                 }
             }
         }
         public void ElementwiseGreaterThan(PrimitiveColumnContainer<uint> column, uint scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] > scalar);
+                    ret[index++] = (span[i] > scalar);
                 }
             }
         }
         public void ElementwiseLessThan(PrimitiveColumnContainer<uint> left, PrimitiveColumnContainer<uint> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] < otherSpan[i]);
+                    ret[index++] = (span[i] < otherSpan[i]);
                 }
             }
         }
         public void ElementwiseLessThan(PrimitiveColumnContainer<uint> column, uint scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] < scalar);
+                    ret[index++] = (span[i] < scalar);
                 }
             }
         }
@@ -5045,139 +5169,151 @@ namespace Microsoft.Data.Analysis
         }
         public void ElementwiseEquals(PrimitiveColumnContainer<ulong> left, PrimitiveColumnContainer<ulong> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] == otherSpan[i]);
+                    ret[index++] = (span[i] == otherSpan[i]);
                 }
             }
         }
         public void ElementwiseEquals(PrimitiveColumnContainer<ulong> column, ulong scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] == scalar);
+                    ret[index++] = (span[i] == scalar);
                 }
             }
         }
         public void ElementwiseNotEquals(PrimitiveColumnContainer<ulong> left, PrimitiveColumnContainer<ulong> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] != otherSpan[i]);
+                    ret[index++] = (span[i] != otherSpan[i]);
                 }
             }
         }
         public void ElementwiseNotEquals(PrimitiveColumnContainer<ulong> column, ulong scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] != scalar);
+                    ret[index++] = (span[i] != scalar);
                 }
             }
         }
         public void ElementwiseGreaterThanOrEqual(PrimitiveColumnContainer<ulong> left, PrimitiveColumnContainer<ulong> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] >= otherSpan[i]);
+                    ret[index++] = (span[i] >= otherSpan[i]);
                 }
             }
         }
         public void ElementwiseGreaterThanOrEqual(PrimitiveColumnContainer<ulong> column, ulong scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] >= scalar);
+                    ret[index++] = (span[i] >= scalar);
                 }
             }
         }
         public void ElementwiseLessThanOrEqual(PrimitiveColumnContainer<ulong> left, PrimitiveColumnContainer<ulong> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] <= otherSpan[i]);
+                    ret[index++] = (span[i] <= otherSpan[i]);
                 }
             }
         }
         public void ElementwiseLessThanOrEqual(PrimitiveColumnContainer<ulong> column, ulong scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] <= scalar);
+                    ret[index++] = (span[i] <= scalar);
                 }
             }
         }
         public void ElementwiseGreaterThan(PrimitiveColumnContainer<ulong> left, PrimitiveColumnContainer<ulong> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] > otherSpan[i]);
+                    ret[index++] = (span[i] > otherSpan[i]);
                 }
             }
         }
         public void ElementwiseGreaterThan(PrimitiveColumnContainer<ulong> column, ulong scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] > scalar);
+                    ret[index++] = (span[i] > scalar);
                 }
             }
         }
         public void ElementwiseLessThan(PrimitiveColumnContainer<ulong> left, PrimitiveColumnContainer<ulong> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] < otherSpan[i]);
+                    ret[index++] = (span[i] < otherSpan[i]);
                 }
             }
         }
         public void ElementwiseLessThan(PrimitiveColumnContainer<ulong> column, ulong scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] < scalar);
+                    ret[index++] = (span[i] < scalar);
                 }
             }
         }
@@ -5506,139 +5642,151 @@ namespace Microsoft.Data.Analysis
         }
         public void ElementwiseEquals(PrimitiveColumnContainer<ushort> left, PrimitiveColumnContainer<ushort> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] == otherSpan[i]);
+                    ret[index++] = (span[i] == otherSpan[i]);
                 }
             }
         }
         public void ElementwiseEquals(PrimitiveColumnContainer<ushort> column, ushort scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] == scalar);
+                    ret[index++] = (span[i] == scalar);
                 }
             }
         }
         public void ElementwiseNotEquals(PrimitiveColumnContainer<ushort> left, PrimitiveColumnContainer<ushort> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] != otherSpan[i]);
+                    ret[index++] = (span[i] != otherSpan[i]);
                 }
             }
         }
         public void ElementwiseNotEquals(PrimitiveColumnContainer<ushort> column, ushort scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] != scalar);
+                    ret[index++] = (span[i] != scalar);
                 }
             }
         }
         public void ElementwiseGreaterThanOrEqual(PrimitiveColumnContainer<ushort> left, PrimitiveColumnContainer<ushort> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] >= otherSpan[i]);
+                    ret[index++] = (span[i] >= otherSpan[i]);
                 }
             }
         }
         public void ElementwiseGreaterThanOrEqual(PrimitiveColumnContainer<ushort> column, ushort scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] >= scalar);
+                    ret[index++] = (span[i] >= scalar);
                 }
             }
         }
         public void ElementwiseLessThanOrEqual(PrimitiveColumnContainer<ushort> left, PrimitiveColumnContainer<ushort> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] <= otherSpan[i]);
+                    ret[index++] = (span[i] <= otherSpan[i]);
                 }
             }
         }
         public void ElementwiseLessThanOrEqual(PrimitiveColumnContainer<ushort> column, ushort scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] <= scalar);
+                    ret[index++] = (span[i] <= scalar);
                 }
             }
         }
         public void ElementwiseGreaterThan(PrimitiveColumnContainer<ushort> left, PrimitiveColumnContainer<ushort> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] > otherSpan[i]);
+                    ret[index++] = (span[i] > otherSpan[i]);
                 }
             }
         }
         public void ElementwiseGreaterThan(PrimitiveColumnContainer<ushort> column, ushort scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] > scalar);
+                    ret[index++] = (span[i] > scalar);
                 }
             }
         }
         public void ElementwiseLessThan(PrimitiveColumnContainer<ushort> left, PrimitiveColumnContainer<ushort> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] < otherSpan[i]);
+                    ret[index++] = (span[i] < otherSpan[i]);
                 }
             }
         }
         public void ElementwiseLessThan(PrimitiveColumnContainer<ushort> column, ushort scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] < scalar);
+                    ret[index++] = (span[i] < scalar);
                 }
             }
         }
@@ -5751,47 +5899,51 @@ namespace Microsoft.Data.Analysis
         }
         public void ElementwiseEquals(PrimitiveColumnContainer<DateTime> left, PrimitiveColumnContainer<DateTime> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] == otherSpan[i]);
+                    ret[index++] = (span[i] == otherSpan[i]);
                 }
             }
         }
         public void ElementwiseEquals(PrimitiveColumnContainer<DateTime> column, DateTime scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] == scalar);
+                    ret[index++] = (span[i] == scalar);
                 }
             }
         }
         public void ElementwiseNotEquals(PrimitiveColumnContainer<DateTime> left, PrimitiveColumnContainer<DateTime> right, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < left.Buffers.Count; b++)
             {
                 var span = left.Buffers[b].ReadOnlySpan;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] != otherSpan[i]);
+                    ret[index++] = (span[i] != otherSpan[i]);
                 }
             }
         }
         public void ElementwiseNotEquals(PrimitiveColumnContainer<DateTime> column, DateTime scalar, PrimitiveColumnContainer<bool> ret)
         {
+            long index = 0;
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var span = column.Buffers[b].ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
-                    ret[i + b] = (span[i] != scalar);
+                    ret[index++] = (span[i] != scalar);
                 }
             }
         }

--- a/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumnArithmetic.tt
+++ b/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumnArithmetic.tt
@@ -58,6 +58,9 @@ namespace Microsoft.Data.Analysis
 <# if ((method.IsNumeric && !type.SupportsNumeric) || (method.IsBitwise && !type.SupportsBitwise) || (type.UnsupportedMethods.Contains(method.MethodName))) { #>
             throw new NotSupportedException();
 <# } else if (method.Operator != null) { #>
+<# if (method.MethodType == MethodType.Comparison || method.MethodType == MethodType.ComparisonScalar) { #>
+            long index = 0;
+<# } #>
             for (int b = 0; b < <#= method.Op1Name #>.Buffers.Count; b++)
             {
 <# if (method.MethodType == MethodType.Comparison) { #>
@@ -79,9 +82,9 @@ namespace Microsoft.Data.Analysis
 <# } else if (method.MethodType == MethodType.Binary) { #>
                     span[i] = (<#=type.TypeName#>)(span[i] <#= method.Operator #> otherSpan[i]);
 <# } else if (method.MethodType == MethodType.Comparison) { #>
-                    ret[i + b] = (span[i] <#= method.Operator #> otherSpan[i]);
+                    ret[index++] = (span[i] <#= method.Operator #> otherSpan[i]);
 <# } else if (method.MethodType == MethodType.ComparisonScalar) { #>
-                    ret[i + b] = (span[i] <#= method.Operator #> <#= method.Op2Name #>);
+                    ret[index++] = (span[i] <#= method.Operator #> <#= method.Op2Name #>);
 <# } else {#>
                     throw new NotImplementedException();
 <# } #>

--- a/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumnArithmetic.tt
+++ b/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumnArithmetic.tt
@@ -79,9 +79,9 @@ namespace Microsoft.Data.Analysis
 <# } else if (method.MethodType == MethodType.Binary) { #>
                     span[i] = (<#=type.TypeName#>)(span[i] <#= method.Operator #> otherSpan[i]);
 <# } else if (method.MethodType == MethodType.Comparison) { #>
-                    ret[i] = (span[i] <#= method.Operator #> otherSpan[i]);
+                    ret[i + b] = (span[i] <#= method.Operator #> otherSpan[i]);
 <# } else if (method.MethodType == MethodType.ComparisonScalar) { #>
-                    ret[i] = (span[i] <#= method.Operator #> <#= method.Op2Name #>);
+                    ret[i + b] = (span[i] <#= method.Operator #> <#= method.Op2Name #>);
 <# } else {#>
                     throw new NotImplementedException();
 <# } #>


### PR DESCRIPTION
Arithmetics for columns containg multiple buffers (actualy with size more than 2 Gb) was incorrect. Buffer number was not taken into account

