### PR TITLE
Reduce coupling of Data.Analysis.Tests project

### DIFF
--- a/test/Microsoft.Data.Analysis.Tests/DataFrame.IOTests.cs
+++ b/test/Microsoft.Data.Analysis.Tests/DataFrame.IOTests.cs
@@ -1049,7 +1049,7 @@ CMT,";
             Assert.Equal(vals, resVals);
         }
 
-        [X86X64FactAttribute("The SQLite un-managed code, SQLite.interop, only supports x86/x64 architectures.")]
+        [X86X64Fact("The SQLite un-managed code, SQLite.interop, only supports x86/x64 architectures.")]
         public async void TestSQLite()
         {
             var (columns, vals) = GetTestData();

--- a/test/Microsoft.Data.Analysis.Tests/Microsoft.Data.Analysis.Tests.csproj
+++ b/test/Microsoft.Data.Analysis.Tests/Microsoft.Data.Analysis.Tests.csproj
@@ -7,9 +7,7 @@
     <ItemGroup>
         <ProjectReference Include="..\..\src\Microsoft.Data.Analysis\Microsoft.Data.Analysis.csproj" />
         <ProjectReference Include="..\..\src\Microsoft.ML.Data\Microsoft.ML.Data.csproj" />
-        <ProjectReference Include="..\..\src\Microsoft.ML\Microsoft.ML.csproj" />
         <ProjectReference Include="..\Microsoft.ML.TestFrameworkCommon\Microsoft.ML.TestFrameworkCommon.csproj" />
-        <ProjectReference Include="..\Microsoft.ML.TestFramework\Microsoft.ML.TestFramework.csproj" />
         <Compile Include="..\..\src\Microsoft.Data.Analysis\TextFieldParser.cs" />
     </ItemGroup>
 

--- a/test/Microsoft.ML.TestFrameworkCommon/Attributes/X64FactAttribute.cs
+++ b/test/Microsoft.ML.TestFrameworkCommon/Attributes/X64FactAttribute.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using Microsoft.ML.TestFrameworkCommon.Attributes;
 
 namespace Microsoft.ML.TestFramework.Attributes
 {

--- a/test/Microsoft.ML.TestFrameworkCommon/Attributes/X86X64FactAttribute.cs
+++ b/test/Microsoft.ML.TestFrameworkCommon/Attributes/X86X64FactAttribute.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Runtime.InteropServices;
-using Microsoft.ML.TestFrameworkCommon.Attributes;
 
 namespace Microsoft.ML.TestFramework.Attributes
 {


### PR DESCRIPTION
This PR continues work started in https://github.com/dotnet/machinelearning/pull/4346

The aim is to eliminate dependency of Microsoft.Data.Analysis.Tests from overal ML infrastructure. Before this PR it's required to build the overal ML solution (including native cpp projects) for running Unit tests for the DataFrame. Actually all these transative dependencies where the results of using Test attributes (like X86, X86X64 and NotArm32). Moving these attributes out of the Microsoft.ML.TestFramework into light Microsoft.ML.TestFrameworkCommon reduce coupling of tests projects.


