### PR TITLE
Update .NET Runtimes to latest version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -77,8 +77,8 @@
     <!-- Test-only Dependencies -->
     <ApprovalTestsVersion>5.4.7</ApprovalTestsVersion>
     <BenchmarkDotNetVersion>0.13.1</BenchmarkDotNetVersion>
-    <DotNetRuntime60Version>6.0.9</DotNetRuntime60Version>
-    <DotNetRuntime80Version>8.0.0</DotNetRuntime80Version>
+    <DotNetRuntime60Version>6.0.26</DotNetRuntime60Version>
+    <DotNetRuntime80Version>8.0.1</DotNetRuntime80Version>
     <FluentAssertionVersion>5.10.2</FluentAssertionVersion>
     <MicrosoftCodeAnalysisTestingVersion>1.1.2-beta1.23431.1</MicrosoftCodeAnalysisTestingVersion>
     <MicrosoftDotNetXUnitExtensionsVersion>9.0.0-beta.24062.5</MicrosoftDotNetXUnitExtensionsVersion>


### PR DESCRIPTION
This version is used for testing and needs to be kept up-to-date with latest.
