### PR TITLE
Fix DataFrame Saving csv with VBufferDataFrameColumn

### DIFF
--- a/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.cs
+++ b/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.cs
@@ -231,7 +231,7 @@ namespace Microsoft.Data.Analysis
             return new PrimitiveDataFrameColumn<T>(name, length);
         }
 
-        internal T? GetTypedValue(long rowIndex) => _columnContainer[rowIndex];
+        protected T? GetTypedValue(long rowIndex) => _columnContainer[rowIndex];
 
         protected override object GetValue(long rowIndex) => GetTypedValue(rowIndex);
 

--- a/src/Microsoft.ML.DataView/VBuffer.cs
+++ b/src/Microsoft.ML.DataView/VBuffer.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using Microsoft.ML.Internal.DataView;
@@ -27,7 +28,7 @@ namespace Microsoft.ML.Data
     /// a value is sufficient to make a completely independent copy of it. So, for example, this means that a buffer of
     /// buffers is not possible. But, things like <see cref="int"/>, <see cref="float"/>, and <see
     /// cref="ReadOnlyMemory{Char}"/>, are totally fine.</typeparam>
-    public readonly struct VBuffer<T>
+    public readonly struct VBuffer<T> : IEnumerable
     {
         /// <summary>
         /// The internal re-usable array of values.
@@ -402,6 +403,14 @@ namespace Microsoft.ML.Data
 
         public override string ToString()
             => IsDense ? $"Dense vector of size {Length}" : $"Sparse vector of size {Length}, {_count} explicit values";
+
+        /// <summary>
+        /// Returns an enumerator that iterates through the values in VBuffer.
+        /// </summary>
+        public IEnumerator GetEnumerator()
+        {
+            return _values.GetEnumerator();
+        }
 
         internal VBufferEditor<T> GetEditor()
         {


### PR DESCRIPTION
Fixed saving DataFrame with VBufferDataFrame column into csv file. Loading VBufferDataFrame from csv is out of scope of this PR. Currently it's load as a string column. Correct reading of csv requires redesign of the DataFrame to support save/load of user defined types (part of #6859)

Fixes #6858


