### PR TITLE
PrimitiveDataFrameColumn.Clone method crashes when is used with IEnumerable mapIndices argument

### DIFF
--- a/src/Microsoft.Data.Analysis/PrimitiveColumnContainer.cs
+++ b/src/Microsoft.Data.Analysis/PrimitiveColumnContainer.cs
@@ -180,8 +180,11 @@ namespace Microsoft.Data.Analysis
                 lastNullBitMapBuffer.Length += nullBufferAllocatable;
                 Length += allocatable;
 
-                mutableLastBuffer.RawSpan.Slice(mutableLastBuffer.Length - allocatable, allocatable).Fill(value ?? default);
-                lastNullBitMapBuffer.RawSpan.Slice(lastNullBitMapBuffer.Length - nullBufferAllocatable, nullBufferAllocatable).Fill(value.HasValue ? (byte)0xFF : (byte)0x0);
+                if (value.HasValue)
+                {
+                    mutableLastBuffer.RawSpan.Slice(mutableLastBuffer.Length - allocatable, allocatable).Fill(value.Value);
+                    lastNullBitMapBuffer.RawSpan.Slice(lastNullBitMapBuffer.Length - nullBufferAllocatable, nullBufferAllocatable).Fill(0xFF);
+                }
 
                 remaining -= allocatable;
             }

--- a/src/Microsoft.Data.Analysis/PrimitiveColumnContainer.cs
+++ b/src/Microsoft.Data.Analysis/PrimitiveColumnContainer.cs
@@ -31,6 +31,11 @@ namespace Microsoft.Data.Analysis
             return ((curBitMap >> (index & 7)) & 1) != 0;
         }
 
+        public static bool IsBitClear(byte curBitMap, int index)
+        {
+            return ((curBitMap >> (index & 7)) & 1) == 0;
+        }
+
         public static bool GetBit(byte data, int index) =>
            ((data >> index) & 1) != 0;
 
