### PR TITLE
Improve performance of DataFrame binary comparison operations

### DIFF
--- a/src/Microsoft.Data.Analysis/ArrowStringDataFrameColumn.cs
+++ b/src/Microsoft.Data.Analysis/ArrowStringDataFrameColumn.cs
@@ -226,7 +226,7 @@ namespace Microsoft.Data.Analysis
         {
             if (rowIndex >= Length)
             {
-                throw new ArgumentOutOfRangeException(Strings.RowIndexOutOfRange, nameof(rowIndex));
+                throw new ArgumentOutOfRangeException(Strings.IndexIsGreaterThanColumnLength, nameof(rowIndex));
             }
 
             // Since the strings here could be of variable length, scan linearly

--- a/src/Microsoft.Data.Analysis/ArrowStringDataFrameColumn.cs
+++ b/src/Microsoft.Data.Analysis/ArrowStringDataFrameColumn.cs
@@ -226,7 +226,7 @@ namespace Microsoft.Data.Analysis
         {
             if (rowIndex >= Length)
             {
-                throw new ArgumentOutOfRangeException(Strings.ColumnIndexOutOfRange, nameof(rowIndex));
+                throw new ArgumentOutOfRangeException(Strings.RowIndexOutOfRange, nameof(rowIndex));
             }
 
             // Since the strings here could be of variable length, scan linearly

--- a/src/Microsoft.Data.Analysis/BitUtility.cs
+++ b/src/Microsoft.Data.Analysis/BitUtility.cs
@@ -148,7 +148,7 @@ namespace Microsoft.Data.Analysis
         {
             var endByteIndex = (int)(length / 8);
 
-            Debug.Assert(span.Length > endByteIndex);
+            Debug.Assert(span.Length >= endByteIndex);
 
             long count = 0;
             for (var i = 0; i < endByteIndex; i++)

--- a/src/Microsoft.Data.Analysis/Computations/Arithmetic.cs
+++ b/src/Microsoft.Data.Analysis/Computations/Arithmetic.cs
@@ -192,52 +192,52 @@ namespace Microsoft.Data.Analysis
 
         //Comparison operations
 
-        public void HandleOperation(ComparisonOperation operation, ReadOnlySpan<T> x, ReadOnlySpan<T> y, PrimitiveColumnContainer<bool> result, long offset)
+        public void HandleOperation(ComparisonOperation operation, ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<bool> destination)
         {
             switch (operation)
             {
                 case ComparisonOperation.ElementwiseEquals:
-                    ElementwiseEquals(x, y, result, offset);
+                    ElementwiseEquals(x, y, destination);
                     break;
                 case ComparisonOperation.ElementwiseNotEquals:
-                    ElementwiseNotEquals(x, y, result, offset);
+                    ElementwiseNotEquals(x, y, destination);
                     break;
                 case ComparisonOperation.ElementwiseGreaterThanOrEqual:
-                    ElementwiseGreaterThanOrEqual(x, y, result, offset);
+                    ElementwiseGreaterThanOrEqual(x, y, destination);
                     break;
                 case ComparisonOperation.ElementwiseLessThanOrEqual:
-                    ElementwiseLessThanOrEqual(x, y, result, offset);
+                    ElementwiseLessThanOrEqual(x, y, destination);
                     break;
                 case ComparisonOperation.ElementwiseGreaterThan:
-                    ElementwiseGreaterThan(x, y, result, offset);
+                    ElementwiseGreaterThan(x, y, destination);
                     break;
                 case ComparisonOperation.ElementwiseLessThan:
-                    ElementwiseLessThan(x, y, result, offset);
+                    ElementwiseLessThan(x, y, destination);
                     break;
             }
         }
 
-        public void HandleOperation(ComparisonOperation operation, ReadOnlySpan<T> x, T y, PrimitiveColumnContainer<bool> result, long offset)
+        public void HandleOperation(ComparisonOperation operation, ReadOnlySpan<T> x, T y, Span<bool> destination)
         {
             switch (operation)
             {
                 case ComparisonOperation.ElementwiseEquals:
-                    ElementwiseEquals(x, y, result, offset);
+                    ElementwiseEquals(x, y, destination);
                     break;
                 case ComparisonOperation.ElementwiseNotEquals:
-                    ElementwiseNotEquals(x, y, result, offset);
+                    ElementwiseNotEquals(x, y, destination);
                     break;
                 case ComparisonOperation.ElementwiseGreaterThanOrEqual:
-                    ElementwiseGreaterThanOrEqual(x, y, result, offset);
+                    ElementwiseGreaterThanOrEqual(x, y, destination);
                     break;
                 case ComparisonOperation.ElementwiseLessThanOrEqual:
-                    ElementwiseLessThanOrEqual(x, y, result, offset);
+                    ElementwiseLessThanOrEqual(x, y, destination);
                     break;
                 case ComparisonOperation.ElementwiseGreaterThan:
-                    ElementwiseGreaterThan(x, y, result, offset);
+                    ElementwiseGreaterThan(x, y, destination);
                     break;
                 case ComparisonOperation.ElementwiseLessThan:
-                    ElementwiseLessThan(x, y, result, offset);
+                    ElementwiseLessThan(x, y, destination);
                     break;
             }
         }
@@ -297,29 +297,29 @@ namespace Microsoft.Data.Analysis
 
         protected virtual void RightShift(ReadOnlySpan<T> x, int y, Span<T> destination) => throw new NotSupportedException();
 
-        protected virtual void ElementwiseEquals(ReadOnlySpan<T> x, ReadOnlySpan<T> y, PrimitiveColumnContainer<bool> result, long offset) => throw new NotSupportedException();
+        protected virtual void ElementwiseEquals(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<bool> destination) => throw new NotSupportedException();
 
-        protected virtual void ElementwiseEquals(ReadOnlySpan<T> x, T y, PrimitiveColumnContainer<bool> result, long offset) => throw new NotSupportedException();
+        protected virtual void ElementwiseEquals(ReadOnlySpan<T> x, T y, Span<bool> destination) => throw new NotSupportedException();
 
-        protected virtual void ElementwiseNotEquals(ReadOnlySpan<T> x, ReadOnlySpan<T> y, PrimitiveColumnContainer<bool> result, long offset) => throw new NotSupportedException();
+        protected virtual void ElementwiseNotEquals(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<bool> destination) => throw new NotSupportedException();
 
-        protected virtual void ElementwiseNotEquals(ReadOnlySpan<T> x, T y, PrimitiveColumnContainer<bool> result, long offset) => throw new NotSupportedException();
+        protected virtual void ElementwiseNotEquals(ReadOnlySpan<T> x, T y, Span<bool> destination) => throw new NotSupportedException();
 
-        protected virtual void ElementwiseGreaterThanOrEqual(ReadOnlySpan<T> x, ReadOnlySpan<T> y, PrimitiveColumnContainer<bool> result, long offset) => throw new NotSupportedException();
+        protected virtual void ElementwiseGreaterThanOrEqual(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<bool> destination) => throw new NotSupportedException();
 
-        protected virtual void ElementwiseGreaterThanOrEqual(ReadOnlySpan<T> x, T y, PrimitiveColumnContainer<bool> result, long offset) => throw new NotSupportedException();
+        protected virtual void ElementwiseGreaterThanOrEqual(ReadOnlySpan<T> x, T y, Span<bool> destination) => throw new NotSupportedException();
 
-        protected virtual void ElementwiseLessThanOrEqual(ReadOnlySpan<T> x, ReadOnlySpan<T> y, PrimitiveColumnContainer<bool> result, long offset) => throw new NotSupportedException();
+        protected virtual void ElementwiseLessThanOrEqual(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<bool> destination) => throw new NotSupportedException();
 
-        protected virtual void ElementwiseLessThanOrEqual(ReadOnlySpan<T> x, T y, PrimitiveColumnContainer<bool> result, long offset) => throw new NotSupportedException();
+        protected virtual void ElementwiseLessThanOrEqual(ReadOnlySpan<T> x, T y, Span<bool> destination) => throw new NotSupportedException();
 
-        protected virtual void ElementwiseGreaterThan(ReadOnlySpan<T> x, ReadOnlySpan<T> y, PrimitiveColumnContainer<bool> result, long offset) => throw new NotSupportedException();
+        protected virtual void ElementwiseGreaterThan(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<bool> destination) => throw new NotSupportedException();
 
-        protected virtual void ElementwiseGreaterThan(ReadOnlySpan<T> x, T y, PrimitiveColumnContainer<bool> result, long offset) => throw new NotSupportedException();
+        protected virtual void ElementwiseGreaterThan(ReadOnlySpan<T> x, T y, Span<bool> destination) => throw new NotSupportedException();
 
-        protected virtual void ElementwiseLessThan(ReadOnlySpan<T> x, ReadOnlySpan<T> y, PrimitiveColumnContainer<bool> result, long offset) => throw new NotSupportedException();
+        protected virtual void ElementwiseLessThan(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<bool> destination) => throw new NotSupportedException();
 
-        protected virtual void ElementwiseLessThan(ReadOnlySpan<T> x, T y, PrimitiveColumnContainer<bool> result, long offset) => throw new NotSupportedException();
+        protected virtual void ElementwiseLessThan(ReadOnlySpan<T> x, T y, Span<bool> destination) => throw new NotSupportedException();
 
         protected virtual T Divide(T x, T y) => throw new NotSupportedException();
 

--- a/src/Microsoft.Data.Analysis/Computations/Arithmetic.tt
+++ b/src/Microsoft.Data.Analysis/Computations/Arithmetic.tt
@@ -125,28 +125,28 @@ namespace Microsoft.Data.Analysis
 
         //Comparison operations
 
-        public void HandleOperation(ComparisonOperation operation, ReadOnlySpan<T> x, ReadOnlySpan<T> y, PrimitiveColumnContainer<bool> result, long offset)
+        public void HandleOperation(ComparisonOperation operation, ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<bool> destination)
         {
             switch (operation)
             {
 <# foreach (MethodConfiguration method in methodConfiguration) { #>
 <# if (method.MethodType == MethodType.Comparison) { #>
                 case ComparisonOperation.<#=method.MethodName#>:
-                    <#=method.MethodName#>(x, y, result, offset);
+                    <#=method.MethodName#>(x, y, destination);
                     break;
 <# } #>
 <# } #>
             }
         }
 
-        public void HandleOperation(ComparisonOperation operation, ReadOnlySpan<T> x, T y, PrimitiveColumnContainer<bool> result, long offset)
+        public void HandleOperation(ComparisonOperation operation, ReadOnlySpan<T> x, T y, Span<bool> destination)
         {
             switch (operation)
             {
 <# foreach (MethodConfiguration method in methodConfiguration) { #>
 <# if (method.MethodType == MethodType.ComparisonScalar) { #>
                 case ComparisonOperation.<#=method.MethodName#>:
-                    <#=method.MethodName#>(x, y, result, offset);
+                    <#=method.MethodName#>(x, y, destination);
                     break;
 <# } #>
 <# } #>
@@ -158,11 +158,11 @@ namespace Microsoft.Data.Analysis
 <# foreach (MethodConfiguration method in methodConfiguration) { #>
 <# if (method.MethodType == MethodType.Comparison) { #>
 
-        protected virtual void <#=method.MethodName#>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, PrimitiveColumnContainer<bool> result, long offset) => throw new NotSupportedException();
+        protected virtual void <#=method.MethodName#>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<bool> destination) => throw new NotSupportedException();
 <# } #>
 <# else if (method.MethodType == MethodType.ComparisonScalar) { #>
 
-        protected virtual void <#=method.MethodName#>(ReadOnlySpan<T> x, T y, PrimitiveColumnContainer<bool> result, long offset) => throw new NotSupportedException();
+        protected virtual void <#=method.MethodName#>(ReadOnlySpan<T> x, T y, Span<bool> destination) => throw new NotSupportedException();
 <# } #>
 <# else if (method.MethodType == MethodType.Binary) { #>
 

--- a/src/Microsoft.Data.Analysis/Computations/Arithmetics.cs
+++ b/src/Microsoft.Data.Analysis/Computations/Arithmetics.cs
@@ -113,35 +113,35 @@ namespace Microsoft.Data.Analysis
             }
         }
 
-        protected override void ElementwiseEquals(ReadOnlySpan<bool> x, ReadOnlySpan<bool> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseEquals(ReadOnlySpan<bool> x, ReadOnlySpan<bool> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] == y[i]);
+                destination[i] = (x[i] == y[i]);
             }
         }
 
-        protected override void ElementwiseEquals(ReadOnlySpan<bool> x, bool y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseEquals(ReadOnlySpan<bool> x, bool y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] == y);
+                destination[i] = (x[i] == y);
             }
         }
 
