### PR TITLE
Fix wrong type conversion on PrimitiveDataFrameColumn

### DIFF
--- a/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.BinaryOperations.cs
+++ b/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.BinaryOperations.cs
@@ -1955,7 +1955,7 @@ namespace Microsoft.Data.Analysis
                     {
                         throw new NotSupportedException();
                     }
-                    return new BooleanDataFrameColumn(Name, (this as PrimitiveDataFrameColumn<bool>)._columnContainer.ElementwiseEquals(Unsafe.As<U, bool>(ref value)));
+                    return new BooleanDataFrameColumn(Name, (this as PrimitiveDataFrameColumn<DateTime>)._columnContainer.ElementwiseEquals(Unsafe.As<U, DateTime>(ref value)));
                 case Type byteType when byteType == typeof(byte):
                 case Type charType when charType == typeof(char):
                 case Type doubleType when doubleType == typeof(double):
@@ -2102,7 +2102,7 @@ namespace Microsoft.Data.Analysis
                     {
                         throw new NotSupportedException();
                     }
-                    return new BooleanDataFrameColumn(Name, (this as PrimitiveDataFrameColumn<bool>)._columnContainer.ElementwiseNotEquals(Unsafe.As<U, bool>(ref value)));
+                    return new BooleanDataFrameColumn(Name, (this as PrimitiveDataFrameColumn<DateTime>)._columnContainer.ElementwiseNotEquals(Unsafe.As<U, DateTime>(ref value)));
                 case Type byteType when byteType == typeof(byte):
                 case Type charType when charType == typeof(char):
                 case Type doubleType when doubleType == typeof(double):

--- a/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.BinaryOperations.tt
+++ b/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.BinaryOperations.tt
@@ -190,7 +190,7 @@ namespace Microsoft.Data.Analysis
                         throw new NotSupportedException();
                     }
 <# if (method.MethodType == MethodType.ComparisonScalar) { #>
-                    return new BooleanDataFrameColumn(Name, (this as PrimitiveDataFrameColumn<bool>)._columnContainer.<#=method.MethodName#>(Unsafe.As<U, bool>(ref value)));
+                    return new BooleanDataFrameColumn(Name, (this as PrimitiveDataFrameColumn<<#=type.TypeName#>>)._columnContainer.<#=method.MethodName#>(Unsafe.As<U, <#=type.TypeName#>>(ref value)));
 <# } else if (method.MethodType == MethodType.Comparison) { #>
                     return new BooleanDataFrameColumn(Name, (this as PrimitiveDataFrameColumn<U>)._columnContainer.<#=method.MethodName#>(column._columnContainer));
 <# } else if (method.MethodType == MethodType.BinaryScalar) {#>

--- a/test/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
+++ b/test/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
@@ -625,9 +625,15 @@ namespace Microsoft.Data.Analysis.Tests
             Assert.True(equalsResult[0]);
             Assert.False(equalsResult[4]);
 
+            var equalsByDataFrameResult = df["DateTime1"].ElementwiseEquals(dataFrameColumn2);
+            Assert.Equal(equalsResult, equalsByDataFrameResult);
+
             var notEqualsResult = dataFrameColumn1.ElementwiseNotEquals(dataFrameColumn2);
             Assert.False(notEqualsResult[0]);
             Assert.True(notEqualsResult[4]);
+
+            var notEqualsByDataFrameResult = df["DateTime1"].ElementwiseEquals(dataFrameColumn2);
+            Assert.Equal(notEqualsResult, notEqualsByDataFrameResult);
         }
 
         [Fact]

--- a/test/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
+++ b/test/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
@@ -625,15 +625,17 @@ namespace Microsoft.Data.Analysis.Tests
             Assert.True(equalsResult[0]);
             Assert.False(equalsResult[4]);
 
-            var equalsByDataFrameResult = df["DateTime1"].ElementwiseEquals(dataFrameColumn2);
-            Assert.Equal(equalsResult, equalsByDataFrameResult);
+            var equalsToScalarResult = df["DateTime1"].ElementwiseEquals(SampleDateTime);
+            Assert.True(equalsToScalarResult[0]);
+            Assert.False(equalsToScalarResult[1]);
 
             var notEqualsResult = dataFrameColumn1.ElementwiseNotEquals(dataFrameColumn2);
             Assert.False(notEqualsResult[0]);
             Assert.True(notEqualsResult[4]);
 
-            var notEqualsByDataFrameResult = df["DateTime1"].ElementwiseNotEquals(dataFrameColumn2);
-            Assert.Equal(notEqualsResult, notEqualsByDataFrameResult);
+            var notEqualsToScalarResult = df["DateTime1"].ElementwiseNotEquals(SampleDateTime);
+            Assert.False(notEqualsToScalarResult[0]);
+            Assert.True(notEqualsToScalarResult[1]);
         }
 
         [Fact]

--- a/test/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
+++ b/test/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
@@ -632,7 +632,7 @@ namespace Microsoft.Data.Analysis.Tests
             Assert.False(notEqualsResult[0]);
             Assert.True(notEqualsResult[4]);
 
-            var notEqualsByDataFrameResult = df["DateTime1"].ElementwiseEquals(dataFrameColumn2);
+            var notEqualsByDataFrameResult = df["DateTime1"].ElementwiseNotEquals(dataFrameColumn2);
             Assert.Equal(notEqualsResult, notEqualsByDataFrameResult);
         }
 


### PR DESCRIPTION
Fixes #6829

Adds the patch commented by @asmirnov82 in #6831

Updated only the *.tt template, tried generating the *.cs through Visual Studio but it leaves blank lines where the templating is (the current files don't have it so I immagine there is a next step/I'm doing something wrong)

Also couldn't manage to run tests due to errors with arcade and formatting during compilation.