### PR TITLE
Improve performance of column cloning inside DataFrame arithmetics

### DIFF
--- a/src/Microsoft.Data.Analysis/ArrowStringDataFrameColumn.cs
+++ b/src/Microsoft.Data.Analysis/ArrowStringDataFrameColumn.cs
@@ -213,9 +213,9 @@ namespace Microsoft.Data.Analysis
                     _offsetsBuffers.Add(mutableOffsetsBuffer);
                     mutableOffsetsBuffer.Append(0);
                 }
-                mutableDataBuffer.EnsureCapacity(value.Length);
-                value.CopyTo(mutableDataBuffer.RawSpan.Slice(mutableDataBuffer.Length));
-                mutableDataBuffer.Length += value.Length;
+                var startIndex = mutableDataBuffer.Length;
+                mutableDataBuffer.IncreaseSize(value.Length);
+                value.CopyTo(mutableDataBuffer.RawSpan.Slice(startIndex));
                 mutableOffsetsBuffer.Append(mutableOffsetsBuffer[mutableOffsetsBuffer.Length - 1] + value.Length);
             }
             SetValidityBit(Length - 1, value != default);

--- a/src/Microsoft.Data.Analysis/DataFrameBuffer.cs
+++ b/src/Microsoft.Data.Analysis/DataFrameBuffer.cs
@@ -57,14 +57,10 @@ namespace Microsoft.Data.Analysis
 
         public void Append(T value)
         {
-            if (Length == MaxCapacity)
-            {
-                throw new ArgumentException("Current buffer is full", nameof(value));
-            }
             EnsureCapacity(1);
-            if (Length < MaxCapacity)
-                ++Length;
-            Span[Length - 1] = value;
+
+            RawSpan[Length] = value;
+            Length++;
         }
 
         public void IncreaseSize(int numberOfValues)