-        protected override void ElementwiseNotEquals(ReadOnlySpan<bool> x, ReadOnlySpan<bool> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseNotEquals(ReadOnlySpan<bool> x, ReadOnlySpan<bool> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] != y[i]);
+                destination[i] = (x[i] != y[i]);
             }
         }
 
-        protected override void ElementwiseNotEquals(ReadOnlySpan<bool> x, bool y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseNotEquals(ReadOnlySpan<bool> x, bool y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] != y);
+                destination[i] = (x[i] != y);
             }
         }
     }
@@ -518,99 +518,99 @@ namespace Microsoft.Data.Analysis
                 destination[i] = (byte)(x[i] >> y);
         }
 
-        protected override void ElementwiseEquals(ReadOnlySpan<byte> x, ReadOnlySpan<byte> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseEquals(ReadOnlySpan<byte> x, ReadOnlySpan<byte> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] == y[i]);
+                destination[i] = (x[i] == y[i]);
             }
         }
 
-        protected override void ElementwiseEquals(ReadOnlySpan<byte> x, byte y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseEquals(ReadOnlySpan<byte> x, byte y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] == y);
+                destination[i] = (x[i] == y);
             }
         }
 
-        protected override void ElementwiseNotEquals(ReadOnlySpan<byte> x, ReadOnlySpan<byte> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseNotEquals(ReadOnlySpan<byte> x, ReadOnlySpan<byte> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] != y[i]);
+                destination[i] = (x[i] != y[i]);
             }
         }
 
-        protected override void ElementwiseNotEquals(ReadOnlySpan<byte> x, byte y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseNotEquals(ReadOnlySpan<byte> x, byte y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] != y);
+                destination[i] = (x[i] != y);
             }
         }
 
-        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<byte> x, ReadOnlySpan<byte> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<byte> x, ReadOnlySpan<byte> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] >= y[i]);
+                destination[i] = (x[i] >= y[i]);
             }
         }
 
-        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<byte> x, byte y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<byte> x, byte y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] >= y);
+                destination[i] = (x[i] >= y);
             }
         }
 
-        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<byte> x, ReadOnlySpan<byte> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<byte> x, ReadOnlySpan<byte> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] <= y[i]);
+                destination[i] = (x[i] <= y[i]);
             }
         }
 
-        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<byte> x, byte y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<byte> x, byte y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] <= y);
+                destination[i] = (x[i] <= y);
             }
         }
 
-        protected override void ElementwiseGreaterThan(ReadOnlySpan<byte> x, ReadOnlySpan<byte> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThan(ReadOnlySpan<byte> x, ReadOnlySpan<byte> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] > y[i]);
+                destination[i] = (x[i] > y[i]);
             }
         }
 
-        protected override void ElementwiseGreaterThan(ReadOnlySpan<byte> x, byte y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThan(ReadOnlySpan<byte> x, byte y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] > y);
+                destination[i] = (x[i] > y);
             }
         }
 
-        protected override void ElementwiseLessThan(ReadOnlySpan<byte> x, ReadOnlySpan<byte> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThan(ReadOnlySpan<byte> x, ReadOnlySpan<byte> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] < y[i]);
+                destination[i] = (x[i] < y[i]);
             }
         }
 
-        protected override void ElementwiseLessThan(ReadOnlySpan<byte> x, byte y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThan(ReadOnlySpan<byte> x, byte y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] < y);
+                destination[i] = (x[i] < y);
             }
         }
     }
@@ -987,99 +987,99 @@ namespace Microsoft.Data.Analysis
                 destination[i] = (char)(x[i] >> y);
         }
 
