### PR TITLE
Fix assert by only accessing idx

### DIFF
--- a/src/Microsoft.ML.Data/DataView/CacheDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/CacheDataView.cs
@@ -1320,7 +1320,7 @@ namespace Microsoft.ML.Data
 
             private sealed class ImplVec<T> : ColumnCache<VBuffer<T>>
             {
-                // The number of rows cached.
+                // The number of rows cached.  Only to be accesssed by the Caching thread.
                 private int _rowCount;
                 // For a given row [r], elements at [r] and [r+1] specify the inclusive
                 // and exclusive range of values for the two big arrays. In the case
@@ -1384,10 +1384,10 @@ namespace Microsoft.ML.Data
 
                 public override void Fetch(int idx, ref VBuffer<T> value)
                 {
-                    Ctx.Assert(0 <= idx && idx < _rowCount);
-                    Ctx.Assert(_rowCount < Utils.Size(_indexBoundaries));
-                    Ctx.Assert(_rowCount < Utils.Size(_valueBoundaries));
-                    Ctx.Assert(_uniformLength > 0 || _rowCount <= Utils.Size(_lengths));
+                    Ctx.Assert(0 <= idx);
+                    Ctx.Assert((idx + 1) < Utils.Size(_indexBoundaries));
+                    Ctx.Assert((idx + 1) < Utils.Size(_valueBoundaries));
+                    Ctx.Assert(_uniformLength > 0 || idx < Utils.Size(_lengths));
 
                     Ctx.Assert(_indexBoundaries[idx + 1] - _indexBoundaries[idx] <= int.MaxValue);
                     int indexCount = (int)(_indexBoundaries[idx + 1] - _indexBoundaries[idx]);


### PR DESCRIPTION
Fixes #6921 

Asserting on `_rowCount <  Utils.Size(_valueBoundaries)` was catching a case where `_rowCount`'s update was reordered before `_valueBoundaries`

This was unnecessary, since this method doesn't need to use `_rowCount`.

Instead, make the asserts use only `idx` which will be maintained consistent with the waiter logic in this cache.  This will lock and synchronize with the main thread to ensure `idx` is always within bounds.

Ensure we only ever use `_rowCount` from the caching thread, so write reordering won't matter.