--- a/src/Microsoft.Data.Analysis/DataFrameBuffer.cs
+++ b/src/Microsoft.Data.Analysis/DataFrameBuffer.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using Microsoft.ML.Data;
 
 namespace Microsoft.Data.Analysis
 {

--- a/src/Microsoft.Data.Analysis/DataFrameBuffer.cs
+++ b/src/Microsoft.Data.Analysis/DataFrameBuffer.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Microsoft.ML.Data;
 
 namespace Microsoft.Data.Analysis
 {
@@ -36,7 +37,15 @@ namespace Microsoft.Data.Analysis
             get => MemoryMarshal.Cast<byte, T>(Buffer.Span);
         }
 
-        public DataFrameBuffer(int numberOfValues = 8) : base(numberOfValues) { }
+        public DataFrameBuffer(int numberOfValues = 8)
+        {
+            if ((long)numberOfValues * Size > MaxCapacity)
+            {
+                throw new ArgumentException($"{numberOfValues} exceeds buffer capacity", nameof(numberOfValues));
+            }
+
+            _memory = new byte[numberOfValues];
+        }
 
         internal DataFrameBuffer(ReadOnlyMemory<byte> buffer, int length)
         {

--- a/src/Microsoft.Data.Analysis/DataFrameBuffer.cs
+++ b/src/Microsoft.Data.Analysis/DataFrameBuffer.cs
@@ -38,10 +38,11 @@ namespace Microsoft.Data.Analysis
 
         public DataFrameBuffer(int numberOfValues = 8) : base(numberOfValues) { }
 
-        internal DataFrameBuffer(ReadOnlyMemory<byte> buffer, int length) : base(buffer, length)
+        internal DataFrameBuffer(ReadOnlyMemory<byte> buffer, int length)
         {
             _memory = new byte[buffer.Length];
             buffer.CopyTo(_memory);
+            Length = length;
         }
 
         public void Append(T value)

--- a/src/Microsoft.Data.Analysis/PrimitiveColumnContainer.cs
+++ b/src/Microsoft.Data.Analysis/PrimitiveColumnContainer.cs
@@ -9,7 +9,6 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
-using Microsoft.ML.Data;
 
 namespace Microsoft.Data.Analysis
 {

--- a/src/Microsoft.Data.Analysis/PrimitiveColumnContainer.cs
+++ b/src/Microsoft.Data.Analysis/PrimitiveColumnContainer.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
+using Microsoft.ML.Data;
 
 namespace Microsoft.Data.Analysis
 {
@@ -436,13 +437,8 @@ namespace Microsoft.Data.Analysis
             List<ReadOnlyDataFrameBuffer<byte>> ret = new List<ReadOnlyDataFrameBuffer<byte>>();
             foreach (ReadOnlyDataFrameBuffer<byte> buffer in NullBitMapBuffers)
             {
-                DataFrameBuffer<byte> newBuffer = new DataFrameBuffer<byte>();
+                DataFrameBuffer<byte> newBuffer = new DataFrameBuffer<byte>(buffer.ReadOnlyBuffer, buffer.Length);
                 ret.Add(newBuffer);
-                ReadOnlySpan<byte> span = buffer.ReadOnlySpan;
-                for (int i = 0; i < span.Length; i++)
-                {
-                    newBuffer.Append(span[i]);
-                }
             }
             return ret;
         }
@@ -518,14 +514,9 @@ namespace Microsoft.Data.Analysis
             var ret = new PrimitiveColumnContainer<T>();
             foreach (ReadOnlyDataFrameBuffer<T> buffer in Buffers)
             {
-                DataFrameBuffer<T> newBuffer = new DataFrameBuffer<T>();
+                DataFrameBuffer<T> newBuffer = new DataFrameBuffer<T>(buffer.ReadOnlyBuffer, buffer.Length);
                 ret.Buffers.Add(newBuffer);
-                ReadOnlySpan<T> span = buffer.ReadOnlySpan;
                 ret.Length += buffer.Length;
-                for (int i = 0; i < span.Length; i++)
-                {
-                    newBuffer.Append(span[i]);
-                }
             }
             ret.NullBitMapBuffers = CloneNullBitMapBuffers();
             ret.NullCount = NullCount;

--- a/src/Microsoft.Data.Analysis/PrimitiveColumnContainer.cs
+++ b/src/Microsoft.Data.Analysis/PrimitiveColumnContainer.cs
@@ -527,9 +527,9 @@ namespace Microsoft.Data.Analysis
             var ret = new PrimitiveColumnContainer<bool>();
             foreach (ReadOnlyDataFrameBuffer<T> buffer in Buffers)
             {
-                DataFrameBuffer<bool> newBuffer = new DataFrameBuffer<bool>();
+                DataFrameBuffer<bool> newBuffer = new DataFrameBuffer<bool>(buffer.Length);
                 ret.Buffers.Add(newBuffer);
-                newBuffer.EnsureCapacity(buffer.Length);
+
                 if (typeof(T) == typeof(bool))
                 {
                     var localBuffer = buffer;
@@ -554,9 +554,8 @@ namespace Microsoft.Data.Analysis
             foreach (ReadOnlyDataFrameBuffer<T> buffer in Buffers)
             {
                 ret.Length += buffer.Length;
-                DataFrameBuffer<byte> newBuffer = new DataFrameBuffer<byte>();
+                DataFrameBuffer<byte> newBuffer = new DataFrameBuffer<byte>(buffer.Length);
                 ret.Buffers.Add(newBuffer);
-                newBuffer.EnsureCapacity(buffer.Length);
                 ReadOnlySpan<T> span = buffer.ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -574,9 +573,8 @@ namespace Microsoft.Data.Analysis
             foreach (ReadOnlyDataFrameBuffer<T> buffer in Buffers)
             {
                 ret.Length += buffer.Length;
-                DataFrameBuffer<sbyte> newBuffer = new DataFrameBuffer<sbyte>();
+                DataFrameBuffer<sbyte> newBuffer = new DataFrameBuffer<sbyte>(buffer.Length);
                 ret.Buffers.Add(newBuffer);
-                newBuffer.EnsureCapacity(buffer.Length);
                 ReadOnlySpan<T> span = buffer.ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -594,9 +592,8 @@ namespace Microsoft.Data.Analysis
             foreach (ReadOnlyDataFrameBuffer<T> buffer in Buffers)
             {
                 ret.Length += buffer.Length;
-                DataFrameBuffer<double> newBuffer = new DataFrameBuffer<double>();
+                DataFrameBuffer<double> newBuffer = new DataFrameBuffer<double>(buffer.Length);
                 ret.Buffers.Add(newBuffer);
-                newBuffer.EnsureCapacity(buffer.Length);
                 ReadOnlySpan<T> span = buffer.ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -614,9 +611,8 @@ namespace Microsoft.Data.Analysis
             foreach (ReadOnlyDataFrameBuffer<T> buffer in Buffers)
             {
                 ret.Length += buffer.Length;
-                DataFrameBuffer<decimal> newBuffer = new DataFrameBuffer<decimal>();
+                DataFrameBuffer<decimal> newBuffer = new DataFrameBuffer<decimal>(buffer.Length);
                 ret.Buffers.Add(newBuffer);
-                newBuffer.EnsureCapacity(buffer.Length);
                 ReadOnlySpan<T> span = buffer.ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -634,9 +630,8 @@ namespace Microsoft.Data.Analysis
             foreach (ReadOnlyDataFrameBuffer<T> buffer in Buffers)
             {
                 ret.Length += buffer.Length;
-                DataFrameBuffer<short> newBuffer = new DataFrameBuffer<short>();
+                DataFrameBuffer<short> newBuffer = new DataFrameBuffer<short>(buffer.Length);
                 ret.Buffers.Add(newBuffer);
-                newBuffer.EnsureCapacity(buffer.Length);
                 ReadOnlySpan<T> span = buffer.ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -654,9 +649,8 @@ namespace Microsoft.Data.Analysis
             foreach (ReadOnlyDataFrameBuffer<T> buffer in Buffers)
             {
                 ret.Length += buffer.Length;
-                DataFrameBuffer<ushort> newBuffer = new DataFrameBuffer<ushort>();
+                DataFrameBuffer<ushort> newBuffer = new DataFrameBuffer<ushort>(buffer.Length);
                 ret.Buffers.Add(newBuffer);
-                newBuffer.EnsureCapacity(buffer.Length);
                 ReadOnlySpan<T> span = buffer.ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -674,9 +668,8 @@ namespace Microsoft.Data.Analysis
             foreach (ReadOnlyDataFrameBuffer<T> buffer in Buffers)
             {
                 ret.Length += buffer.Length;
-                DataFrameBuffer<int> newBuffer = new DataFrameBuffer<int>();
+                DataFrameBuffer<int> newBuffer = new DataFrameBuffer<int>(buffer.Length);
                 ret.Buffers.Add(newBuffer);
-                newBuffer.EnsureCapacity(buffer.Length);
                 ReadOnlySpan<T> span = buffer.ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -694,9 +687,8 @@ namespace Microsoft.Data.Analysis
             foreach (ReadOnlyDataFrameBuffer<T> buffer in Buffers)
             {
                 ret.Length += buffer.Length;
-                DataFrameBuffer<uint> newBuffer = new DataFrameBuffer<uint>();
+                DataFrameBuffer<uint> newBuffer = new DataFrameBuffer<uint>(buffer.Length);
                 ret.Buffers.Add(newBuffer);
-                newBuffer.EnsureCapacity(buffer.Length);
                 ReadOnlySpan<T> span = buffer.ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -714,9 +706,8 @@ namespace Microsoft.Data.Analysis
             foreach (ReadOnlyDataFrameBuffer<T> buffer in Buffers)
             {
                 ret.Length += buffer.Length;
-                DataFrameBuffer<long> newBuffer = new DataFrameBuffer<long>();
+                DataFrameBuffer<long> newBuffer = new DataFrameBuffer<long>(buffer.Length);
                 ret.Buffers.Add(newBuffer);
-                newBuffer.EnsureCapacity(buffer.Length);
                 ReadOnlySpan<T> span = buffer.ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -734,9 +725,8 @@ namespace Microsoft.Data.Analysis
             foreach (ReadOnlyDataFrameBuffer<T> buffer in Buffers)
             {
                 ret.Length += buffer.Length;
-                DataFrameBuffer<ulong> newBuffer = new DataFrameBuffer<ulong>();
+                DataFrameBuffer<ulong> newBuffer = new DataFrameBuffer<ulong>(buffer.Length);
                 ret.Buffers.Add(newBuffer);
-                newBuffer.EnsureCapacity(buffer.Length);
                 ReadOnlySpan<T> span = buffer.ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
@@ -754,9 +744,8 @@ namespace Microsoft.Data.Analysis
             foreach (ReadOnlyDataFrameBuffer<T> buffer in Buffers)
             {
                 ret.Length += buffer.Length;
-                DataFrameBuffer<float> newBuffer = new DataFrameBuffer<float>();
+                DataFrameBuffer<float> newBuffer = new DataFrameBuffer<float>(buffer.Length);
                 ret.Buffers.Add(newBuffer);
-                newBuffer.EnsureCapacity(buffer.Length);
                 ReadOnlySpan<T> span = buffer.ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {

--- a/src/Microsoft.Data.Analysis/PrimitiveColumnContainer.cs
+++ b/src/Microsoft.Data.Analysis/PrimitiveColumnContainer.cs
@@ -67,9 +67,8 @@ namespace Microsoft.Data.Analysis
             ReadOnlyDataFrameBuffer<T> dataBuffer;
             if (buffer.IsEmpty)
             {
-                DataFrameBuffer<T> mutableBuffer = new DataFrameBuffer<T>();
-                mutableBuffer.EnsureCapacity(length);
-                mutableBuffer.Length = length;
+                DataFrameBuffer<T> mutableBuffer = new DataFrameBuffer<T>(length);
+                mutableBuffer.IncreaseSize(length);
                 mutableBuffer.RawSpan.Fill(default(T));
                 dataBuffer = mutableBuffer;
             }
@@ -172,15 +171,12 @@ namespace Microsoft.Data.Analysis
 
                 //Calculate how many values we can additionaly allocate and not exceed the MaxCapacity
                 int allocatable = (int)Math.Min(remaining, ReadOnlyDataFrameBuffer<T>.MaxCapacity - mutableLastBuffer.Length);
-                mutableLastBuffer.EnsureCapacity(allocatable);
+                mutableLastBuffer.IncreaseSize(allocatable);
 
                 DataFrameBuffer<byte> lastNullBitMapBuffer = NullBitMapBuffers.GetOrCreateMutable(NullBitMapBuffers.Count - 1);
                 int nullBufferAllocatable = (allocatable + 7) / 8;
-                lastNullBitMapBuffer.EnsureCapacity(nullBufferAllocatable);
+                lastNullBitMapBuffer.IncreaseSize(nullBufferAllocatable);
 
-
-                mutableLastBuffer.Length += allocatable;
-                lastNullBitMapBuffer.Length += nullBufferAllocatable;
                 Length += allocatable;
 
                 if (value.HasValue)
@@ -529,6 +525,7 @@ namespace Microsoft.Data.Analysis
             {
                 DataFrameBuffer<bool> newBuffer = new DataFrameBuffer<bool>(buffer.Length);
                 ret.Buffers.Add(newBuffer);
+                newBuffer.IncreaseSize(buffer.Length);
 
                 if (typeof(T) == typeof(bool))
                 {
@@ -540,7 +537,6 @@ namespace Microsoft.Data.Analysis
                 {
                     newBuffer.Span.Fill(false);
                 }
-                newBuffer.Length = buffer.Length;
                 ret.Length += buffer.Length;
             }
             ret.NullBitMapBuffers = CloneNullBitMapBuffers();

--- a/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.BinaryOperationImplementations.Exploded.cs
+++ b/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.BinaryOperationImplementations.Exploded.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Data.Analysis
             {
                 throw new ArgumentException(Strings.MismatchedColumnLengths, nameof(column));
             }
-            DecimalDataFrameColumn newColumn = inPlace ? this : CloneAsDecimalColumn();
+            DecimalDataFrameColumn newColumn = inPlace ? this : (DecimalDataFrameColumn)Clone();
             newColumn.ColumnContainer.Add(column.ColumnContainer);
             return newColumn;
         }
@@ -32,7 +32,7 @@ namespace Microsoft.Data.Analysis
             {
                 throw new ArgumentException(Strings.MismatchedColumnLengths, nameof(column));
             }
-            DoubleDataFrameColumn newColumn = inPlace ? this : CloneAsDoubleColumn();
+            DoubleDataFrameColumn newColumn = inPlace ? this : (DoubleDataFrameColumn)Clone();
             newColumn.ColumnContainer.Add(column.ColumnContainer);
             return newColumn;
         }
@@ -45,7 +45,7 @@ namespace Microsoft.Data.Analysis
             {
                 throw new ArgumentException(Strings.MismatchedColumnLengths, nameof(column));
             }
-            SingleDataFrameColumn newColumn = inPlace ? this : CloneAsSingleColumn();
+            SingleDataFrameColumn newColumn = inPlace ? this : (SingleDataFrameColumn)Clone();
             newColumn.ColumnContainer.Add(column.ColumnContainer);
             return newColumn;
         }
@@ -58,7 +58,7 @@ namespace Microsoft.Data.Analysis
             {
                 throw new ArgumentException(Strings.MismatchedColumnLengths, nameof(column));
             }
-            Int32DataFrameColumn newColumn = inPlace ? this : CloneAsInt32Column();
+            Int32DataFrameColumn newColumn = inPlace ? this : (Int32DataFrameColumn)Clone();
             newColumn.ColumnContainer.Add(column.ColumnContainer);
             return newColumn;
         }
@@ -71,7 +71,7 @@ namespace Microsoft.Data.Analysis
             {
                 throw new ArgumentException(Strings.MismatchedColumnLengths, nameof(column));
             }
-            Int64DataFrameColumn newColumn = inPlace ? this : CloneAsInt64Column();
+            Int64DataFrameColumn newColumn = inPlace ? this : (Int64DataFrameColumn)Clone();
             newColumn.ColumnContainer.Add(column.ColumnContainer);
             return newColumn;
         }
@@ -84,7 +84,7 @@ namespace Microsoft.Data.Analysis
             {
                 throw new ArgumentException(Strings.MismatchedColumnLengths, nameof(column));
             }
-            UInt32DataFrameColumn newColumn = inPlace ? this : CloneAsUInt32Column();
+            UInt32DataFrameColumn newColumn = inPlace ? this : (UInt32DataFrameColumn)Clone();
             newColumn.ColumnContainer.Add(column.ColumnContainer);
             return newColumn;
         }
@@ -97,7 +97,7 @@ namespace Microsoft.Data.Analysis
             {
                 throw new ArgumentException(Strings.MismatchedColumnLengths, nameof(column));
             }
-            UInt64DataFrameColumn newColumn = inPlace ? this : CloneAsUInt64Column();
+            UInt64DataFrameColumn newColumn = inPlace ? this : (UInt64DataFrameColumn)Clone();
             newColumn.ColumnContainer.Add(column.ColumnContainer);
             return newColumn;
         }
@@ -250,7 +250,7 @@ namespace Microsoft.Data.Analysis
             {
                 throw new ArgumentException(Strings.MismatchedColumnLengths, nameof(column));
             }
-            DecimalDataFrameColumn newColumn = inPlace ? this : CloneAsDecimalColumn();
+            DecimalDataFrameColumn newColumn = inPlace ? this : (DecimalDataFrameColumn)Clone();
             newColumn.ColumnContainer.Subtract(column.ColumnContainer);
             return newColumn;
         }
@@ -263,7 +263,7 @@ namespace Microsoft.Data.Analysis
             {
                 throw new ArgumentException(Strings.MismatchedColumnLengths, nameof(column));
             }
-            DoubleDataFrameColumn newColumn = inPlace ? this : CloneAsDoubleColumn();
+            DoubleDataFrameColumn newColumn = inPlace ? this : (DoubleDataFrameColumn)Clone();
             newColumn.ColumnContainer.Subtract(column.ColumnContainer);
             return newColumn;
         }
@@ -276,7 +276,7 @@ namespace Microsoft.Data.Analysis
             {
                 throw new ArgumentException(Strings.MismatchedColumnLengths, nameof(column));
             }
-            SingleDataFrameColumn newColumn = inPlace ? this : CloneAsSingleColumn();
+            SingleDataFrameColumn newColumn = inPlace ? this : (SingleDataFrameColumn)Clone();
             newColumn.ColumnContainer.Subtract(column.ColumnContainer);
             return newColumn;
         }
@@ -289,7 +289,7 @@ namespace Microsoft.Data.Analysis
             {
                 throw new ArgumentException(Strings.MismatchedColumnLengths, nameof(column));
             }
-            Int32DataFrameColumn newColumn = inPlace ? this : CloneAsInt32Column();
+            Int32DataFrameColumn newColumn = inPlace ? this : (Int32DataFrameColumn)Clone();
             newColumn.ColumnContainer.Subtract(column.ColumnContainer);
             return newColumn;
         }
@@ -302,7 +302,7 @@ namespace Microsoft.Data.Analysis
             {
                 throw new ArgumentException(Strings.MismatchedColumnLengths, nameof(column));
             }
-            Int64DataFrameColumn newColumn = inPlace ? this : CloneAsInt64Column();
+            Int64DataFrameColumn newColumn = inPlace ? this : (Int64DataFrameColumn)Clone();
             newColumn.ColumnContainer.Subtract(column.ColumnContainer);
             return newColumn;
         }
@@ -315,7 +315,7 @@ namespace Microsoft.Data.Analysis
             {
                 throw new ArgumentException(Strings.MismatchedColumnLengths, nameof(column));
             }
-            UInt32DataFrameColumn newColumn = inPlace ? this : CloneAsUInt32Column();
+            UInt32DataFrameColumn newColumn = inPlace ? this : (UInt32DataFrameColumn)Clone();
             newColumn.ColumnContainer.Subtract(column.ColumnContainer);
             return newColumn;
         }
@@ -328,7 +328,7 @@ namespace Microsoft.Data.Analysis
             {
                 throw new ArgumentException(Strings.MismatchedColumnLengths, nameof(column));
             }
-            UInt64DataFrameColumn newColumn = inPlace ? this : CloneAsUInt64Column();
+            UInt64DataFrameColumn newColumn = inPlace ? this : (UInt64DataFrameColumn)Clone();
             newColumn.ColumnContainer.Subtract(column.ColumnContainer);
             return newColumn;
         }
@@ -481,7 +481,7 @@ namespace Microsoft.Data.Analysis
             {
                 throw new ArgumentException(Strings.MismatchedColumnLengths, nameof(column));
             }
-            DecimalDataFrameColumn newColumn = inPlace ? this : CloneAsDecimalColumn();
+            DecimalDataFrameColumn newColumn = inPlace ? this : (DecimalDataFrameColumn)Clone();
             newColumn.ColumnContainer.Multiply(column.ColumnContainer);
             return newColumn;
         }
@@ -494,7 +494,7 @@ namespace Microsoft.Data.Analysis
             {
                 throw new ArgumentException(Strings.MismatchedColumnLengths, nameof(column));
             }
-            DoubleDataFrameColumn newColumn = inPlace ? this : CloneAsDoubleColumn();
+            DoubleDataFrameColumn newColumn = inPlace ? this : (DoubleDataFrameColumn)Clone();
             newColumn.ColumnContainer.Multiply(column.ColumnContainer);
             return newColumn;
         }
@@ -507,7 +507,7 @@ namespace Microsoft.Data.Analysis
             {
                 throw new ArgumentException(Strings.MismatchedColumnLengths, nameof(column));
             }
-            SingleDataFrameColumn newColumn = inPlace ? this : CloneAsSingleColumn();
+            SingleDataFrameColumn newColumn = inPlace ? this : (SingleDataFrameColumn)Clone();
             newColumn.ColumnContainer.Multiply(column.ColumnContainer);
             return newColumn;
         }
@@ -520,7 +520,7 @@ namespace Microsoft.Data.Analysis
             {
                 throw new ArgumentException(Strings.MismatchedColumnLengths, nameof(column));
             }
-            Int32DataFrameColumn newColumn = inPlace ? this : CloneAsInt32Column();
+            Int32DataFrameColumn newColumn = inPlace ? this : (Int32DataFrameColumn)Clone();
             newColumn.ColumnContainer.Multiply(column.ColumnContainer);
             return newColumn;
         }