-        protected override void ElementwiseEquals(ReadOnlySpan<char> x, ReadOnlySpan<char> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseEquals(ReadOnlySpan<char> x, ReadOnlySpan<char> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] == y[i]);
+                destination[i] = (x[i] == y[i]);
             }
         }
 
-        protected override void ElementwiseEquals(ReadOnlySpan<char> x, char y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseEquals(ReadOnlySpan<char> x, char y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] == y);
+                destination[i] = (x[i] == y);
             }
         }
 
-        protected override void ElementwiseNotEquals(ReadOnlySpan<char> x, ReadOnlySpan<char> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseNotEquals(ReadOnlySpan<char> x, ReadOnlySpan<char> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] != y[i]);
+                destination[i] = (x[i] != y[i]);
             }
         }
 
-        protected override void ElementwiseNotEquals(ReadOnlySpan<char> x, char y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseNotEquals(ReadOnlySpan<char> x, char y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] != y);
+                destination[i] = (x[i] != y);
             }
         }
 
-        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<char> x, ReadOnlySpan<char> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<char> x, ReadOnlySpan<char> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] >= y[i]);
+                destination[i] = (x[i] >= y[i]);
             }
         }
 
-        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<char> x, char y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<char> x, char y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] >= y);
+                destination[i] = (x[i] >= y);
             }
         }
 
-        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<char> x, ReadOnlySpan<char> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<char> x, ReadOnlySpan<char> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] <= y[i]);
+                destination[i] = (x[i] <= y[i]);
             }
         }
 
-        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<char> x, char y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<char> x, char y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] <= y);
+                destination[i] = (x[i] <= y);
             }
         }
 
-        protected override void ElementwiseGreaterThan(ReadOnlySpan<char> x, ReadOnlySpan<char> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThan(ReadOnlySpan<char> x, ReadOnlySpan<char> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] > y[i]);
+                destination[i] = (x[i] > y[i]);
             }
         }
 
-        protected override void ElementwiseGreaterThan(ReadOnlySpan<char> x, char y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThan(ReadOnlySpan<char> x, char y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] > y);
+                destination[i] = (x[i] > y);
             }
         }
 
-        protected override void ElementwiseLessThan(ReadOnlySpan<char> x, ReadOnlySpan<char> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThan(ReadOnlySpan<char> x, ReadOnlySpan<char> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] < y[i]);
+                destination[i] = (x[i] < y[i]);
             }
         }
 
-        protected override void ElementwiseLessThan(ReadOnlySpan<char> x, char y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThan(ReadOnlySpan<char> x, char y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] < y);
+                destination[i] = (x[i] < y);
             }
         }
     }
@@ -1261,99 +1261,99 @@ namespace Microsoft.Data.Analysis
             }
         }
 
-        protected override void ElementwiseEquals(ReadOnlySpan<decimal> x, ReadOnlySpan<decimal> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseEquals(ReadOnlySpan<decimal> x, ReadOnlySpan<decimal> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] == y[i]);
+                destination[i] = (x[i] == y[i]);
             }
         }
 
-        protected override void ElementwiseEquals(ReadOnlySpan<decimal> x, decimal y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseEquals(ReadOnlySpan<decimal> x, decimal y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] == y);
+                destination[i] = (x[i] == y);
             }
         }
 
-        protected override void ElementwiseNotEquals(ReadOnlySpan<decimal> x, ReadOnlySpan<decimal> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseNotEquals(ReadOnlySpan<decimal> x, ReadOnlySpan<decimal> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] != y[i]);
+                destination[i] = (x[i] != y[i]);
             }
         }
 
-        protected override void ElementwiseNotEquals(ReadOnlySpan<decimal> x, decimal y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseNotEquals(ReadOnlySpan<decimal> x, decimal y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] != y);
+                destination[i] = (x[i] != y);
             }
         }
 
-        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<decimal> x, ReadOnlySpan<decimal> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<decimal> x, ReadOnlySpan<decimal> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] >= y[i]);
+                destination[i] = (x[i] >= y[i]);
             }
         }
 
-        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<decimal> x, decimal y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<decimal> x, decimal y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] >= y);
+                destination[i] = (x[i] >= y);
             }
         }
 
-        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<decimal> x, ReadOnlySpan<decimal> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<decimal> x, ReadOnlySpan<decimal> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] <= y[i]);
+                destination[i] = (x[i] <= y[i]);
             }
         }
 
-        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<decimal> x, decimal y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<decimal> x, decimal y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] <= y);
+                destination[i] = (x[i] <= y);
             }
         }
 
-        protected override void ElementwiseGreaterThan(ReadOnlySpan<decimal> x, ReadOnlySpan<decimal> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThan(ReadOnlySpan<decimal> x, ReadOnlySpan<decimal> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] > y[i]);
+                destination[i] = (x[i] > y[i]);
             }
         }
 
-        protected override void ElementwiseGreaterThan(ReadOnlySpan<decimal> x, decimal y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThan(ReadOnlySpan<decimal> x, decimal y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] > y);
+                destination[i] = (x[i] > y);
             }
         }
 
-        protected override void ElementwiseLessThan(ReadOnlySpan<decimal> x, ReadOnlySpan<decimal> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThan(ReadOnlySpan<decimal> x, ReadOnlySpan<decimal> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] < y[i]);
+                destination[i] = (x[i] < y[i]);
             }
         }
 
-        protected override void ElementwiseLessThan(ReadOnlySpan<decimal> x, decimal y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThan(ReadOnlySpan<decimal> x, decimal y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] < y);
+                destination[i] = (x[i] < y);
             }
         }
     }
@@ -1619,99 +1619,99 @@ namespace Microsoft.Data.Analysis
             }
         }
 
-        protected override void ElementwiseEquals(ReadOnlySpan<double> x, ReadOnlySpan<double> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseEquals(ReadOnlySpan<double> x, ReadOnlySpan<double> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] == y[i]);
+                destination[i] = (x[i] == y[i]);
             }
         }
 
-        protected override void ElementwiseEquals(ReadOnlySpan<double> x, double y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseEquals(ReadOnlySpan<double> x, double y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] == y);
+                destination[i] = (x[i] == y);
             }
         }
 
-        protected override void ElementwiseNotEquals(ReadOnlySpan<double> x, ReadOnlySpan<double> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseNotEquals(ReadOnlySpan<double> x, ReadOnlySpan<double> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] != y[i]);
+                destination[i] = (x[i] != y[i]);
             }
         }
 
-        protected override void ElementwiseNotEquals(ReadOnlySpan<double> x, double y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseNotEquals(ReadOnlySpan<double> x, double y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] != y);
+                destination[i] = (x[i] != y);
             }
         }
 
-        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<double> x, ReadOnlySpan<double> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<double> x, ReadOnlySpan<double> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] >= y[i]);
+                destination[i] = (x[i] >= y[i]);
             }
         }
 
-        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<double> x, double y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<double> x, double y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] >= y);
+                destination[i] = (x[i] >= y);
             }
         }
 
-        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<double> x, ReadOnlySpan<double> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<double> x, ReadOnlySpan<double> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] <= y[i]);
+                destination[i] = (x[i] <= y[i]);
             }
         }
 
-        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<double> x, double y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<double> x, double y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] <= y);
+                destination[i] = (x[i] <= y);
             }
         }
 
-        protected override void ElementwiseGreaterThan(ReadOnlySpan<double> x, ReadOnlySpan<double> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThan(ReadOnlySpan<double> x, ReadOnlySpan<double> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] > y[i]);
+                destination[i] = (x[i] > y[i]);
             }
         }
 
-        protected override void ElementwiseGreaterThan(ReadOnlySpan<double> x, double y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThan(ReadOnlySpan<double> x, double y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] > y);
+                destination[i] = (x[i] > y);
             }
         }
 
-        protected override void ElementwiseLessThan(ReadOnlySpan<double> x, ReadOnlySpan<double> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThan(ReadOnlySpan<double> x, ReadOnlySpan<double> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] < y[i]);
+                destination[i] = (x[i] < y[i]);
             }
         }
 
-        protected override void ElementwiseLessThan(ReadOnlySpan<double> x, double y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThan(ReadOnlySpan<double> x, double y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] < y);
+                destination[i] = (x[i] < y);
             }
         }
     }
@@ -1977,99 +1977,99 @@ namespace Microsoft.Data.Analysis
             }
         }
 
