### PR TITLE
Added missing TF_StringEncodedSize.

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -14,6 +14,7 @@
     <add key="mlnet-daily" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/MachineLearning/nuget/v3/index.json" />
     <add key="mlnet-assets" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/machinelearning-assets/nuget/v3/index.json" />
     <add key="dotnet8" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/docs/samples/Microsoft.ML.Samples.GPU/Microsoft.ML.Samples.GPU.csproj
+++ b/docs/samples/Microsoft.ML.Samples.GPU/Microsoft.ML.Samples.GPU.csproj
@@ -72,7 +72,15 @@
     </ItemGroup>
 
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+    <PropertyGroup>
+      <EmptyContent />
+    </PropertyGroup>
+
     <MakeDir Directories="obj" />
-    <CreateFile FileName="obj/tensorflow_redist_build_log.txt" />
+    <WriteLinesToFile
+            File="obj/tensorflow_redist_build_log.txt"
+            Lines="@(EmptyContent)"
+            Overwrite="true"
+            Encoding="Unicode"/>
   </Target>
 </Project>

--- a/docs/samples/Microsoft.ML.Samples.GPU/Microsoft.ML.Samples.GPU.csproj
+++ b/docs/samples/Microsoft.ML.Samples.GPU/Microsoft.ML.Samples.GPU.csproj
@@ -38,10 +38,6 @@
 
   </ItemGroup>
 
-  <Task BeforeTargets="Build" Name="FileRestitch" Condition=" '$(OS)' == 'Unix' ">
-    <Mkdir Directories="$(ObjDir)" />
-  </Task>
-
   <ItemGroup>
     <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
   </ItemGroup>
@@ -75,4 +71,7 @@
       <Folder Include="Dynamic\" />
     </ItemGroup>
 
+  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+    <MakeDir Directories="$(ObjDir)" />
+  </Target>
 </Project>

--- a/docs/samples/Microsoft.ML.Samples.GPU/Microsoft.ML.Samples.GPU.csproj
+++ b/docs/samples/Microsoft.ML.Samples.GPU/Microsoft.ML.Samples.GPU.csproj
@@ -71,7 +71,7 @@
       <Folder Include="Dynamic\" />
     </ItemGroup>
 
-  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+  <Target Name="MissingFile" BeforeTargets="Build">
     <PropertyGroup>
       <EmptyContent />
     </PropertyGroup>

--- a/docs/samples/Microsoft.ML.Samples.GPU/Microsoft.ML.Samples.GPU.csproj
+++ b/docs/samples/Microsoft.ML.Samples.GPU/Microsoft.ML.Samples.GPU.csproj
@@ -47,10 +47,10 @@
     <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
   </ItemGroup>
   <ItemGroup Condition=" '$(OS)' == 'Windows_NT'">
-    <PackageReference Include="SciSharp.TensorFlow.Redist-Windows-GPU" Version="$(TensorFlowVersion)" />
+    <PackageReference Include="SciSharp.TensorFlow.Redist-Windows-GPU" Version="$(TensorFlowWindowsGPUVersion)" />
   </ItemGroup>
   <ItemGroup Condition=" '$(OS)' == 'Unix'">
-    <PackageReference Include="SciSharp.TensorFlow.Redist-Linux-GPU" Version="$(TensorFlowVersion)" />
+    <PackageReference Include="SciSharp.TensorFlow.Redist-Linux-GPU" Version="$(TensorFlowLinuxGPUVersion)" />
   </ItemGroup>
 
     <ItemGroup>

--- a/docs/samples/Microsoft.ML.Samples.GPU/Microsoft.ML.Samples.GPU.csproj
+++ b/docs/samples/Microsoft.ML.Samples.GPU/Microsoft.ML.Samples.GPU.csproj
@@ -72,6 +72,6 @@
     </ItemGroup>
 
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
-    <MakeDir Directories="$(ObjDir)" />
+    <MakeDir Directories="obj" />
   </Target>
 </Project>

--- a/docs/samples/Microsoft.ML.Samples.GPU/Microsoft.ML.Samples.GPU.csproj
+++ b/docs/samples/Microsoft.ML.Samples.GPU/Microsoft.ML.Samples.GPU.csproj
@@ -73,5 +73,6 @@
 
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
     <MakeDir Directories="obj" />
+    <CreateFile FileName="obj/tensorflow_redist_build_log.txt" />
   </Target>
 </Project>

--- a/docs/samples/Microsoft.ML.Samples.GPU/Microsoft.ML.Samples.GPU.csproj
+++ b/docs/samples/Microsoft.ML.Samples.GPU/Microsoft.ML.Samples.GPU.csproj
@@ -71,7 +71,7 @@
       <Folder Include="Dynamic\" />
     </ItemGroup>
 