@@ -533,7 +533,7 @@ namespace Microsoft.Data.Analysis
             {
                 throw new ArgumentException(Strings.MismatchedColumnLengths, nameof(column));
             }
-            Int64DataFrameColumn newColumn = inPlace ? this : CloneAsInt64Column();
+            Int64DataFrameColumn newColumn = inPlace ? this : (Int64DataFrameColumn)Clone();
             newColumn.ColumnContainer.Multiply(column.ColumnContainer);
             return newColumn;
         }
@@ -546,7 +546,7 @@ namespace Microsoft.Data.Analysis
             {
                 throw new ArgumentException(Strings.MismatchedColumnLengths, nameof(column));
             }
-            UInt32DataFrameColumn newColumn = inPlace ? this : CloneAsUInt32Column();
+            UInt32DataFrameColumn newColumn = inPlace ? this : (UInt32DataFrameColumn)Clone();
             newColumn.ColumnContainer.Multiply(column.ColumnContainer);
             return newColumn;
         }
@@ -559,7 +559,7 @@ namespace Microsoft.Data.Analysis
             {
                 throw new ArgumentException(Strings.MismatchedColumnLengths, nameof(column));
             }
-            UInt64DataFrameColumn newColumn = inPlace ? this : CloneAsUInt64Column();
+            UInt64DataFrameColumn newColumn = inPlace ? this : (UInt64DataFrameColumn)Clone();
             newColumn.ColumnContainer.Multiply(column.ColumnContainer);
             return newColumn;
         }