-        protected override void ElementwiseEquals(ReadOnlySpan<float> x, ReadOnlySpan<float> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseEquals(ReadOnlySpan<float> x, ReadOnlySpan<float> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] == y[i]);
+                destination[i] = (x[i] == y[i]);
             }
         }
 
-        protected override void ElementwiseEquals(ReadOnlySpan<float> x, float y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseEquals(ReadOnlySpan<float> x, float y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] == y);
+                destination[i] = (x[i] == y);
             }
         }
 
-        protected override void ElementwiseNotEquals(ReadOnlySpan<float> x, ReadOnlySpan<float> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseNotEquals(ReadOnlySpan<float> x, ReadOnlySpan<float> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] != y[i]);
+                destination[i] = (x[i] != y[i]);
             }
         }
 
-        protected override void ElementwiseNotEquals(ReadOnlySpan<float> x, float y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseNotEquals(ReadOnlySpan<float> x, float y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] != y);
+                destination[i] = (x[i] != y);
             }
         }
 
-        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<float> x, ReadOnlySpan<float> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<float> x, ReadOnlySpan<float> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] >= y[i]);
+                destination[i] = (x[i] >= y[i]);
             }
         }
 
-        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<float> x, float y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<float> x, float y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] >= y);
+                destination[i] = (x[i] >= y);
             }
         }
 
-        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<float> x, ReadOnlySpan<float> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<float> x, ReadOnlySpan<float> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] <= y[i]);
+                destination[i] = (x[i] <= y[i]);
             }
         }
 
-        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<float> x, float y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<float> x, float y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] <= y);
+                destination[i] = (x[i] <= y);
             }
         }
 
-        protected override void ElementwiseGreaterThan(ReadOnlySpan<float> x, ReadOnlySpan<float> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThan(ReadOnlySpan<float> x, ReadOnlySpan<float> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] > y[i]);
+                destination[i] = (x[i] > y[i]);
             }
         }
 
-        protected override void ElementwiseGreaterThan(ReadOnlySpan<float> x, float y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThan(ReadOnlySpan<float> x, float y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] > y);
+                destination[i] = (x[i] > y);
             }
         }
 
-        protected override void ElementwiseLessThan(ReadOnlySpan<float> x, ReadOnlySpan<float> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThan(ReadOnlySpan<float> x, ReadOnlySpan<float> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] < y[i]);
+                destination[i] = (x[i] < y[i]);
             }
         }
 
-        protected override void ElementwiseLessThan(ReadOnlySpan<float> x, float y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThan(ReadOnlySpan<float> x, float y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] < y);
+                destination[i] = (x[i] < y);
             }
         }
     }
@@ -2446,99 +2446,99 @@ namespace Microsoft.Data.Analysis
                 destination[i] = (int)(x[i] >> y);
         }
 
-        protected override void ElementwiseEquals(ReadOnlySpan<int> x, ReadOnlySpan<int> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseEquals(ReadOnlySpan<int> x, ReadOnlySpan<int> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] == y[i]);
+                destination[i] = (x[i] == y[i]);
             }
         }
 
-        protected override void ElementwiseEquals(ReadOnlySpan<int> x, int y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseEquals(ReadOnlySpan<int> x, int y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] == y);
+                destination[i] = (x[i] == y);
             }
         }
 
-        protected override void ElementwiseNotEquals(ReadOnlySpan<int> x, ReadOnlySpan<int> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseNotEquals(ReadOnlySpan<int> x, ReadOnlySpan<int> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] != y[i]);
+                destination[i] = (x[i] != y[i]);
             }
         }
 
-        protected override void ElementwiseNotEquals(ReadOnlySpan<int> x, int y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseNotEquals(ReadOnlySpan<int> x, int y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] != y);
+                destination[i] = (x[i] != y);
             }
         }
 
-        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<int> x, ReadOnlySpan<int> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<int> x, ReadOnlySpan<int> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] >= y[i]);
+                destination[i] = (x[i] >= y[i]);
             }
         }
 
-        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<int> x, int y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<int> x, int y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] >= y);
+                destination[i] = (x[i] >= y);
             }
         }
 
-        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<int> x, ReadOnlySpan<int> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<int> x, ReadOnlySpan<int> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] <= y[i]);
+                destination[i] = (x[i] <= y[i]);
             }
         }
 
-        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<int> x, int y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<int> x, int y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] <= y);
+                destination[i] = (x[i] <= y);
             }
         }
 
-        protected override void ElementwiseGreaterThan(ReadOnlySpan<int> x, ReadOnlySpan<int> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThan(ReadOnlySpan<int> x, ReadOnlySpan<int> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] > y[i]);
+                destination[i] = (x[i] > y[i]);
             }
         }
 
-        protected override void ElementwiseGreaterThan(ReadOnlySpan<int> x, int y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThan(ReadOnlySpan<int> x, int y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] > y);
+                destination[i] = (x[i] > y);
             }
         }
 
-        protected override void ElementwiseLessThan(ReadOnlySpan<int> x, ReadOnlySpan<int> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThan(ReadOnlySpan<int> x, ReadOnlySpan<int> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] < y[i]);
+                destination[i] = (x[i] < y[i]);
             }
         }
 
-        protected override void ElementwiseLessThan(ReadOnlySpan<int> x, int y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThan(ReadOnlySpan<int> x, int y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] < y);
+                destination[i] = (x[i] < y);
             }
         }
     }
@@ -2915,99 +2915,99 @@ namespace Microsoft.Data.Analysis
                 destination[i] = (long)(x[i] >> y);
         }
 
-        protected override void ElementwiseEquals(ReadOnlySpan<long> x, ReadOnlySpan<long> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseEquals(ReadOnlySpan<long> x, ReadOnlySpan<long> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] == y[i]);
+                destination[i] = (x[i] == y[i]);
             }
         }
 
-        protected override void ElementwiseEquals(ReadOnlySpan<long> x, long y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseEquals(ReadOnlySpan<long> x, long y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] == y);
+                destination[i] = (x[i] == y);
             }
         }
 
-        protected override void ElementwiseNotEquals(ReadOnlySpan<long> x, ReadOnlySpan<long> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseNotEquals(ReadOnlySpan<long> x, ReadOnlySpan<long> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] != y[i]);
+                destination[i] = (x[i] != y[i]);
             }
         }
 
-        protected override void ElementwiseNotEquals(ReadOnlySpan<long> x, long y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseNotEquals(ReadOnlySpan<long> x, long y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] != y);
+                destination[i] = (x[i] != y);
             }
         }
 
-        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<long> x, ReadOnlySpan<long> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<long> x, ReadOnlySpan<long> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] >= y[i]);
+                destination[i] = (x[i] >= y[i]);
             }
         }
 
-        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<long> x, long y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<long> x, long y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] >= y);
+                destination[i] = (x[i] >= y);
             }
         }
 
-        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<long> x, ReadOnlySpan<long> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<long> x, ReadOnlySpan<long> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] <= y[i]);
+                destination[i] = (x[i] <= y[i]);
             }
         }
 
-        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<long> x, long y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<long> x, long y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] <= y);
+                destination[i] = (x[i] <= y);
             }
         }
 
-        protected override void ElementwiseGreaterThan(ReadOnlySpan<long> x, ReadOnlySpan<long> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThan(ReadOnlySpan<long> x, ReadOnlySpan<long> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] > y[i]);
+                destination[i] = (x[i] > y[i]);
             }
         }
 
-        protected override void ElementwiseGreaterThan(ReadOnlySpan<long> x, long y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThan(ReadOnlySpan<long> x, long y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] > y);
+                destination[i] = (x[i] > y);
             }
         }
 
-        protected override void ElementwiseLessThan(ReadOnlySpan<long> x, ReadOnlySpan<long> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThan(ReadOnlySpan<long> x, ReadOnlySpan<long> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] < y[i]);
+                destination[i] = (x[i] < y[i]);
             }
         }
 
-        protected override void ElementwiseLessThan(ReadOnlySpan<long> x, long y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThan(ReadOnlySpan<long> x, long y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] < y);
+                destination[i] = (x[i] < y);
             }
         }
     }
@@ -3384,99 +3384,99 @@ namespace Microsoft.Data.Analysis
                 destination[i] = (sbyte)(x[i] >> y);
         }
 