-  <Target Name="MissingFile" BeforeTargets="Build">
+  <Target Name="MissingFile" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <EmptyContent />
     </PropertyGroup>

--- a/docs/samples/Microsoft.ML.Samples.GPU/Microsoft.ML.Samples.GPU.csproj
+++ b/docs/samples/Microsoft.ML.Samples.GPU/Microsoft.ML.Samples.GPU.csproj
@@ -38,6 +38,10 @@
 
   </ItemGroup>
 
+  <Task BeforeTargets="Build" Name="FileRestitch" Condition=" '$(OS)' == 'Unix' ">
+    <Mkdir Directories="$(ObjDir)" />
+  </Task>
+
   <ItemGroup>
     <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
   </ItemGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -61,7 +61,9 @@
     <SharpZipLibVersion>1.4.0</SharpZipLibVersion>
     <TensorflowDotNETVersion>0.20.1</TensorflowDotNETVersion>
     <TensorFlowMajorVersion>2</TensorFlowMajorVersion>
-    <TensorFlowVersion>2.3.1</TensorFlowVersion>
+    <TensorFlowVersion>2.16.0</TensorFlowVersion>
+    <TensorFlowWindowsGPUVersion>2.10.3</TensorFlowWindowsGPUVersion>
+    <TensorFlowLinuxGPUVersion>2.11.1</TensorFlowLinuxGPUVersion>
     <TorchSharpVersion>0.99.5</TorchSharpVersion>
     <LibTorchVersion>1.13.0.1</LibTorchVersion>
     <!-- Build/infrastructure Dependencies -->

--- a/src/Microsoft.ML.Vision/ImageClassificationTrainer.cs
+++ b/src/Microsoft.ML.Vision/ImageClassificationTrainer.cs
@@ -761,10 +761,26 @@ namespace Microsoft.ML.Vision
             return (jpegData, resizedImage);
         }
 
+        private static ulong VarintLength(ulong v)
+        {
+            ulong len = 1;
+            while (v >= 128)
+            {
+                v >>= 7;
+                len++;
+            }
+            return len;
+        }
+
+        private static ulong TF_StringEncodedSize(ulong length)
+        {
+            return VarintLength(length) + length;
+        }
+
         private static Tensor EncodeByteAsString(VBuffer<byte> buffer)
         {
             int length = buffer.Length;
-            var size = c_api.TF_StringEncodedSize((ulong)length);
+            var size = TF_StringEncodedSize((ulong)length);
             var handle = c_api.TF_AllocateTensor(TF_DataType.TF_STRING, Array.Empty<long>(), 0, ((ulong)size + 8));
 
             IntPtr tensor = c_api.TF_TensorData(handle);

--- a/src/Microsoft.ML.Vision/ImageClassificationTrainer.cs
+++ b/src/Microsoft.ML.Vision/ImageClassificationTrainer.cs
@@ -772,7 +772,7 @@ namespace Microsoft.ML.Vision
             return len;
         }
 
-        private static ulong TF_StringEncodedSize(ulong length)
+        private static ulong TfStringEncodedSize(ulong length)
         {
             return VarintLength(length) + length;
         }
@@ -780,7 +780,7 @@ namespace Microsoft.ML.Vision
         private static Tensor EncodeByteAsString(VBuffer<byte> buffer)
         {
             int length = buffer.Length;
-            var size = TF_StringEncodedSize((ulong)length);
+            var size = TfStringEncodedSize((ulong)length);
             var handle = c_api.TF_AllocateTensor(TF_DataType.TF_STRING, Array.Empty<long>(), 0, ((ulong)size + 8));
 
             IntPtr tensor = c_api.TF_TensorData(handle);


### PR DESCRIPTION
Fixes #6893

In the recent versions of TensorFlow, the method `TF_StringEncodedSize` was removed.
I implemented the same code in C#, also added new props for separate `SciSharp.TensorFlow.Redist-Linux-GPU` and `SciSharp.TensorFlow.Redist-Windows-GPU` packages.

We are excited to review your PR.

So we can do the best job, please check:

- [X] There's a descriptive title that will make sense to other developers some time from now. 
- [X] There's associated issues. All PR's should have issue(s) associated - unless a trivial self-evident change such as fixing a typo. You can use the format `Fixes #nnnn` in your description to cause GitHub to automatically close the issue(s) when your PR is merged.
- [X] Your change description explains what the change does, why you chose your approach, and anything else that reviewers should know.
- [X] You have included any necessary tests in the same PR.