@@ -712,7 +712,7 @@ namespace Microsoft.Data.Analysis
             {
                 throw new ArgumentException(Strings.MismatchedColumnLengths, nameof(column));
             }
-            DecimalDataFrameColumn newColumn = inPlace ? this : CloneAsDecimalColumn();
+            DecimalDataFrameColumn newColumn = inPlace ? this : (DecimalDataFrameColumn)Clone();
             newColumn.ColumnContainer.Divide(column.ColumnContainer);
             return newColumn;
         }
@@ -725,7 +725,7 @@ namespace Microsoft.Data.Analysis
             {
                 throw new ArgumentException(Strings.MismatchedColumnLengths, nameof(column));
             }
-            DoubleDataFrameColumn newColumn = inPlace ? this : CloneAsDoubleColumn();
+            DoubleDataFrameColumn newColumn = inPlace ? this : (DoubleDataFrameColumn)Clone();
             newColumn.ColumnContainer.Divide(column.ColumnContainer);
             return newColumn;
         }
@@ -738,7 +738,7 @@ namespace Microsoft.Data.Analysis
             {
                 throw new ArgumentException(Strings.MismatchedColumnLengths, nameof(column));
             }
-            SingleDataFrameColumn newColumn = inPlace ? this : CloneAsSingleColumn();
+            SingleDataFrameColumn newColumn = inPlace ? this : (SingleDataFrameColumn)Clone();
             newColumn.ColumnContainer.Divide(column.ColumnContainer);
             return newColumn;
         }
