### PR TITLE
6847 incorrectly sets column value

### DIFF
--- a/src/Microsoft.Data.Analysis/PrimitiveColumnContainer.cs
+++ b/src/Microsoft.Data.Analysis/PrimitiveColumnContainer.cs
@@ -359,13 +359,13 @@ namespace Microsoft.Data.Analysis
         }
 
         // private function. Faster to use when we already have a span since it avoids indexing
-        private void SetValidityBit(Span<byte> validitySpan, int index, bool value)
+        private void SetValidityBit(Span<byte> bitMapBufferSpan, int index, bool value)
         {
             int bitMapBufferIndex = (int)((uint)index / 8);
-            Debug.Assert(validitySpan.Length >= bitMapBufferIndex);
-            byte curBitMap = validitySpan[bitMapBufferIndex];
+            Debug.Assert(bitMapBufferSpan.Length >= bitMapBufferIndex);
+            byte curBitMap = bitMapBufferSpan[bitMapBufferIndex];
             byte newBitMap = SetBit(curBitMap, index, value);
-            validitySpan[bitMapBufferIndex] = newBitMap;
+            bitMapBufferSpan[bitMapBufferIndex] = newBitMap;
         }
 
         /// <summary>

--- a/test/Microsoft.Data.Analysis.Tests/BufferTests.cs
+++ b/test/Microsoft.Data.Analysis.Tests/BufferTests.cs
@@ -8,12 +8,27 @@ using System.Linq;
 using System.Text;
 using Apache.Arrow;
 using Microsoft.ML.TestFramework.Attributes;
+using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Microsoft.Data.Analysis.Tests
 {
     public class BufferTests
     {
+        [X64Fact("32-bit doesn't allow to allocate more than 2 Gb")]
+        public void TestGetterAndSetterForColumnsGreaterThanMaxCapacity()
+        {
+            const int MaxCapacityInBytes = 2147483591;
+
+            var length = MaxCapacityInBytes + 5;
+            var column = new PrimitiveDataFrameColumn<byte>("LargeColumn", length);
+            var index = length - 1;
+            column[index] = 33;
+
+            Assert.Equal((byte)33, column[index]);
+            Assert.Null(column[index % MaxCapacityInBytes]);
+        }
+
         [Fact]
         public void TestNullCounts()
         {
@@ -446,7 +461,7 @@ namespace Microsoft.Data.Analysis.Tests
                 Assert.Null(clone[i]);
         }
 
-        [X64Fact("32-bit dosn't allow to allocate more than 2 Gb")]
+        [X64Fact("32-bit doesn't allow to allocate more than 2 Gb")]
         public void TestAppend_SizeMoreThanMaxBufferCapacity()
         {
             //Check appending value, than can increase buffer size over MaxCapacity (default strategy is to double buffer capacity)
@@ -454,7 +469,7 @@ namespace Microsoft.Data.Analysis.Tests
             intColumn.Append(10);
         }
 
-        [X64Fact("32-bit dosn't allow to allocate more than 2 Gb")]
+        [X64Fact("32-bit doesn't allow to allocate more than 2 Gb")]
         public void TestAppendMany_SizeMoreThanMaxBufferCapacity()
         {
             const int MaxCapacityInBytes = 2147483591;


### PR DESCRIPTION
Fixes #6847

Issue was in PrimitiveColumnContainer Setter. 

SetValidityBit(rowIndex, true) method accepts rowIndex as a parameter. Before the PR offset in the last buffer was used instead
