### PR TITLE
Clean DataFrame meaningless code

### DIFF
--- a/src/Microsoft.Data.Analysis/DataFrame.IO.cs
+++ b/src/Microsoft.Data.Analysis/DataFrame.IO.cs
@@ -127,10 +127,6 @@ namespace Microsoft.Data.Analysis
 
             foreach (var items in vals)
             {
-                for (var c = 0; c < items.Count; c++)
-                {
-                    items[c] = items[c];
-                }
                 res.Append(items, inPlace: true);
             }
 

--- a/src/Microsoft.Data.Analysis/PrimitiveColumnContainer.cs
+++ b/src/Microsoft.Data.Analysis/PrimitiveColumnContainer.cs
@@ -44,35 +44,6 @@ namespace Microsoft.Data.Analysis
         // Need a way to differentiate between columns initialized with default values and those with null values in SetValidityBit
         internal bool _modifyNullCountWhileIndexing = true;
 
-        public PrimitiveColumnContainer(T[] values)
-        {
-            values = values ?? throw new ArgumentNullException(nameof(values));
-            long length = values.LongLength;
-            DataFrameBuffer<T> curBuffer;
-            if (Buffers.Count == 0)
-            {
-                curBuffer = new DataFrameBuffer<T>();
-                Buffers.Add(curBuffer);
-                NullBitMapBuffers.Add(new DataFrameBuffer<byte>());
-            }
-            else
-            {
-                curBuffer = (DataFrameBuffer<T>)Buffers[Buffers.Count - 1];
-            }
-            for (long i = 0; i < length; i++)
-            {
-                if (curBuffer.Length == ReadOnlyDataFrameBuffer<T>.MaxCapacity)
-                {
-                    curBuffer = new DataFrameBuffer<T>();
-                    Buffers.Add(curBuffer);
-                    NullBitMapBuffers.Add(new DataFrameBuffer<byte>());
-                }
-                curBuffer.Append(values[i]);
-                SetValidityBit(Length, true);
-                Length++;
-            }
-        }
-
         public PrimitiveColumnContainer(IEnumerable<T> values)
         {
             values = values ?? throw new ArgumentNullException(nameof(values));
@@ -81,6 +52,7 @@ namespace Microsoft.Data.Analysis
                 Append(value);
             }
         }
+
         public PrimitiveColumnContainer(IEnumerable<T?> values)
         {
             values = values ?? throw new ArgumentNullException(nameof(values));


### PR DESCRIPTION
Fixes #6754

1) PrimitiveColumnContainer is internal class, PrimitiveColumnContainer(T[] values) is not used anywhere inside DataFrameProject and there is another constructor that can be used for the same purpose PrimitiveColumnContainer(IEnumerable<T> values). so this unused contructor can be easily removed (taking into account, that it contains errors - seems due to copy-past of code from the append method)

2) Line 
`items[c] = items[c];  `
is redundant, seems to appear after copy pasting from:

```
public static async Task<DataFrame> LoadFrom(DbDataReader reader)
...
  for (var c = 0; c < columnsCount; c++)
  {
     items[c] = reader.IsDBNull(c)  ? null : reader[c];
  }
```

Method has unit tests. Changes don't affect method behaviour