@@ -751,7 +751,7 @@ namespace Microsoft.Data.Analysis
             {
                 throw new ArgumentException(Strings.MismatchedColumnLengths, nameof(column));
             }
-            Int32DataFrameColumn newColumn = inPlace ? this : CloneAsInt32Column();
+            Int32DataFrameColumn newColumn = inPlace ? this : (Int32DataFrameColumn)Clone();
             newColumn.ColumnContainer.Divide(column.ColumnContainer);
             return newColumn;
         }
@@ -764,7 +764,7 @@ namespace Microsoft.Data.Analysis
             {
                 throw new ArgumentException(Strings.MismatchedColumnLengths, nameof(column));
             }
-            Int64DataFrameColumn newColumn = inPlace ? this : CloneAsInt64Column();
+            Int64DataFrameColumn newColumn = inPlace ? this : (Int64DataFrameColumn)Clone();
             newColumn.ColumnContainer.Divide(column.ColumnContainer);
             return newColumn;
         }
@@ -777,7 +777,7 @@ namespace Microsoft.Data.Analysis
             {
                 throw new ArgumentException(Strings.MismatchedColumnLengths, nameof(column));
             }
-            UInt32DataFrameColumn newColumn = inPlace ? this : CloneAsUInt32Column();
+            UInt32DataFrameColumn newColumn = inPlace ? this : (UInt32DataFrameColumn)Clone();
             newColumn.ColumnContainer.Divide(column.ColumnContainer);
             return newColumn;
         }
