### PR TITLE
stop shuffle rows in ITrainValidationDatasetManager

### DIFF
--- a/src/Microsoft.ML.AutoML/AutoMLExperiment/IDatasetManager.cs
+++ b/src/Microsoft.ML.AutoML/AutoMLExperiment/IDatasetManager.cs
@@ -94,7 +94,6 @@ namespace Microsoft.ML.AutoML
         private void InitializeTrainDataset(MLContext context)
         {
             _rowCount = DatasetDimensionsUtil.CountRows(_trainDataset, ulong.MaxValue);
-            _trainDataset = context.Data.ShuffleRows(_trainDataset);
         }
     }
 

--- a/src/Microsoft.ML.AutoML/AutoMLExperiment/IDatasetManager.cs
+++ b/src/Microsoft.ML.AutoML/AutoMLExperiment/IDatasetManager.cs
@@ -46,7 +46,7 @@ namespace Microsoft.ML.AutoML
     internal class TrainValidateDatasetManager : IDatasetManager, ITrainValidateDatasetManager
     {
         private ulong _rowCount;
-        private IDataView _trainDataset;
+        private readonly IDataView _trainDataset;
         private readonly IDataView _validateDataset;
         private readonly string _subSamplingKey = "TrainValidateDatasetSubsamplingKey";
         private bool _isInitialized = false;


### PR DESCRIPTION
We are excited to review your PR.

So we can do the best job, please check:

- [x] There's a descriptive title that will make sense to other developers some time from now. 
- [x] There's associated issues. All PR's should have issue(s) associated - unless a trivial self-evident change such as fixing a typo. You can use the format `Fixes #nnnn` in your description to cause GitHub to automatically close the issue(s) when your PR is merged.
- [ ] Your change description explains what the change does, why you chose your approach, and anything else that reviewers should know.
- [ ] You have included any necessary tests in the same PR.

ShuffleRows transformer will drop non-cacheable columns, which causes [this issue](https://github.com/dotnet/machinelearning-modelbuilder/issues/2730)

In the meantime, user can always shuffle rows before sending dataset to AutoML. So in that aspect, shuffling rows in AutoML might not be necessary as well.
