### PR TITLE
Don't include the SDK in our helix payload

### DIFF
--- a/build/ci/send-to-helix.yml
+++ b/build/ci/send-to-helix.yml
@@ -11,7 +11,6 @@ parameters:
   WarnAsError: ''
   TestTargetFramework: ''
   HelixConfiguration: ''                 # optional -- additional property attached to a job
-  IncludeDotNetCli: true                 # optional -- true will download a version of the .NET CLI onto the Helix machine as a correlation payload; requires DotNetCliPackageType and DotNetCliVersion
   EnableXUnitReporter: true              # optional -- true enables XUnit result reporting to Mission Control
   WaitForWorkItemCompletion: true        # optional -- true will make the task wait until work items have been completed and fail the build if work items fail. False is "fire and forget."
   HelixBaseUri: 'https://helix.dot.net' # optional -- sets the Helix API base URI (allows targeting int)
@@ -34,7 +33,6 @@ steps:
             /p:HelixBuild=${{ parameters.HelixBuild }}
             /p:HelixConfiguration="${{ parameters.HelixConfiguration }}"
             /p:HelixAccessToken="${{ parameters.HelixAccessToken }}"
-            /p:IncludeDotNetCli=${{ parameters.IncludeDotNetCli }}
             /p:EnableXUnitReporter=${{ parameters.EnableXUnitReporter }}
             /p:WaitForWorkItemCompletion=${{ parameters.WaitForWorkItemCompletion }}
             /p:HelixBaseUri=${{ parameters.HelixBaseUri }}

--- a/eng/helix.proj
+++ b/eng/helix.proj
@@ -99,6 +99,9 @@
       <HelixPreCommands Condition="$(IsPosixShell)">$(HelixPreCommands);export ML_TEST_DATADIR=$HELIX_CORRELATION_PAYLOAD;export MICROSOFTML_RESOURCE_PATH=$HELIX_WORKITEM_ROOT;sudo chmod -R 777 $HELIX_WORKITEM_ROOT;sudo chown -R $USER $HELIX_WORKITEM_ROOT</HelixPreCommands>
       <HelixPreCommands Condition="!$(IsPosixShell)">$(HelixPreCommands);set ML_TEST_DATADIR=%HELIX_CORRELATION_PAYLOAD%;set MICROSOFTML_RESOURCE_PATH=%HELIX_WORKITEM_ROOT%</HelixPreCommands>
 
+      <HelixPreCommands Condition="$(IsPosixShell)">$(HelixPreCommands);export PATH=$HELIX_CORRELATION_PAYLOAD/$(DotNetCliDestination):$PATH</HelixPreCommands>
+      <HelixPreCommands Condition="!$(IsPosixShell)">$(HelixPreCommands);set PATH=%HELIX_CORRELATION_PAYLOAD%\$(DotNetCliDestination)%3B%PATH%</HelixPreCommands> 
+
       <HelixPreCommands Condition="$(HelixTargetQueues.ToLowerInvariant().Contains('osx'))">$(HelixPreCommands);export LD_LIBRARY_PATH=/opt/homebrew/opt/mono-libgdiplus/lib;</HelixPreCommands>
 
       <HelixPreCommands Condition="$(HelixTargetQueues.ToLowerInvariant().Contains('armarch'))">$(HelixPreCommands);sudo apt update;sudo apt-get install libomp-dev libomp5 -y</HelixPreCommands>


### PR DESCRIPTION
I noticed that the tests included the latest SDK - including the host - in our helix payloads.

This is a large amount of unnecessary downloads and it also makes it so we use the latest host on the older frameworks which can fail when the latest host drops support for distros.

Since our tests shouldn't need the full CLI, remove this from our helix payloads.

We'll instead get just the runtime we need through `AdditionalDotNetPackage`