@@ -790,7 +790,7 @@ namespace Microsoft.Data.Analysis
             {
                 throw new ArgumentException(Strings.MismatchedColumnLengths, nameof(column));
             }
-            UInt64DataFrameColumn newColumn = inPlace ? this : CloneAsUInt64Column();
+            UInt64DataFrameColumn newColumn = inPlace ? this : (UInt64DataFrameColumn)Clone();
             newColumn.ColumnContainer.Divide(column.ColumnContainer);
             return newColumn;
         }
@@ -943,7 +943,7 @@ namespace Microsoft.Data.Analysis
             {
                 throw new ArgumentException(Strings.MismatchedColumnLengths, nameof(column));
             }
-            DecimalDataFrameColumn newColumn = inPlace ? this : CloneAsDecimalColumn();
+            DecimalDataFrameColumn newColumn = inPlace ? this : (DecimalDataFrameColumn)Clone();
             newColumn.ColumnContainer.Modulo(column.ColumnContainer);
             return newColumn;
         }
@@ -956,7 +956,7 @@ namespace Microsoft.Data.Analysis
             {
                 throw new ArgumentException(Strings.MismatchedColumnLengths, nameof(column));
             }
-            DoubleDataFrameColumn newColumn = inPlace ? this : CloneAsDoubleColumn();
+            DoubleDataFrameColumn newColumn = inPlace ? this : (DoubleDataFrameColumn)Clone();
             newColumn.ColumnContainer.Modulo(column.ColumnContainer);
             return newColumn;
         }
