### PR TITLE
use HingeLoss as default loss function

### DIFF
--- a/src/Microsoft.ML.StandardTrainers/Standard/Online/AveragedPerceptron.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/Online/AveragedPerceptron.cs
@@ -184,7 +184,7 @@ namespace Microsoft.ML.Trainers
                 DecreaseLearningRate = decreaseLearningRate,
                 L2Regularization = l2Regularization,
                 NumberOfIterations = numberOfIterations,
-                LossFunction = lossFunction ?? new HingeLoss()
+                LossFunction = lossFunction
             })
         {
         }

--- a/src/Microsoft.ML.StandardTrainers/StandardTrainersCatalog.cs
+++ b/src/Microsoft.ML.StandardTrainers/StandardTrainersCatalog.cs
@@ -426,7 +426,7 @@ namespace Microsoft.ML
             Contracts.CheckValue(catalog, nameof(catalog));
 
             var env = CatalogUtils.GetEnvironment(catalog);
-            return new AveragedPerceptronTrainer(env, labelColumnName, featureColumnName, lossFunction ?? new LogLoss(), learningRate, decreaseLearningRate, l2Regularization, numberOfIterations);
+            return new AveragedPerceptronTrainer(env, labelColumnName, featureColumnName, lossFunction, learningRate, decreaseLearningRate, l2Regularization, numberOfIterations);
         }
 
         /// <summary>


### PR DESCRIPTION
#6815 

[StandardTrainersCatalog.AveragedPerceptron](https://github.com/dotnet/machinelearning/blob/09b80f8a08340dc7d79ac75e13c722313f0845eb/src/Microsoft.ML.StandardTrainers/StandardTrainersCatalog.cs#L429C13-L429C196) factory method uses LogLoss as its default loss function, which contradicts method documentation and defaults.AveragedPerceptronTrainer.Options