-        protected override void ElementwiseEquals(ReadOnlySpan<sbyte> x, ReadOnlySpan<sbyte> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseEquals(ReadOnlySpan<sbyte> x, ReadOnlySpan<sbyte> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] == y[i]);
+                destination[i] = (x[i] == y[i]);
             }
         }
 
-        protected override void ElementwiseEquals(ReadOnlySpan<sbyte> x, sbyte y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseEquals(ReadOnlySpan<sbyte> x, sbyte y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] == y);
+                destination[i] = (x[i] == y);
             }
         }
 
-        protected override void ElementwiseNotEquals(ReadOnlySpan<sbyte> x, ReadOnlySpan<sbyte> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseNotEquals(ReadOnlySpan<sbyte> x, ReadOnlySpan<sbyte> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] != y[i]);
+                destination[i] = (x[i] != y[i]);
             }
         }
 
-        protected override void ElementwiseNotEquals(ReadOnlySpan<sbyte> x, sbyte y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseNotEquals(ReadOnlySpan<sbyte> x, sbyte y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] != y);
+                destination[i] = (x[i] != y);
             }
         }
 
-        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<sbyte> x, ReadOnlySpan<sbyte> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<sbyte> x, ReadOnlySpan<sbyte> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] >= y[i]);
+                destination[i] = (x[i] >= y[i]);
             }
         }
 
-        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<sbyte> x, sbyte y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<sbyte> x, sbyte y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] >= y);
+                destination[i] = (x[i] >= y);
             }
         }
 
-        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<sbyte> x, ReadOnlySpan<sbyte> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<sbyte> x, ReadOnlySpan<sbyte> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] <= y[i]);
+                destination[i] = (x[i] <= y[i]);
             }
         }
 
-        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<sbyte> x, sbyte y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<sbyte> x, sbyte y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] <= y);
+                destination[i] = (x[i] <= y);
             }
         }
 
-        protected override void ElementwiseGreaterThan(ReadOnlySpan<sbyte> x, ReadOnlySpan<sbyte> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThan(ReadOnlySpan<sbyte> x, ReadOnlySpan<sbyte> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] > y[i]);
+                destination[i] = (x[i] > y[i]);
             }
         }
 
-        protected override void ElementwiseGreaterThan(ReadOnlySpan<sbyte> x, sbyte y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThan(ReadOnlySpan<sbyte> x, sbyte y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] > y);
+                destination[i] = (x[i] > y);
             }
         }
 
-        protected override void ElementwiseLessThan(ReadOnlySpan<sbyte> x, ReadOnlySpan<sbyte> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThan(ReadOnlySpan<sbyte> x, ReadOnlySpan<sbyte> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] < y[i]);
+                destination[i] = (x[i] < y[i]);
             }
         }
 
-        protected override void ElementwiseLessThan(ReadOnlySpan<sbyte> x, sbyte y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThan(ReadOnlySpan<sbyte> x, sbyte y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] < y);
+                destination[i] = (x[i] < y);
             }
         }
     }
@@ -3853,99 +3853,99 @@ namespace Microsoft.Data.Analysis
                 destination[i] = (short)(x[i] >> y);
         }
 
-        protected override void ElementwiseEquals(ReadOnlySpan<short> x, ReadOnlySpan<short> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseEquals(ReadOnlySpan<short> x, ReadOnlySpan<short> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] == y[i]);
+                destination[i] = (x[i] == y[i]);
             }
         }
 
-        protected override void ElementwiseEquals(ReadOnlySpan<short> x, short y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseEquals(ReadOnlySpan<short> x, short y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] == y);
+                destination[i] = (x[i] == y);
             }
         }
 
-        protected override void ElementwiseNotEquals(ReadOnlySpan<short> x, ReadOnlySpan<short> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseNotEquals(ReadOnlySpan<short> x, ReadOnlySpan<short> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] != y[i]);
+                destination[i] = (x[i] != y[i]);
             }
         }
 
-        protected override void ElementwiseNotEquals(ReadOnlySpan<short> x, short y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseNotEquals(ReadOnlySpan<short> x, short y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] != y);
+                destination[i] = (x[i] != y);
             }
         }
 
-        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<short> x, ReadOnlySpan<short> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<short> x, ReadOnlySpan<short> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] >= y[i]);
+                destination[i] = (x[i] >= y[i]);
             }
         }
 
-        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<short> x, short y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<short> x, short y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] >= y);
+                destination[i] = (x[i] >= y);
             }
         }
 
-        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<short> x, ReadOnlySpan<short> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<short> x, ReadOnlySpan<short> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] <= y[i]);
+                destination[i] = (x[i] <= y[i]);
             }
         }
 
-        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<short> x, short y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<short> x, short y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] <= y);
+                destination[i] = (x[i] <= y);
             }
         }
 
-        protected override void ElementwiseGreaterThan(ReadOnlySpan<short> x, ReadOnlySpan<short> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThan(ReadOnlySpan<short> x, ReadOnlySpan<short> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] > y[i]);
+                destination[i] = (x[i] > y[i]);
             }
         }
 
-        protected override void ElementwiseGreaterThan(ReadOnlySpan<short> x, short y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThan(ReadOnlySpan<short> x, short y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] > y);
+                destination[i] = (x[i] > y);
             }
         }
 
-        protected override void ElementwiseLessThan(ReadOnlySpan<short> x, ReadOnlySpan<short> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThan(ReadOnlySpan<short> x, ReadOnlySpan<short> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] < y[i]);
+                destination[i] = (x[i] < y[i]);
             }
         }
 
-        protected override void ElementwiseLessThan(ReadOnlySpan<short> x, short y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThan(ReadOnlySpan<short> x, short y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] < y);
+                destination[i] = (x[i] < y);
             }
         }
     }
@@ -4322,99 +4322,99 @@ namespace Microsoft.Data.Analysis
                 destination[i] = (uint)(x[i] >> y);
         }
 
-        protected override void ElementwiseEquals(ReadOnlySpan<uint> x, ReadOnlySpan<uint> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseEquals(ReadOnlySpan<uint> x, ReadOnlySpan<uint> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] == y[i]);
+                destination[i] = (x[i] == y[i]);
             }
         }
 
-        protected override void ElementwiseEquals(ReadOnlySpan<uint> x, uint y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseEquals(ReadOnlySpan<uint> x, uint y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] == y);
+                destination[i] = (x[i] == y);
             }
         }
 
-        protected override void ElementwiseNotEquals(ReadOnlySpan<uint> x, ReadOnlySpan<uint> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseNotEquals(ReadOnlySpan<uint> x, ReadOnlySpan<uint> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] != y[i]);
+                destination[i] = (x[i] != y[i]);
             }
         }
 
-        protected override void ElementwiseNotEquals(ReadOnlySpan<uint> x, uint y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseNotEquals(ReadOnlySpan<uint> x, uint y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] != y);
+                destination[i] = (x[i] != y);
             }
         }
 
-        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<uint> x, ReadOnlySpan<uint> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<uint> x, ReadOnlySpan<uint> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] >= y[i]);
+                destination[i] = (x[i] >= y[i]);
             }
         }
 
-        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<uint> x, uint y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<uint> x, uint y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] >= y);
+                destination[i] = (x[i] >= y);
             }
         }
 
-        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<uint> x, ReadOnlySpan<uint> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<uint> x, ReadOnlySpan<uint> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] <= y[i]);
+                destination[i] = (x[i] <= y[i]);
             }
         }
 
-        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<uint> x, uint y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<uint> x, uint y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] <= y);
+                destination[i] = (x[i] <= y);
             }
         }
 
-        protected override void ElementwiseGreaterThan(ReadOnlySpan<uint> x, ReadOnlySpan<uint> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThan(ReadOnlySpan<uint> x, ReadOnlySpan<uint> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] > y[i]);
+                destination[i] = (x[i] > y[i]);
             }
         }
 
-        protected override void ElementwiseGreaterThan(ReadOnlySpan<uint> x, uint y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThan(ReadOnlySpan<uint> x, uint y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] > y);
+                destination[i] = (x[i] > y);
             }
         }
 