@@ -969,7 +969,7 @@ namespace Microsoft.Data.Analysis
             {
                 throw new ArgumentException(Strings.MismatchedColumnLengths, nameof(column));
             }
-            SingleDataFrameColumn newColumn = inPlace ? this : CloneAsSingleColumn();
+            SingleDataFrameColumn newColumn = inPlace ? this : (SingleDataFrameColumn)Clone();
             newColumn.ColumnContainer.Modulo(column.ColumnContainer);
             return newColumn;
         }
@@ -982,7 +982,7 @@ namespace Microsoft.Data.Analysis
             {
                 throw new ArgumentException(Strings.MismatchedColumnLengths, nameof(column));
             }
-            Int32DataFrameColumn newColumn = inPlace ? this : CloneAsInt32Column();
+            Int32DataFrameColumn newColumn = inPlace ? this : (Int32DataFrameColumn)Clone();
             newColumn.ColumnContainer.Modulo(column.ColumnContainer);
             return newColumn;
         }
@@ -995,7 +995,7 @@ namespace Microsoft.Data.Analysis
             {
                 throw new ArgumentException(Strings.MismatchedColumnLengths, nameof(column));
             }
-            Int64DataFrameColumn newColumn = inPlace ? this : CloneAsInt64Column();
+            Int64DataFrameColumn newColumn = inPlace ? this : (Int64DataFrameColumn)Clone();
             newColumn.ColumnContainer.Modulo(column.ColumnContainer);
             return newColumn;
         }
@@ -1008,7 +1008,7 @@ namespace Microsoft.Data.Analysis
             {
                 throw new ArgumentException(Strings.MismatchedColumnLengths, nameof(column));
             }
-            UInt32DataFrameColumn newColumn = inPlace ? this : CloneAsUInt32Column();
+            UInt32DataFrameColumn newColumn = inPlace ? this : (UInt32DataFrameColumn)Clone();
             newColumn.ColumnContainer.Modulo(column.ColumnContainer);
             return newColumn;
         }
@@ -1021,7 +1021,7 @@ namespace Microsoft.Data.Analysis
             {
                 throw new ArgumentException(Strings.MismatchedColumnLengths, nameof(column));
             }
-            UInt64DataFrameColumn newColumn = inPlace ? this : CloneAsUInt64Column();
+            UInt64DataFrameColumn newColumn = inPlace ? this : (UInt64DataFrameColumn)Clone();
             newColumn.ColumnContainer.Modulo(column.ColumnContainer);
             return newColumn;
         }

--- a/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.BinaryOperationImplementations.Exploded.tt
+++ b/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.BinaryOperationImplementations.Exploded.tt
@@ -76,7 +76,7 @@ void GenerateAllBinaryCombinationsForMethod(string inputMethodName)
             {
                 throw new ArgumentException(Strings.MismatchedColumnLengths, nameof(column));
             }
-            <#=fullReturnType#> newColumn = inPlace ? this : CloneAs<#=capitalizedReturnType#>Column();
+            <#=fullReturnType#> newColumn = inPlace ? this : (<#=fullReturnType#>)Clone();
             newColumn.ColumnContainer.<#=inputMethodName#>(column.ColumnContainer);
             return newColumn;
         }

--- a/src/Microsoft.Data.Analysis/ReadOnlyDataFrameBuffer.cs
+++ b/src/Microsoft.Data.Analysis/ReadOnlyDataFrameBuffer.cs
@@ -48,15 +48,16 @@ namespace Microsoft.Data.Analysis
             get => (MemoryMarshal.Cast<byte, T>(ReadOnlyBuffer.Span)).Slice(0, Length);
         }
 
-        public int Length { get; internal set; }
+        public int Length { get; protected set; }
 
-        public ReadOnlyDataFrameBuffer(int numberOfValues = 8)
+        public ReadOnlyDataFrameBuffer(int length = 0)
         {
-            if ((long)numberOfValues * Size > MaxCapacity)
+            if ((long)length * Size > MaxCapacity)
             {
-                throw new ArgumentException($"{numberOfValues} exceeds buffer capacity", nameof(numberOfValues));
+                throw new ArgumentException($"{length} exceeds buffer capacity", nameof(length));
             }
-            _readOnlyBuffer = new byte[numberOfValues * Size];
+            _readOnlyBuffer = new byte[length * Size];
+            Length = length;
         }
 
         public ReadOnlyDataFrameBuffer(ReadOnlyMemory<byte> buffer, int length)

--- a/test/Microsoft.Data.Analysis.Tests/BufferTests.cs
+++ b/test/Microsoft.Data.Analysis.Tests/BufferTests.cs
@@ -79,7 +79,6 @@ namespace Microsoft.Data.Analysis.Tests
             Assert.Equal(2, intColumn[3]);
             Assert.Null(intColumn[4]);
             Assert.Equal(3, intColumn[5]);
