### PR TITLE
Only use semi-colons for NoWarn - fixes build break

### DIFF
--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -18,7 +18,7 @@
       CS1591: Missing XML comment for publicly visible type or member 'Type_or_Member'
       CS1712: Type parameter 'parameter' has no matching typeparam tag in the XML comment on 'Type_or_Member' (but other type parameters do)
     -->
-    <NoWarn>$(NoWarn),1573,1591,1712</NoWarn>
+    <NoWarn>$(NoWarn);1573;1591;1712</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Turns out that using a mix of semi-colons and commas doesn't work correctly.  The NoWarn value I added for NETSDK1206 was being ignored due to the way this property was split.

Fix this by standardizing on `;`