@@ -334,7 +339,7 @@ namespace Microsoft.Data.Analysis
             if (value)
             {
                 newBitMap = (byte)(curBitMap | (byte)(1 << (index & 7))); //bit hack for index % 8
-                if (((curBitMap >> (index & 7)) & 1) == 0 && index < Length && NullCount > 0)
+                if (BitmapHelper.IsBitClear(curBitMap, index) && index < Length && NullCount > 0)
                 {
                     // Old value was null.
                     NullCount--;
@@ -342,7 +347,7 @@ namespace Microsoft.Data.Analysis
             }
             else
             {
-                if (((curBitMap >> (index & 7)) & 1) == 1 && index < Length)
+                if (BitmapHelper.IsBitSet(curBitMap, index) && index < Length)
                 {
                     // old value was NOT null and new value is null
                     NullCount++;

--- a/src/Microsoft.Data.Analysis/PrimitiveColumnContainer.cs
+++ b/src/Microsoft.Data.Analysis/PrimitiveColumnContainer.cs
@@ -14,6 +14,10 @@ namespace Microsoft.Data.Analysis
 {
     internal static class BitmapHelper
     {
+        private static ReadOnlySpan<byte> BitMask => new byte[] {
+            1, 2, 4, 8, 16, 32, 64, 128
+        };
+
         // Faster to use when we already have a span since it avoids indexing
         public static bool IsValid(ReadOnlySpan<byte> bitMapBufferSpan, int index)
         {
@@ -25,6 +29,93 @@ namespace Microsoft.Data.Analysis
         public static bool IsBitSet(byte curBitMap, int index)
         {
             return ((curBitMap >> (index & 7)) & 1) != 0;
+        }
+
+        public static bool GetBit(byte data, int index) =>
+           ((data >> index) & 1) != 0;
+
+        public static bool GetBit(ReadOnlySpan<byte> data, int index) =>
+            (data[index / 8] & BitMask[index % 8]) != 0;
+
+        public static void ClearBit(Span<byte> data, int index)
+        {
+            data[index / 8] &= (byte)~BitMask[index % 8];
+        }
+
+        public static void SetBit(Span<byte> data, int index)
+        {
+            data[index / 8] |= BitMask[index % 8];
+        }
+
+        public static void SetBit(Span<byte> data, int index, bool value)
+        {
+            int idx = index / 8;
+            int mod = index % 8;
+            data[idx] = value
+                ? (byte)(data[idx] | BitMask[mod])
+                : (byte)(data[idx] & ~BitMask[mod]);
+        }
+
+        /// <summary>
+        /// Set the number of bits in a span of bytes starting
+        /// at a specific index, and limiting to length.
+        /// </summary>
+        /// <param name="data">Span to set bits value.</param>
+        /// <param name="index">Bit index to start counting from.</param>
+        /// <param name="length">Maximum of bits in the span to consider.</param>
+        /// <param name="value">Bit value.</param>
+        internal static void SetBits(Span<byte> data, int index, int length, bool value)
+        {
+            if (length == 0)
+                return;
+
+            int endBitIndex = checked(index + length - 1);
+
+            // Use simpler method if there aren't many values
+            if (length < 20)
+            {
+                for (int i = index; i <= endBitIndex; i++)
+                {
+                    SetBit(data, i, value);
+                }
+                return;
+            }
+
+            // Otherwise do the work to figure out how to copy whole bytes
+            int startByteIndex = index / 8;
+            int startBitOffset = index % 8;
+            int endByteIndex = endBitIndex / 8;
+            int endBitOffset = endBitIndex % 8;
+
+            // If the starting index and ending index are not byte-aligned,
+            // we'll need to set bits the slow way. If they are
+            // byte-aligned, and for all other bytes in the 'middle', we
+            // can use a faster byte-aligned set.
+            int fullByteStartIndex = startBitOffset == 0 ? startByteIndex : startByteIndex + 1;
+            int fullByteEndIndex = endBitOffset == 7 ? endByteIndex : endByteIndex - 1;
+
+            // Bits we will be using to finish up the first byte
+            if (startBitOffset != 0)
+            {
+                Span<byte> slice = data.Slice(startByteIndex, 1);
+                for (int i = startBitOffset; i <= 7; i++)
+                    SetBit(slice, i, value);
+            }
+
+            if (fullByteEndIndex >= fullByteStartIndex)
+            {
+                Span<byte> slice = data.Slice(fullByteStartIndex, fullByteEndIndex - fullByteStartIndex + 1);
+                byte fill = (byte)(value ? 0xFF : 0x00);
+
+                slice.Fill(fill);
+            }
+
+            if (endBitOffset != 7)
+            {
+                Span<byte> slice = data.Slice(endByteIndex, 1);
+                for (int i = 0; i <= endBitOffset; i++)
+                    SetBit(slice, i, value);
+            }
         }
     }
 
@@ -166,15 +257,16 @@ namespace Microsoft.Data.Analysis
                 }
 
                 DataFrameBuffer<T> mutableLastBuffer = Buffers.GetOrCreateMutable(Buffers.Count - 1);
+                DataFrameBuffer<byte> lastNullBitMapBuffer = NullBitMapBuffers.GetOrCreateMutable(NullBitMapBuffers.Count - 1);
 
                 //Calculate how many values we can additionaly allocate and not exceed the MaxCapacity
-                int allocatable = (int)Math.Min(remaining, ReadOnlyDataFrameBuffer<T>.MaxCapacity - mutableLastBuffer.Length);
+                int originalBufferLength = mutableLastBuffer.Length;
+                int allocatable = (int)Math.Min(remaining, ReadOnlyDataFrameBuffer<T>.MaxCapacity - originalBufferLength);
                 mutableLastBuffer.EnsureCapacity(allocatable);
 
-                DataFrameBuffer<byte> lastNullBitMapBuffer = NullBitMapBuffers.GetOrCreateMutable(NullBitMapBuffers.Count - 1);
-                int nullBufferAllocatable = (allocatable + 7) / 8;
+                //Calculate how many bytes we have additionaly allocate to store allocatable number of bits (need to take into account not used bits that are already allocated)
+                int nullBufferAllocatable = (originalBufferLength + allocatable + 7) / 8 - lastNullBitMapBuffer.Length;
                 lastNullBitMapBuffer.EnsureCapacity(nullBufferAllocatable);
-
 
                 mutableLastBuffer.Length += allocatable;
                 lastNullBitMapBuffer.Length += nullBufferAllocatable;
@@ -183,7 +275,7 @@ namespace Microsoft.Data.Analysis
                 if (value.HasValue)
                 {
                     mutableLastBuffer.RawSpan.Slice(mutableLastBuffer.Length - allocatable, allocatable).Fill(value.Value);
-                    lastNullBitMapBuffer.RawSpan.Slice(lastNullBitMapBuffer.Length - nullBufferAllocatable, nullBufferAllocatable).Fill(0xFF);
+                    BitmapHelper.SetBits(lastNullBitMapBuffer.RawSpan, originalBufferLength, allocatable, true);
                 }
 
                 remaining -= allocatable;

--- a/src/Microsoft.Data.Analysis/PrimitiveColumnContainer.cs
+++ b/src/Microsoft.Data.Analysis/PrimitiveColumnContainer.cs
@@ -183,17 +183,8 @@ namespace Microsoft.Data.Analysis
                 lastNullBitMapBuffer.Length += nullBufferAllocatable;
                 Length += allocatable;
 
-                if (value.HasValue)
-                {
-                    mutableLastBuffer.RawSpan.Slice(mutableLastBuffer.Length - allocatable, allocatable).Fill(value ?? default);
-
-                    _modifyNullCountWhileIndexing = false;
-                    for (long i = Length - allocatable; i < Length; i++)
-                    {
-                        SetValidityBit(i, value.HasValue);
-                    }
-                    _modifyNullCountWhileIndexing = true;
-                }
+                mutableLastBuffer.RawSpan.Slice(mutableLastBuffer.Length - allocatable, allocatable).Fill(value ?? default);
+                lastNullBitMapBuffer.RawSpan.Slice(lastNullBitMapBuffer.Length - nullBufferAllocatable, nullBufferAllocatable).Fill(value.HasValue ? (byte)0xFF : (byte)0x0);
 
                 remaining -= allocatable;
             }

--- a/src/Microsoft.Data.Analysis/PrimitiveColumnContainer.cs
+++ b/src/Microsoft.Data.Analysis/PrimitiveColumnContainer.cs
@@ -264,7 +264,7 @@ namespace Microsoft.Data.Analysis
                 int allocatable = (int)Math.Min(remaining, ReadOnlyDataFrameBuffer<T>.MaxCapacity - originalBufferLength);
                 mutableLastBuffer.EnsureCapacity(allocatable);
 
-                //Calculate how many bytes we have additionaly allocate to store allocatable number of bits (need to take into account not used bits that are already allocated)
+                //Calculate how many bytes we have additionaly allocate to store allocatable number of bits (need to take into account unused bits inside already allocated bytes)
                 int nullBufferAllocatable = (originalBufferLength + allocatable + 7) / 8 - lastNullBitMapBuffer.Length;
                 lastNullBitMapBuffer.EnsureCapacity(nullBufferAllocatable);
 

--- a/src/Microsoft.Data.Analysis/PrimitiveColumnContainer.cs
+++ b/src/Microsoft.Data.Analysis/PrimitiveColumnContainer.cs
@@ -41,9 +41,6 @@ namespace Microsoft.Data.Analysis
         // A set bit implies a valid value. An unset bit => null value
         public IList<ReadOnlyDataFrameBuffer<byte>> NullBitMapBuffers = new List<ReadOnlyDataFrameBuffer<byte>>();
 
-        // Need a way to differentiate between columns initialized with default values and those with null values in SetValidityBit
-        internal bool _modifyNullCountWhileIndexing = true;
-
         public PrimitiveColumnContainer(IEnumerable<T> values)
         {
             values = values ?? throw new ArgumentNullException(nameof(values));
@@ -242,7 +239,7 @@ namespace Microsoft.Data.Analysis
             if (value)
             {
                 newBitMap = (byte)(curBitMap | (byte)(1 << (index & 7))); //bit hack for index % 8
-                if (_modifyNullCountWhileIndexing && ((curBitMap >> (index & 7)) & 1) == 0 && index < Length && NullCount > 0)
+                if (((curBitMap >> (index & 7)) & 1) == 0 && index < Length && NullCount > 0)
                 {
                     // Old value was null.
                     NullCount--;
@@ -250,12 +247,12 @@ namespace Microsoft.Data.Analysis
             }
             else
             {
-                if (_modifyNullCountWhileIndexing && ((curBitMap >> (index & 7)) & 1) == 1 && index < Length)
+                if (((curBitMap >> (index & 7)) & 1) == 1 && index < Length)
                 {
                     // old value was NOT null and new value is null
                     NullCount++;
                 }
-                else if (_modifyNullCountWhileIndexing && index == Length)
+                else if (index == Length)
                 {
                     // New entry from an append
                     NullCount++;

--- a/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.cs
+++ b/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Runtime.InteropServices;
 using Apache.Arrow;
 using Apache.Arrow.Types;
@@ -473,20 +474,21 @@ namespace Microsoft.Data.Analysis
         public PrimitiveDataFrameColumn<T> Clone(IEnumerable<long> mapIndices)
         {
             IEnumerator<long> rows = mapIndices.GetEnumerator();
-            PrimitiveDataFrameColumn<T> ret = new PrimitiveDataFrameColumn<T>(Name);
-            ret._columnContainer._modifyNullCountWhileIndexing = false;
+            PrimitiveDataFrameColumn<T> ret = CreateNewColumn(Name);
             long numberOfRows = 0;
             while (rows.MoveNext() && numberOfRows < Length)
             {
                 numberOfRows++;
-                long curRow = rows.Current;
-                T? value = _columnContainer[curRow];
-                ret[curRow] = value;
-                if (!value.HasValue)
-                    ret._columnContainer.NullCount++;
+                var curRow = rows.Current;
+                var value = _columnContainer[curRow];
+                ret.Append(value);
             }
-            ret._columnContainer._modifyNullCountWhileIndexing = true;
             return ret;
+        }
+
+        public PrimitiveDataFrameColumn<T> Clone(IEnumerable<int> mapIndices)
+        {
+            return Clone(mapIndices.Select(x => (long)x));
         }
 
         internal BooleanDataFrameColumn CloneAsBooleanColumn()

--- a/test/Microsoft.Data.Analysis.Tests/BufferTests.cs
+++ b/test/Microsoft.Data.Analysis.Tests/BufferTests.cs
@@ -146,7 +146,7 @@ namespace Microsoft.Data.Analysis.Tests
         }
 
         [Fact]
-        public void TestAppendManyNotNullsToEmptyColumn()
+        public void TestAppendManyValuesToEmptyColumn()
         {
             //Arrange
             PrimitiveDataFrameColumn<int> intColumn = new PrimitiveDataFrameColumn<int>("Int1");
@@ -159,6 +159,29 @@ namespace Microsoft.Data.Analysis.Tests
             Assert.Equal(5, intColumn.Length);
 
             for (int i = 0; i < intColumn.Length; i++)
+            {
+                Assert.Equal(5, intColumn[i]);
+            }
+        }
+
+        [Fact]
+        public void TestAppendManyValuesToColumnWithValues()
+        {
+            //Arrange
+            PrimitiveDataFrameColumn<int> intColumn = new PrimitiveDataFrameColumn<int>("Int1", new int?[] { 1, 2, 3, null, null });
+
+            //Act
+            intColumn.AppendMany(5, 5);
+
+            //Assert
+            Assert.Equal(2, intColumn.NullCount);
+            Assert.Equal(10, intColumn.Length);
+
+            Assert.Equal(3, intColumn[2]);
+            Assert.Null(intColumn[3]);
+            Assert.Null(intColumn[4]);
+
+            for (int i = 5; i < intColumn.Length; i++)
             {
                 Assert.Equal(5, intColumn[i]);
             }

--- a/test/Microsoft.Data.Analysis.Tests/BufferTests.cs
+++ b/test/Microsoft.Data.Analysis.Tests/BufferTests.cs
@@ -249,11 +249,32 @@ namespace Microsoft.Data.Analysis.Tests
         }
 
         [Fact]
-        public void TestNotNullableColumnCloneWithIndicesMapAsEnumerable()
+        public void TestNotNullableColumnCloneWithIndicesMapAsEnumerableLong()
         {
             //Arrange
             var column = new Int32DataFrameColumn("Int column", values: new[] { 0, 5, 2, 4, 1, 3 });
             var indicesMap = new long[] { 0, 1, 2, 5, 3, 4 };
+
+            //Act
+            var clonedColumn = column.Clone(indicesMap);
+
+            //Assert
+            Assert.NotSame(column, clonedColumn);
+            Assert.Equal(column.Name, clonedColumn.Name);
+            Assert.Equal(column.DataType, clonedColumn.DataType);
+            Assert.Equal(column.NullCount, clonedColumn.NullCount);
+            Assert.Equal(indicesMap.Length, clonedColumn.Length);
+
+            for (int i = 0; i < indicesMap.Length; i++)
+                Assert.Equal(column[indicesMap[i]], clonedColumn[i]);
+        }
+
+        [Fact]
+        public void TestNotNullableColumnCloneWithIndicesMapAsEnumerableInt()
+        {
+            //Arrange
+            var column = new Int32DataFrameColumn("Int column", values: new[] { 0, 5, 2, 4, 1, 3 });
+            var indicesMap = new int[] { 0, 1, 2, 5, 3, 4 };
 
             //Act
             var clonedColumn = column.Clone(indicesMap);

--- a/test/Microsoft.Data.Analysis.Tests/BufferTests.cs
+++ b/test/Microsoft.Data.Analysis.Tests/BufferTests.cs
@@ -93,10 +93,10 @@ namespace Microsoft.Data.Analysis.Tests
 
             //Act
             intColumn.Append(null);
-            intColumn.Append(null);
 
             Assert.Equal(1, intColumn.NullCount);
             Assert.Equal(1, intColumn.Length);
+
             for (int i = 0; i < intColumn.Length; i++)
             {
                 Assert.False(intColumn.IsValid(i));

--- a/test/Microsoft.Data.Analysis.Tests/BufferTests.cs
+++ b/test/Microsoft.Data.Analysis.Tests/BufferTests.cs
@@ -187,6 +187,101 @@ namespace Microsoft.Data.Analysis.Tests
         }
 
         [Fact]
+        public void TestNotNullableColumnClone()
+        {
+            //Arrange
+            var column = new Int32DataFrameColumn("Int column", values: new[] { -1, 2, 3, 2, 1, -2 });
+
+            //Act
+            var clonedColumn = column.Clone();
+
+            //Assert
+            Assert.NotSame(column, clonedColumn);
+            Assert.Equal(column.Name, clonedColumn.Name);
+            Assert.Equal(column.DataType, clonedColumn.DataType);
+            Assert.Equal(column.NullCount, clonedColumn.NullCount);
+            Assert.Equal(column.Length, clonedColumn.Length);
+
+            for (long i = 0; i < column.Length; i++)
+                Assert.Equal(column[i], clonedColumn[i]);
+        }
+
+        [Fact]
+        public void TestNullableColumnClone()
+        {
+            //Arrange
+            var column = new Int32DataFrameColumn("Int column", values: new int?[] { -1, null, 3, 2, 1, -2 });
+
+            //Act
+            var clonedColumn = column.Clone();
+
+            //Assert
+            Assert.NotSame(column, clonedColumn);
+            Assert.Equal(column.Name, clonedColumn.Name);
+            Assert.Equal(column.DataType, clonedColumn.DataType);
+            Assert.Equal(column.NullCount, clonedColumn.NullCount);
+            Assert.Equal(column.Length, clonedColumn.Length);
+
+            for (long i = 0; i < column.Length; i++)
+                Assert.Equal(column[i], clonedColumn[i]);
+
+        }
+
+        [Fact]
+        public void TestNotNullableColumnCloneWithIndicesMap()
+        {
+            //Arrange
+            var column = new Int32DataFrameColumn("Int column", values: new[] { 0, 5, 2, 4, 1, 3 });
+            var indicesMap = new Int32DataFrameColumn("Indices", new[] { 0, 1, 2, 5, 3, 4 });
+
+            //Act
+            var clonedColumn = column.Clone(indicesMap);
+
+            //Assert
+            Assert.NotSame(column, clonedColumn);
+            Assert.Equal(column.Name, clonedColumn.Name);
+            Assert.Equal(column.DataType, clonedColumn.DataType);
+            Assert.Equal(column.NullCount, clonedColumn.NullCount);
+            Assert.Equal(indicesMap.Length, clonedColumn.Length);
+
+            for (int i = 0; i < indicesMap.Length; i++)
+                Assert.Equal(column[indicesMap[i].Value], clonedColumn[i]);
+
+        }
+
+        [Fact]
+        public void TestNullableColumnCloneWithIndicesMapAndSmallerSize()
+        {
+            //Arrange
+            var column = new Int32DataFrameColumn("Int column", values: new int?[] { null, 5, 2, 4, 1, 3 });
+            var indicesMap = new Int32DataFrameColumn("Indices", new[] { 0, 4, 2, 5, 3 });
+
+            //Act
+            var clonedColumn = column.Clone(indicesMap);
+
+            //Assert
+            Assert.NotSame(column, clonedColumn);
+            Assert.Equal(column.Name, clonedColumn.Name);
+            Assert.Equal(indicesMap.Length, clonedColumn.Length);
+            Assert.Equal(column.DataType, clonedColumn.DataType);
+
+            for (int i = 0; i < indicesMap.Length; i++)
+                Assert.Equal(indicesMap.IsValid(i) ? column[indicesMap[i].Value] : null, clonedColumn[i]);
+        }
+
+        [Fact]
+        public void TestNullableColumnCloneWithIndicesMap_OutOfRange()
+        {
+            //Arrange
+            var column = new Int32DataFrameColumn("Int column", values: new int?[] { null, 1, 1 });
+            var indicesMap = new Int32DataFrameColumn("Indices", new[] { 0, 1, 4 });
+
+            //Act and assert
+            Assert.Throws<IndexOutOfRangeException>(() => column.Clone(indicesMap));
+        }
+
+
+        [Fact]
         public void TestBasicArrowStringColumn()
         {
             StringArray strArray = new StringArray.Builder().Append("foo").Append("bar").Build();

--- a/test/Microsoft.Data.Analysis.Tests/BufferTests.cs
+++ b/test/Microsoft.Data.Analysis.Tests/BufferTests.cs
@@ -246,8 +246,29 @@ namespace Microsoft.Data.Analysis.Tests
 
             for (int i = 0; i < indicesMap.Length; i++)
                 Assert.Equal(column[indicesMap[i].Value], clonedColumn[i]);
-
         }
+
+        [Fact]
+        public void TestNotNullableColumnCloneWithIndicesMapAsEnumerable()
+        {
+            //Arrange
+            var column = new Int32DataFrameColumn("Int column", values: new[] { 0, 5, 2, 4, 1, 3 });
+            var indicesMap = new long[] { 0, 1, 2, 5, 3, 4 };
+
+            //Act
+            var clonedColumn = column.Clone(indicesMap);
+
+            //Assert
+            Assert.NotSame(column, clonedColumn);
+            Assert.Equal(column.Name, clonedColumn.Name);
+            Assert.Equal(column.DataType, clonedColumn.DataType);
+            Assert.Equal(column.NullCount, clonedColumn.NullCount);
+            Assert.Equal(indicesMap.Length, clonedColumn.Length);
+
+            for (int i = 0; i < indicesMap.Length; i++)
+                Assert.Equal(column[indicesMap[i]], clonedColumn[i]);
+        }
+
 
         [Fact]
         public void TestNullableColumnCloneWithIndicesMapAndSmallerSize()

--- a/test/Microsoft.Data.Analysis.Tests/BufferTests.cs
+++ b/test/Microsoft.Data.Analysis.Tests/BufferTests.cs
@@ -17,10 +17,6 @@ namespace Microsoft.Data.Analysis.Tests
         [Fact]
         public void TestNullCounts()
         {
-            PrimitiveDataFrameColumn<int> dataFrameColumn1 = new PrimitiveDataFrameColumn<int>("Int1", Enumerable.Range(0, 10).Select(x => x));
-            dataFrameColumn1.Append(null);
-            Assert.Equal(1, dataFrameColumn1.NullCount);
-
             PrimitiveDataFrameColumn<int> column2 = new PrimitiveDataFrameColumn<int>("Int2");
             Assert.Equal(0, column2.NullCount);
 
@@ -65,21 +61,6 @@ namespace Microsoft.Data.Analysis.Tests
             Assert.Equal(1, strCol.NullCount);
             strCol[0] = null;
             Assert.Equal(1, strCol.NullCount);
-
-            PrimitiveDataFrameColumn<int> intColumn = new PrimitiveDataFrameColumn<int>("Int");
-            intColumn.Append(0);
-            intColumn.Append(1);
-            intColumn.Append(null);
-            intColumn.Append(2);
-            intColumn.Append(null);
-            intColumn.Append(3);
-            Assert.Equal(0, intColumn[0]);
-            Assert.Equal(1, intColumn[1]);
-            Assert.Null(intColumn[2]);
-            Assert.Equal(2, intColumn[3]);
-            Assert.Null(intColumn[4]);
-            Assert.Equal(3, intColumn[5]);
-
         }
 
         [Fact]
@@ -103,6 +84,56 @@ namespace Microsoft.Data.Analysis.Tests
             {
                 Assert.True(dataFrameColumn1.IsValid(i));
             }
+        }
+
+        [Fact]
+        public void TestAppendNullToEmptyColumn()
+        {
+            PrimitiveDataFrameColumn<int> intColumn = new PrimitiveDataFrameColumn<int>("Int1");
+
+            //Act
+            intColumn.Append(null);
+            intColumn.Append(null);
+
+            Assert.Equal(1, intColumn.NullCount);
+            Assert.Equal(1, intColumn.Length);
+            for (int i = 0; i < intColumn.Length; i++)
+            {
+                Assert.False(intColumn.IsValid(i));
+            }
+        }
+
+        [Fact]
+        public void TestAppendNullToColumnWithValues()
+        {
+            PrimitiveDataFrameColumn<int> dataFrameColumn1 = new PrimitiveDataFrameColumn<int>("Int1", Enumerable.Range(0, 10));
+            dataFrameColumn1.Append(null);
+            Assert.Equal(1, dataFrameColumn1.NullCount);
+            Assert.Equal(11, dataFrameColumn1.Length);
+            Assert.Null(dataFrameColumn1[10]);
+        }
+
+        [Fact]
+        public void TestAppendToColumnWithValues()
+        {
+            PrimitiveDataFrameColumn<int> intColumn = new PrimitiveDataFrameColumn<int>("Int", Enumerable.Range(0, 10));
+
+            intColumn.Append(0);
+            intColumn.Append(1);
+            intColumn.Append(null);
+            intColumn.Append(2);
+            intColumn.Append(null);
+            intColumn.Append(3);
+
+            Assert.Equal(16, intColumn.Length);
+            Assert.Equal(2, intColumn.NullCount);
+
+            Assert.Equal(0, intColumn[10]);
+            Assert.Equal(1, intColumn[11]);
+            Assert.Null(intColumn[12]);
+            Assert.Equal(2, intColumn[13]);
+            Assert.Null(intColumn[14]);
+            Assert.Equal(3, intColumn[15]);
         }
 
         [Fact]

--- a/test/Microsoft.Data.Analysis.Tests/BufferTests.cs
+++ b/test/Microsoft.Data.Analysis.Tests/BufferTests.cs
@@ -106,9 +106,11 @@ namespace Microsoft.Data.Analysis.Tests
         }
 
         [Fact]
-        public void TestAppendMany()
+        public void TestAppendManyNullsToEmptyColumn()
         {
             PrimitiveDataFrameColumn<int> intColumn = new PrimitiveDataFrameColumn<int>("Int1");
+
+            //Act
             intColumn.AppendMany(null, 5);
             Assert.Equal(5, intColumn.NullCount);
             Assert.Equal(5, intColumn.Length);
@@ -116,20 +118,70 @@ namespace Microsoft.Data.Analysis.Tests
             {
                 Assert.False(intColumn.IsValid(i));
             }
+        }
 
-            intColumn.AppendMany(5, 5);
-            Assert.Equal(5, intColumn.NullCount);
+        [Fact]
+        public void TestAppendManyNullsToColumnWithValues()
+        {
+            //Arrange
+            var initialValues = new int?[] { 1, 2, null, 4, 5 };
+            PrimitiveDataFrameColumn<int> intColumn = new PrimitiveDataFrameColumn<int>("Int1", initialValues);
+
+            //Act
+            intColumn.AppendMany(null, 5);
+
+            //Assert
+            Assert.Equal(6, intColumn.NullCount);
             Assert.Equal(10, intColumn.Length);
-            for (int i = 5; i < intColumn.Length; i++)
+
+            for (int i = 0; i < 5; i++)
             {
-                Assert.True(intColumn.IsValid(i));
+                Assert.Equal(initialValues[i], intColumn[i]);
             }
 
+            for (int i = 5; i < 10; i++)
+            {
+                Assert.False(intColumn.IsValid(i));
+            }
+        }
+
+        [Fact]
+        public void TestAppendManyNotNullsToEmptyColumn()
+        {
+            //Arrange
+            PrimitiveDataFrameColumn<int> intColumn = new PrimitiveDataFrameColumn<int>("Int1");
+
+            //Act
+            intColumn.AppendMany(5, 5);
+
+            //Assert
+            Assert.Equal(0, intColumn.NullCount);
+            Assert.Equal(5, intColumn.Length);
+
+            for (int i = 0; i < intColumn.Length; i++)
+            {
+                Assert.Equal(5, intColumn[i]);
+            }
+        }
+
+        [Fact]
+        public void TestNullCountChange()
+        {
+            //Arrange
+            var initialValues = new int?[] { null, null, null, null, null, 5, 5, 5, 5, 5 };
+            PrimitiveDataFrameColumn<int> intColumn = new PrimitiveDataFrameColumn<int>("Int1", initialValues);
+
+            //Act
             intColumn[2] = 10;
+
+            //Assert
             Assert.Equal(4, intColumn.NullCount);
             Assert.True(intColumn.IsValid(2));
 
+            //Act
             intColumn[7] = null;
+
+            //Assert
             Assert.Equal(5, intColumn.NullCount);
             Assert.False(intColumn.IsValid(7));
         }


### PR DESCRIPTION
In frame of this PR:

1) Cover PrimitiveDataFrameColumn.Clone method with additional unit tests
2) Use Span.Fill method to init NullValidityBuffer instead of setting individual bits  in a cycle inside AppendMany (value, count) method

`lastNullBitMapBuffer.RawSpan.Slice(lastNullBitMapBuffer.Length - nullBufferAllocatable,  BitmapHelper.SetBits(lastNullBitMapBuffer.RawSpan, originalBufferLength, allocatable, true);

3) Fixes #6821 

Root cause: 
using of _ret[curRow] = value;_ for empty column. 
changed to _ret.Append(value);_

Additionaly fix returning columns with parent column type for inheritors of PrimitiveDataFrame<T> in Clone method

4) Refactoring: Fixing 3 and 2 allowed to get rid of _internal bool _modifyNullCountWhileIndexing_ field.