-
         }
 
         [Fact]
@@ -132,6 +131,20 @@ namespace Microsoft.Data.Analysis.Tests
             intColumn[7] = null;
             Assert.Equal(5, intColumn.NullCount);
             Assert.False(intColumn.IsValid(7));
+        }
+
+        [Fact]
+        public void TestClone()
+        {
+            PrimitiveDataFrameColumn<int> intColumn = new PrimitiveDataFrameColumn<int>("Int1", new int?[] { 1, 2, 3, 4, null });
+            var copy = intColumn.Clone();
+
+            Assert.Equal(intColumn.Name, copy.Name);
+            Assert.Equal(intColumn.Length, copy.Length);
+            Assert.Equal(intColumn.DataType, copy.DataType);
+
+            for (int i = 0; i < intColumn.Length; i++)
+                Assert.Equal(intColumn[i], copy[i]);
         }
 
         [Fact]

--- a/test/Microsoft.ML.Fairlearn.Tests/GridSearchTest.cs
+++ b/test/Microsoft.ML.Fairlearn.Tests/GridSearchTest.cs
@@ -45,7 +45,7 @@ namespace Microsoft.ML.Fairlearn.Tests
         }
 
         // Data generated so it is identical from Binary_Classification.ipynb from Fairlearn.github on Github
-        private DataFrame CreateGridScearhDataset()
+        private DataFrame CreateGridSearchDataset()
         {
             float[] score_feature = new float[52];
             int index = 0;
@@ -89,7 +89,7 @@ namespace Microsoft.ML.Fairlearn.Tests
                 }
             };
             var experiment = context.Auto().CreateExperiment();
-            var df = CreateGridScearhDataset();
+            var df = CreateGridSearchDataset();
             var shuffledDataset = context.Data.ShuffleRows(df);
             var trainTestSplit = context.Data.TrainTestSplit(shuffledDataset, 0.2);
             var pipeline = context.Transforms.Categorical.OneHotHashEncoding("sensitiveFeature_encode", "sensitiveFeature")


### PR DESCRIPTION
The goal of this PR is to perform Arithmetics operation on columns with the same underlying data type approximately 3 times faster.

Detail of changes:

1) Fix PrimitiveColumnContainer Clone() method to use memory block coping for internal buffer instead of appending values one by one (with memory reallocation on each buffer resizing cycle). Do similar changes for CloneNullBitMapBuffers() method

2)  Improve BinaryOperation.Implementation methods for all Arithmetic operations that happen not in place (default behavior). 
Before the change autogenerated code looked like this:

```
public partial class SingleDataFrameColumn
{
    internal SingleDataFrameColumn AddImplementation(SingleDataFrameColumn column, bool inPlace = false)
    {
        if (column.Length != Length)
        {
            throw new ArgumentException(Strings.MismatchedColumnLengths, nameof(column));
        }
        SingleDataFrameColumn newColumn = inPlace ? this : CloneAsSingleColumn();
        newColumn.ColumnContainer.Add(column.ColumnContainer);
        return newColumn;
    }
}
```

After PR https://github.com/dotnet/machinelearning/pull/6677 CloneAsSingleColumn can be changed to just this.Clone(). This allow to avoid unnecessary type conversion, that happens inside CloneAs... method and use fast Clone() method with bulk memory copy for internal buffers. For example. for Single:

```
internal PrimitiveColumnContainer<float> CloneAsFloatContainer()
{
 ...
    for (int i = 0; i < span.Length; i++)
   {
          newBuffer.Append(SingleConverter<T>.Instance.GetSingle(span[i]);
   }
}
```

3) Fix DataFrameBuffer constructor. 
DataFrameBuffer overrides parent ReadOnlyDataFrameBuffer ReadOnlyBuffer to return own new field _memory instead of parent _readOnlyBuffer (after this parent _readonlybuffer is ignored and never used). However in constructor _memory is not created, instead base constructor is called to allocate _readonlybuffer (which is ignored). So after creating Capacity of such buffer is always 0 (ignoring the actual parameter passed to the constructor) and additional memory is allocated

4) After 3 is fixed, changed code to use DataFrameBuffer constructor with capacity instead of creating empty dataframe buffer and than reallocating memory by calling EnsureCapacity 

___________________________

Result:

Simple tests for 1 million of rows:

```
[GlobalSetup]
public void SetUp()
{
    var values = Enumerable.Range(0, ItemsCount);
    _column1 = new Int32DataFrameColumn("Column1", values);
    _column2 = new Int32DataFrameColumn("Column2", values);
}

[Benchmark]
public void Sum()
{
    var column = _column1 + _column2;
}
```

```
Before PR:
| Method |    Mean |     Error |   StdDev |
|    Sum | 18.02 ms | 0.090 ms | 0.080 ms |

After PR:
| Method |     Mean |     Error |    StdDev |
|    Sum | 6.896 ms | 0.1363 ms | 0.1673 ms |
```

Part of #6824 issue