-        protected override void ElementwiseLessThan(ReadOnlySpan<uint> x, ReadOnlySpan<uint> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThan(ReadOnlySpan<uint> x, ReadOnlySpan<uint> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] < y[i]);
+                destination[i] = (x[i] < y[i]);
             }
         }
 
-        protected override void ElementwiseLessThan(ReadOnlySpan<uint> x, uint y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThan(ReadOnlySpan<uint> x, uint y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] < y);
+                destination[i] = (x[i] < y);
             }
         }
     }
@@ -4791,99 +4791,99 @@ namespace Microsoft.Data.Analysis
                 destination[i] = (ulong)(x[i] >> y);
         }
 
-        protected override void ElementwiseEquals(ReadOnlySpan<ulong> x, ReadOnlySpan<ulong> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseEquals(ReadOnlySpan<ulong> x, ReadOnlySpan<ulong> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] == y[i]);
+                destination[i] = (x[i] == y[i]);
             }
         }
 
-        protected override void ElementwiseEquals(ReadOnlySpan<ulong> x, ulong y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseEquals(ReadOnlySpan<ulong> x, ulong y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] == y);
+                destination[i] = (x[i] == y);
             }
         }
 
-        protected override void ElementwiseNotEquals(ReadOnlySpan<ulong> x, ReadOnlySpan<ulong> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseNotEquals(ReadOnlySpan<ulong> x, ReadOnlySpan<ulong> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] != y[i]);
+                destination[i] = (x[i] != y[i]);
             }
         }
 
-        protected override void ElementwiseNotEquals(ReadOnlySpan<ulong> x, ulong y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseNotEquals(ReadOnlySpan<ulong> x, ulong y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] != y);
+                destination[i] = (x[i] != y);
             }
         }
 
-        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<ulong> x, ReadOnlySpan<ulong> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<ulong> x, ReadOnlySpan<ulong> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] >= y[i]);
+                destination[i] = (x[i] >= y[i]);
             }
         }
 
-        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<ulong> x, ulong y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<ulong> x, ulong y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] >= y);
+                destination[i] = (x[i] >= y);
             }
         }
 
-        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<ulong> x, ReadOnlySpan<ulong> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<ulong> x, ReadOnlySpan<ulong> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] <= y[i]);
+                destination[i] = (x[i] <= y[i]);
             }
         }
 
-        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<ulong> x, ulong y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<ulong> x, ulong y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] <= y);
+                destination[i] = (x[i] <= y);
             }
         }
 
-        protected override void ElementwiseGreaterThan(ReadOnlySpan<ulong> x, ReadOnlySpan<ulong> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThan(ReadOnlySpan<ulong> x, ReadOnlySpan<ulong> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] > y[i]);
+                destination[i] = (x[i] > y[i]);
             }
         }
 
-        protected override void ElementwiseGreaterThan(ReadOnlySpan<ulong> x, ulong y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThan(ReadOnlySpan<ulong> x, ulong y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] > y);
+                destination[i] = (x[i] > y);
             }
         }
 
-        protected override void ElementwiseLessThan(ReadOnlySpan<ulong> x, ReadOnlySpan<ulong> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThan(ReadOnlySpan<ulong> x, ReadOnlySpan<ulong> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] < y[i]);
+                destination[i] = (x[i] < y[i]);
             }
         }
 
-        protected override void ElementwiseLessThan(ReadOnlySpan<ulong> x, ulong y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThan(ReadOnlySpan<ulong> x, ulong y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] < y);
+                destination[i] = (x[i] < y);
             }
         }
     }
@@ -5260,134 +5260,134 @@ namespace Microsoft.Data.Analysis
                 destination[i] = (ushort)(x[i] >> y);
         }
 
-        protected override void ElementwiseEquals(ReadOnlySpan<ushort> x, ReadOnlySpan<ushort> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseEquals(ReadOnlySpan<ushort> x, ReadOnlySpan<ushort> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] == y[i]);
+                destination[i] = (x[i] == y[i]);
             }
         }
 
-        protected override void ElementwiseEquals(ReadOnlySpan<ushort> x, ushort y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseEquals(ReadOnlySpan<ushort> x, ushort y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] == y);
+                destination[i] = (x[i] == y);
             }
         }
 
-        protected override void ElementwiseNotEquals(ReadOnlySpan<ushort> x, ReadOnlySpan<ushort> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseNotEquals(ReadOnlySpan<ushort> x, ReadOnlySpan<ushort> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] != y[i]);
+                destination[i] = (x[i] != y[i]);
             }
         }
 
-        protected override void ElementwiseNotEquals(ReadOnlySpan<ushort> x, ushort y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseNotEquals(ReadOnlySpan<ushort> x, ushort y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] != y);
+                destination[i] = (x[i] != y);
             }
         }
 
-        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<ushort> x, ReadOnlySpan<ushort> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<ushort> x, ReadOnlySpan<ushort> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] >= y[i]);
+                destination[i] = (x[i] >= y[i]);
             }
         }
 
-        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<ushort> x, ushort y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThanOrEqual(ReadOnlySpan<ushort> x, ushort y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] >= y);
+                destination[i] = (x[i] >= y);
             }
         }
 
-        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<ushort> x, ReadOnlySpan<ushort> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<ushort> x, ReadOnlySpan<ushort> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] <= y[i]);
+                destination[i] = (x[i] <= y[i]);
             }
         }
 
-        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<ushort> x, ushort y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThanOrEqual(ReadOnlySpan<ushort> x, ushort y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] <= y);
+                destination[i] = (x[i] <= y);
             }
         }
 
-        protected override void ElementwiseGreaterThan(ReadOnlySpan<ushort> x, ReadOnlySpan<ushort> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThan(ReadOnlySpan<ushort> x, ReadOnlySpan<ushort> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] > y[i]);
+                destination[i] = (x[i] > y[i]);
             }
         }
 
-        protected override void ElementwiseGreaterThan(ReadOnlySpan<ushort> x, ushort y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseGreaterThan(ReadOnlySpan<ushort> x, ushort y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] > y);
+                destination[i] = (x[i] > y);
             }
         }
 
-        protected override void ElementwiseLessThan(ReadOnlySpan<ushort> x, ReadOnlySpan<ushort> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThan(ReadOnlySpan<ushort> x, ReadOnlySpan<ushort> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] < y[i]);
+                destination[i] = (x[i] < y[i]);
             }
         }
 
-        protected override void ElementwiseLessThan(ReadOnlySpan<ushort> x, ushort y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseLessThan(ReadOnlySpan<ushort> x, ushort y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] < y);
+                destination[i] = (x[i] < y);
             }
         }
     }
     internal class DateTimeArithmetic : Arithmetic<DateTime>
     {
 
-        protected override void ElementwiseEquals(ReadOnlySpan<DateTime> x, ReadOnlySpan<DateTime> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseEquals(ReadOnlySpan<DateTime> x, ReadOnlySpan<DateTime> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] == y[i]);
+                destination[i] = (x[i] == y[i]);
             }
         }
 
-        protected override void ElementwiseEquals(ReadOnlySpan<DateTime> x, DateTime y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseEquals(ReadOnlySpan<DateTime> x, DateTime y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] == y);
+                destination[i] = (x[i] == y);
             }
         }
 
-        protected override void ElementwiseNotEquals(ReadOnlySpan<DateTime> x, ReadOnlySpan<DateTime> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseNotEquals(ReadOnlySpan<DateTime> x, ReadOnlySpan<DateTime> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] != y[i]);
+                destination[i] = (x[i] != y[i]);
             }
         }
 
-        protected override void ElementwiseNotEquals(ReadOnlySpan<DateTime> x, DateTime y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void ElementwiseNotEquals(ReadOnlySpan<DateTime> x, DateTime y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] != y);
+                destination[i] = (x[i] != y);
             }
         }
     }

--- a/src/Microsoft.Data.Analysis/Computations/Arithmetics.tt
+++ b/src/Microsoft.Data.Analysis/Computations/Arithmetics.tt
@@ -25,20 +25,20 @@ namespace Microsoft.Data.Analysis
 <# if (!((method.IsNumeric && !type.SupportsNumeric) || (method.IsBitwise && !type.SupportsBitwise) || (type.UnsupportedMethods.Contains(method.MethodName))) && method.Operator != null) { #>
 <# if (method.MethodType == MethodType.Comparison) { #>
 
