### PR TITLE
Modernized some argument checks that still used string literals for parameter names

### DIFF
--- a/src/Microsoft.ML.Core/ComponentModel/ComponentCatalog.cs
+++ b/src/Microsoft.ML.Core/ComponentModel/ComponentCatalog.cs
@@ -30,7 +30,7 @@ namespace Microsoft.ML.Runtime
                 return AccessModifier.Internal;
             if (methodInfo.IsPublic)
                 return AccessModifier.Public;
-            throw new ArgumentException("Did not find access modifier", "methodInfo");
+            throw new ArgumentException("Did not find access modifier", nameof(methodInfo));
         }
 
         internal static AccessModifier Accessmodifier(this ConstructorInfo constructorInfo)
@@ -47,7 +47,7 @@ namespace Microsoft.ML.Runtime
                 return AccessModifier.Internal;
             if (constructorInfo.IsPublic)
                 return AccessModifier.Public;
-            throw new ArgumentException("Did not find access modifier", "constructorInfo");
+            throw new ArgumentException("Did not find access modifier", nameof(constructorInfo));
         }
 
         internal enum AccessModifier

--- a/src/Microsoft.ML.TorchSharp/Utils/Index.cs
+++ b/src/Microsoft.ML.TorchSharp/Utils/Index.cs
@@ -29,7 +29,7 @@ namespace System
         {
             if (value < 0)
             {
-                throw new ArgumentOutOfRangeException("value", "Non-negative number required.");
+                throw new ArgumentOutOfRangeException(nameof(value), "Non-negative number required.");
             }
 
             if (fromEnd)
@@ -57,7 +57,7 @@ namespace System
         {
             if (value < 0)
             {
-                throw new ArgumentOutOfRangeException("value", "Non-negative number required.");
+                throw new ArgumentOutOfRangeException(nameof(value), "Non-negative number required.");
             }
 
             return new Index(value);
@@ -70,7 +70,7 @@ namespace System
         {
             if (value < 0)
             {
-                throw new ArgumentOutOfRangeException("value", "Non-negative number required.");
+                throw new ArgumentOutOfRangeException(nameof(value), "Non-negative number required.");
             }
 
             return new Index(~value);

--- a/src/Microsoft.ML.TorchSharp/Utils/Range.cs
+++ b/src/Microsoft.ML.TorchSharp/Utils/Range.cs
@@ -122,7 +122,7 @@ namespace System
 
             if ((uint)end > (uint)length || (uint)start > (uint)end)
             {
-                throw new ArgumentOutOfRangeException("length");
+                throw new ArgumentOutOfRangeException(nameof(length));
             }
 
             return (start, end - start);

--- a/test/Microsoft.ML.IntegrationTests/Datasets/TypeTestData.cs
+++ b/test/Microsoft.ML.IntegrationTests/Datasets/TypeTestData.cs
@@ -123,7 +123,7 @@ namespace Microsoft.ML.IntegrationTests.Datasets
         public static TypeTestData GetRandomInstance(Random rng)
         {
             if (rng == null)
-                throw new ArgumentNullException("rng");
+                throw new ArgumentNullException(nameof(rng));
 
             return new TypeTestData
             {


### PR DESCRIPTION
No changes in behavior, just leveraging more modern syntax