-        protected override void <#=method.MethodName#>(ReadOnlySpan<<#=type.TypeName#>> x, ReadOnlySpan<<#=type.TypeName#>> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void <#=method.MethodName#>(ReadOnlySpan<<#=type.TypeName#>> x, ReadOnlySpan<<#=type.TypeName#>> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] <#= method.Operator #> y[i]);
+                destination[i] = (x[i] <#= method.Operator #> y[i]);
             }
         }
 <# } else if (method.MethodType == MethodType.ComparisonScalar) {#>
 
-        protected override void <#=method.MethodName#>(ReadOnlySpan<<#=type.TypeName#>> x, <#=type.TypeName#> y, PrimitiveColumnContainer<bool> result, long offset)
+        protected override void <#=method.MethodName#>(ReadOnlySpan<<#=type.TypeName#>> x, <#=type.TypeName#> y, Span<bool> destination)
         {
             for (var i = 0; i < x.Length; i++)
             {
-                result[i + offset] = (x[i] <#= method.Operator #> y);
+                destination[i] = (x[i] <#= method.Operator #> y);
             }
         }
 <# } else if (method.MethodType == MethodType.Binary) { #>

--- a/src/Microsoft.Data.Analysis/Computations/IArithmetic.cs
+++ b/src/Microsoft.Data.Analysis/Computations/IArithmetic.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Data.Analysis
         void HandleOperation(BinaryIntOperation operation, ReadOnlySpan<T> x, int y, Span<T> destination);
 
         //Comparison operations
-        void HandleOperation(ComparisonOperation operation, ReadOnlySpan<T> x, ReadOnlySpan<T> y, PrimitiveColumnContainer<bool> destination, long offset);
-        void HandleOperation(ComparisonOperation operation, ReadOnlySpan<T> x, T y, PrimitiveColumnContainer<bool> destination, long offset);
+        void HandleOperation(ComparisonOperation operation, ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<bool> destination);
+        void HandleOperation(ComparisonOperation operation, ReadOnlySpan<T> x, T y, Span<bool> destination);
     }
 }

--- a/src/Microsoft.Data.Analysis/DataFrameBuffer.cs
+++ b/src/Microsoft.Data.Analysis/DataFrameBuffer.cs
@@ -40,12 +40,12 @@ namespace Microsoft.Data.Analysis
 
         public DataFrameBuffer(int capacity = 0)
         {
-            if ((long)capacity * Size > MaxCapacity)
+            if ((long)capacity > MaxCapacity)
             {
                 throw new ArgumentException($"{capacity} exceeds buffer capacity", nameof(capacity));
             }
 
-            _memory = new byte[Math.Max(capacity, MinCapacity)];
+            _memory = new byte[Math.Max(capacity, MinCapacity) * Size];
         }
 
         internal DataFrameBuffer(ReadOnlyMemory<byte> buffer, int length)

--- a/src/Microsoft.Data.Analysis/PrimitiveColumnContainer.BinaryOperations.cs
+++ b/src/Microsoft.Data.Analysis/PrimitiveColumnContainer.BinaryOperations.cs
@@ -107,17 +107,41 @@ namespace Microsoft.Data.Analysis
 
         public PrimitiveColumnContainer<bool> HandleOperation(ComparisonOperation operation, PrimitiveColumnContainer<T> right)
         {
+            var ret = new PrimitiveColumnContainer<bool>(Length, false);
             var arithmetic = Arithmetic<T>.Instance;
 
-            var ret = new PrimitiveColumnContainer<bool>(Length);
-            long offset = 0;
+            //Size of any buffer in PrimitiveColumnContainer<bool> is larger (or equal) than size of the buffers for other types
+            long index = 0;
             for (int i = 0; i < this.Buffers.Count; i++)
             {
                 var leftSpan = this.Buffers[i].ReadOnlySpan;
                 var rightSpan = right.Buffers[i].ReadOnlySpan;
 
-                arithmetic.HandleOperation(operation, leftSpan, rightSpan, ret, offset);
-                offset += leftSpan.Length;
+                // Get correct ret Span for storing results
+                var retSpanIndex = ret.GetIndexOfBufferContainingRowIndex(index);
+                var retSpan = ret.Buffers.GetOrCreateMutable(retSpanIndex).Span;
+
+                //Get offset in the buffer to store new data
+                var retOffset = (int)(index % DataFrameBuffer<bool>.MaxCapacity);
+
+                //Check if there is enought space in the current ret buffer
+                var availableInRetSpan = DataFrameBuffer<bool>.MaxCapacity - retOffset;
+                if (availableInRetSpan < leftSpan.Length)
+                {
+                    //We are not able to place all results into remaining space into our ret buffer, have to split the results
+
+                    //This will be simplified when the size of buffers of different types are done equal
+                    //(not supported by classic .Net framework due to the 2 Gb limitation on array size)
+
+                    arithmetic.HandleOperation(operation, leftSpan.Slice(0, availableInRetSpan), rightSpan.Slice(0, availableInRetSpan), retSpan.Slice(retOffset));
+
+                    var nextRetSpan = ret.Buffers.GetOrCreateMutable(retSpanIndex + 1).Span;
+                    arithmetic.HandleOperation(operation, leftSpan.Slice(availableInRetSpan), rightSpan.Slice(availableInRetSpan), nextRetSpan);
+                }
+                else
+                    arithmetic.HandleOperation(operation, leftSpan, rightSpan, retSpan.Slice(retOffset));
+
+                index += leftSpan.Length;
             }
 
             return ret;
@@ -125,14 +149,41 @@ namespace Microsoft.Data.Analysis
 
         public PrimitiveColumnContainer<bool> HandleOperation(ComparisonOperation operation, T right)
         {
-            var ret = new PrimitiveColumnContainer<bool>(Length);
-            long offset = 0;
+            var ret = new PrimitiveColumnContainer<bool>(Length, false);
             var arithmetic = Arithmetic<T>.Instance;
+
+            //Size of any buffer in PrimitiveColumnContainer<bool> is larger (or equal) than size of the buffers for other types
+            long index = 0;
             for (int i = 0; i < this.Buffers.Count; i++)
             {
                 var leftSpan = this.Buffers[i].ReadOnlySpan;
 
-                arithmetic.HandleOperation(operation, leftSpan, right, ret, offset);
+                //Get correct ret Span for storing results
+                var retSpanIndex = ret.GetIndexOfBufferContainingRowIndex(index);
+                var retSpan = ret.Buffers.GetOrCreateMutable(retSpanIndex).Span;
+
+                //Get offset in the buffer to store new data
+                var retOffset = (int)(index % DataFrameBuffer<bool>.MaxCapacity);
+
+                //Check if there is enought space in the current ret buffer
+                var availableInRetSpan = DataFrameBuffer<bool>.MaxCapacity - retOffset;
+
+                if (availableInRetSpan < leftSpan.Length)
+                {
+                    //We are not able to place all results into remaining space into our ret buffer, have to split the results
+
+                    //This will be simplified when the size of buffers of different types are done equal
+                    //(not supported by classic .Net framework due to the 2 Gb limitation on array size)
+
+                    arithmetic.HandleOperation(operation, leftSpan.Slice(0, availableInRetSpan), right, retSpan.Slice(retOffset));
+
+                    var nextRetSpan = ret.Buffers.GetOrCreateMutable(retSpanIndex + 1).Span;
+                    arithmetic.HandleOperation(operation, leftSpan.Slice(availableInRetSpan), right, nextRetSpan);
+                }
+                else
+                    arithmetic.HandleOperation(operation, leftSpan, right, retSpan.Slice(retOffset));
+
+                index += leftSpan.Length;
             }
 
             return ret;

--- a/src/Microsoft.Data.Analysis/PrimitiveColumnContainer.cs
+++ b/src/Microsoft.Data.Analysis/PrimitiveColumnContainer.cs
@@ -313,7 +313,7 @@ namespace Microsoft.Data.Analysis
         {
             if (rowIndex >= Length)
             {
-                throw new ArgumentOutOfRangeException(Strings.RowIndexOutOfRange, nameof(rowIndex));
+                throw new ArgumentOutOfRangeException(Strings.IndexIsGreaterThanColumnLength, nameof(rowIndex));
             }
             return (int)(rowIndex / ReadOnlyDataFrameBuffer<T>.MaxCapacity);
         }

--- a/src/Microsoft.Data.Analysis/StringDataFrameColumn.cs
+++ b/src/Microsoft.Data.Analysis/StringDataFrameColumn.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Data.Analysis
         {
             if (rowIndex >= Length)
             {
-                throw new ArgumentOutOfRangeException(Strings.RowIndexOutOfRange, nameof(rowIndex));
+                throw new ArgumentOutOfRangeException(Strings.IndexIsGreaterThanColumnLength, nameof(rowIndex));
             }
             return (int)(rowIndex / MaxCapacity);
         }

--- a/src/Microsoft.Data.Analysis/StringDataFrameColumn.cs
+++ b/src/Microsoft.Data.Analysis/StringDataFrameColumn.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Data.Analysis
         {
             if (rowIndex >= Length)
             {
-                throw new ArgumentOutOfRangeException(Strings.ColumnIndexOutOfRange, nameof(rowIndex));
+                throw new ArgumentOutOfRangeException(Strings.RowIndexOutOfRange, nameof(rowIndex));
             }
             return (int)(rowIndex / MaxCapacity);
         }

--- a/src/Microsoft.Data.Analysis/Strings.Designer.cs
+++ b/src/Microsoft.Data.Analysis/Strings.Designer.cs
@@ -106,15 +106,6 @@ namespace Microsoft.Data {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Index cannot be greater than the Column&apos;s Length.
-        /// </summary>
-        internal static string ColumnIndexOutOfRange {
-            get {
-                return ResourceManager.GetString("ColumnIndexOutOfRange", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Comment token cannot contain whitespace.
         /// </summary>
         internal static string CommentTokenCannotContainWhitespace {
@@ -417,6 +408,15 @@ namespace Microsoft.Data {
         internal static string PositiveNumberOfCharacters {
             get {
                 return ResourceManager.GetString("PositiveNumberOfCharacters", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Index cannot be greater than the Column&apos;s Length.
+        /// </summary>
+        internal static string RowIndexOutOfRange {
+            get {
+                return ResourceManager.GetString("RowIndexOutOfRange", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Data.Analysis/Strings.Designer.cs
+++ b/src/Microsoft.Data.Analysis/Strings.Designer.cs
@@ -259,6 +259,15 @@ namespace Microsoft.Data {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Index cannot be greater than the Column&apos;s Length.
+        /// </summary>
+        internal static string IndexIsGreaterThanColumnLength {
+            get {
+                return ResourceManager.GetString("IndexIsGreaterThanColumnLength", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Column &apos;{0}&apos; does not exist.
         /// </summary>
         internal static string InvalidColumnName {
@@ -408,15 +417,6 @@ namespace Microsoft.Data {
         internal static string PositiveNumberOfCharacters {
             get {
                 return ResourceManager.GetString("PositiveNumberOfCharacters", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Index cannot be greater than the Column&apos;s Length.
-        /// </summary>
-        internal static string RowIndexOutOfRange {
-            get {
-                return ResourceManager.GetString("RowIndexOutOfRange", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Data.Analysis/Strings.resx
+++ b/src/Microsoft.Data.Analysis/Strings.resx
@@ -183,6 +183,9 @@
   <data name="InconsistentNullBitMapAndNullCount" xml:space="preserve">
     <value>Inconsistent null bitmaps and NullCounts</value>
   </data>
+  <data name="IndexIsGreaterThanColumnLength" xml:space="preserve">
+    <value>Index cannot be greater than the Column's Length</value>
+  </data>
   <data name="InvalidColumnName" xml:space="preserve">
     <value>Column '{0}' does not exist</value>
   </data>
@@ -233,9 +236,6 @@
   </data>
   <data name="PositiveNumberOfCharacters" xml:space="preserve">
     <value>{0} must be greater than 0</value>
-  </data>
-  <data name="RowIndexOutOfRange" xml:space="preserve">
-    <value>Index cannot be greater than the Column's Length</value>
   </data>
   <data name="SpansMultipleBuffers" xml:space="preserve">
     <value>Cannot span multiple buffers</value>

--- a/src/Microsoft.Data.Analysis/Strings.resx
+++ b/src/Microsoft.Data.Analysis/Strings.resx
@@ -132,9 +132,6 @@
   <data name="CannotResizeDown" xml:space="preserve">
     <value>Cannot resize down</value>
   </data>
-  <data name="ColumnIndexOutOfRange" xml:space="preserve">
-    <value>Index cannot be greater than the Column's Length</value>
-  </data>
   <data name="CommentTokenCannotContainWhitespace" xml:space="preserve">
     <value>Comment token cannot contain whitespace</value>
   </data>
@@ -236,6 +233,9 @@
   </data>
   <data name="PositiveNumberOfCharacters" xml:space="preserve">
     <value>{0} must be greater than 0</value>
+  </data>
+  <data name="RowIndexOutOfRange" xml:space="preserve">
+    <value>Index cannot be greater than the Column's Length</value>
   </data>
   <data name="SpansMultipleBuffers" xml:space="preserve">
     <value>Cannot span multiple buffers</value>

--- a/src/Microsoft.Data.Analysis/VBufferDataFrameColumn.cs
+++ b/src/Microsoft.Data.Analysis/VBufferDataFrameColumn.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Data.Analysis
         {
             if (rowIndex >= Length)
             {
-                throw new ArgumentOutOfRangeException(Strings.ColumnIndexOutOfRange, nameof(rowIndex));
+                throw new ArgumentOutOfRangeException(Strings.RowIndexOutOfRange, nameof(rowIndex));
             }
 
             return (int)(rowIndex / MaxCapacity);

--- a/src/Microsoft.Data.Analysis/VBufferDataFrameColumn.cs
+++ b/src/Microsoft.Data.Analysis/VBufferDataFrameColumn.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Data.Analysis
         {
             if (rowIndex >= Length)
             {
-                throw new ArgumentOutOfRangeException(Strings.RowIndexOutOfRange, nameof(rowIndex));
+                throw new ArgumentOutOfRangeException(Strings.IndexIsGreaterThanColumnLength, nameof(rowIndex));
             }
 
             return (int)(rowIndex / MaxCapacity);

--- a/test/Microsoft.Data.Analysis.PerformanceTests/PerformanceTests.cs
+++ b/test/Microsoft.Data.Analysis.PerformanceTests/PerformanceTests.cs
@@ -209,8 +209,9 @@ namespace Microsoft.Data.Analysis.PerformanceTests
         [Benchmark]
         public void ElementwiseEquals_Int16_Int16()
         {
-            var column = _int32Column1.ElementwiseEquals(_int16Column2);
+            var column = _int16Column1.ElementwiseEquals(_int16Column2);
         }
+
 
         [Benchmark]
         public void ElementwiseEquals_Double_Double()


### PR DESCRIPTION
Goal of this PR is to improve performance of comparison operation and is the next step in aligning datafrane arithmetic API with the new TensorPrimitives API

In DataFrame 0.20.1:

|                          Method |     Mean |    Error |   StdDev |
|-------------------------------- |---------:|---------:|---------:|
|   ElementwiseEquals_Int32_Int32 | 38.00 ms | 0.145 ms | 0.121 ms |
|   ElementwiseEquals_Int16_Int16 | 39.55 ms | 0.291 ms | 0.258 ms |
| ElementwiseEquals_Double_Double | 40.28 ms | 0.367 ms | 0.343 ms |
|   ElementwiseEquals_Float_Float | 41.18 ms | 0.805 ms | 1.074 ms |

After this PR:

|                          Method |      Mean |     Error |    StdDev |
|-------------------------------- |----------:|----------:|----------:|
|   ElementwiseEquals_Int32_Int32 |  1.171 ms | 0.0228 ms | 0.0263 ms |
|   ElementwiseEquals_Int16_Int16 |  1.090 ms | 0.0569 ms | 0.0475 ms |
| ElementwiseEquals_Double_Double |  1.388 ms | 0.0264 ms | 0.0247 ms |
|   ElementwiseEquals_Float_Float |  1.250 ms | 0.0215 ms | 0.0190 ms |``

Other comparison operations shows the same boost in performance