### PR TITLE
Tokenizer's Interfaces Cleanup

### DIFF
--- a/src/Microsoft.ML.Tokenizers/Model/BPE.cs
+++ b/src/Microsoft.ML.Tokenizers/Model/BPE.cs
@@ -95,6 +95,7 @@ namespace Microsoft.ML.Tokenizers
 
             (Dictionary<string, int>? vocab1, Vec<(string, string)> merges) = ReadFile(vocabFile, mergesFile);
             Vocab = vocab1 ?? new Dictionary<string, int>();
+            Cache = new Cache<string, Word>();
 
             VocabReverse = new();
 
@@ -146,23 +147,33 @@ namespace Microsoft.ML.Tokenizers
         /// Tokenize a sequence string to a list of tokens.
         /// </summary>
         /// <param name="sequence">The sequence to tokenize.</param>
+        /// <param name="isSpecialToken">Indicate if the token is a special token.</param>
         /// <returns>The list of tokens generated from the sequence tokenization.</returns>
-        public override IReadOnlyList<Token> Tokenize(string sequence)
+        public override IReadOnlyList<Token> Tokenize(string sequence, bool isSpecialToken = false)
         {
             if (sequence.Length == 0)
             {
                 return EmptyTokensList;
             }
 
-            if (!Dropout.HasValue)
-            {
-                return TokenizeWithCache(sequence);
-            }
-
-            Word word = MergeWord(sequence);
-
-            return WordToTokens(ref word);
+            return TokenizeWithCache(sequence);
         }
+
+        /// <summary>
+        /// Tokenize a split sequence string to a list of Ids and add them to the accumulatedIds list.
+        /// </summary>
+        /// <param name="sequence">The sequence to split.</param>
+        /// <param name="isSpecialToken">Indicate if the token is a special token.</param>
+        /// <param name="accumulatedIds">The list of accumulated tokenized Ids.</param>
+        public override void TokenizeToIds(string sequence, bool isSpecialToken, IList<int> accumulatedIds) => TokenizeToIdsWithCache(sequence, accumulatedIds);
+
+        /// <summary>
+        /// Get the number of token's Ids that the input sequence will be encoded to.
+        /// </summary>
+        /// <param name="sequence">The text to tokenize.</param>
+        /// <param name="isSpecialToken">Indicate if the token is special token.</param>
+        /// <returns>The number of token's Ids that the input sequence will be encoded to.</returns>
+        public override int GetTokenizedIdsCount(string sequence, bool isSpecialToken) => TokenizeToIdsWithCache(sequence, null);
 
         /// <summary>
         /// Map the token to tokenized Id.
@@ -194,14 +205,6 @@ namespace Microsoft.ML.Tokenizers
 
             return null;
         }
-
-        /// <summary>
-        /// Map the tokenized Id to the token.
-        /// </summary>
-        /// <param name="id">The Id to map to the token.</param>
-        /// <param name="skipSpecialTokens">Indicate if want to skip the special tokens during the decoding.</param>
-        /// <returns>The mapped token of the Id.</returns>
-        public override string? IdToString(int id, bool skipSpecialTokens = false) => throw new NotImplementedException();
 
         /// <summary>
         /// Gets the dictionary mapping tokens to Ids.
@@ -332,7 +335,7 @@ namespace Microsoft.ML.Tokenizers
 
         internal Word MergeWord(string w)
         {
-            Word word = Word.WithCapacity((int)w.Length);
+            Word word = Word.WithCapacity(w.Length);
             (int Id, int Len)? unk = null;
             int i = 0;
 
@@ -344,7 +347,7 @@ namespace Microsoft.ML.Tokenizers
                 if (Char.IsHighSurrogate(w[i]) && i < w.Length - 1 && Char.IsLowSurrogate(w[i + 1]))
                 {
                     length = 2;
-                    s = w.Substring(i, (int)length);
+                    s = w.Substring(i, length);
                 }
                 else
                 {
@@ -403,7 +406,7 @@ namespace Microsoft.ML.Tokenizers
                     }
                 }
 
-                i += (int)length;
+                i += length;
             }
 
             if (unk.HasValue)
@@ -415,45 +418,59 @@ namespace Microsoft.ML.Tokenizers
             return word;
         }
 
-        // internal Word.Enumerator WordToTokens(Word word) => word.GetIterator(VocabReverse);
-        internal List<Token> WordToTokens(ref Word word)
-        {
-            List<Token> tokens = new(word.SymbolsCount);
-
-            foreach (Token token in word.GetIterator(VocabReverse))
-            {
-                tokens.Add(token);
-            }
-
-            return tokens;
-        }
+        internal List<Token> WordToTokens(ref Word word) => word.ToTokens(VocabReverse);
 
         internal List<Token> TokenizeWithCache(string sequence)
         {
+            Word word;
             if (Cache is not null)
             {
-                Word? hit = Cache.Get(sequence);
-                if (hit.HasValue)
+                if (Cache.TryGet(sequence, out word))
                 {
-                    Word w = hit.Value;
-                    return WordToTokens(ref w);
+                    return WordToTokens(ref word);
                 }
-            }
 
-            Word word = MergeWord(sequence);
-            List<Token> tokens = WordToTokens(ref word);
-
-            if (Cache is not null)
-            {
+                word = MergeWord(sequence);
                 Cache.Set(sequence, word);
             }
+            else
+            {
+                word = MergeWord(sequence);
+            }
 
-            return tokens;
+            return WordToTokens(ref word);
         }
 
-        public override bool IsValidChar(char ch)
+        internal int WordToIds(ref Word word, IList<int>? accumulatedIds)
         {
-            throw new NotImplementedException();
+            if (accumulatedIds is not null)
+            {
+                word.PopulateIds(accumulatedIds);
+            }
+
+            return word.SymbolsCount;
+        }
+
+        internal int TokenizeToIdsWithCache(string sequence, IList<int>? accumulatedIds)
+        {
+            Word word;
+
+            if (Cache is not null)
+            {
+                if (Cache.TryGet(sequence, out Word hit))
+                {
+                    return WordToIds(ref hit, accumulatedIds);
+                }
+
+                word = MergeWord(sequence);
+                Cache.Set(sequence, word);
+            }
+            else
+            {
+                word = MergeWord(sequence);
+            }
+
+            return WordToIds(ref word, accumulatedIds);
         }
 
         internal static readonly List<Token> EmptyTokensList = new();

--- a/src/Microsoft.ML.Tokenizers/Model/BPE.cs
+++ b/src/Microsoft.ML.Tokenizers/Model/BPE.cs
@@ -168,12 +168,12 @@ namespace Microsoft.ML.Tokenizers
         public override void TokenizeToIds(string sequence, bool isSpecialToken, IList<int> accumulatedIds) => TokenizeToIdsWithCache(sequence, accumulatedIds);
 
         /// <summary>
-        /// Get the number of token's Ids that the input sequence will be encoded to.
+        /// Get the number of tokens that the input sequence will be encoded to.
         /// </summary>
         /// <param name="sequence">The text to tokenize.</param>
         /// <param name="isSpecialToken">Indicate if the token is special token.</param>
-        /// <returns>The number of token's Ids that the input sequence will be encoded to.</returns>
-        public override int GetTokenizedIdsCount(string sequence, bool isSpecialToken) => TokenizeToIdsWithCache(sequence, null);
+        /// <returns>The number of tokens that the input sequence will be encoded to.</returns>
+        public override int CountTokens(string sequence, bool isSpecialToken) => TokenizeToIdsWithCache(sequence, null);
 
         /// <summary>
         /// Map the token to tokenized Id.

--- a/src/Microsoft.ML.Tokenizers/Model/Model.cs
+++ b/src/Microsoft.ML.Tokenizers/Model/Model.cs
@@ -46,16 +46,16 @@ namespace Microsoft.ML.Tokenizers
         }
 
         /// <summary>
-        /// Get the number of token's Ids that the input sequence will be encoded to.
+        /// Get the number of tokens that the input sequence will be encoded to.
         /// </summary>
         /// <param name="sequence">The text to tokenize.</param>
         /// <param name="isSpecialToken">Indicate if the token is special token.</param>
-        /// <returns>The number of token's Ids that the input sequence will be encoded to.</returns>
+        /// <returns>The number of tokens that the input sequence will be encoded to.</returns>
         /// <remarks>
         /// This method does the default implementation that uses the TokenizeToIds method to get the number of token's Ids.
         /// Tokenizer's models which care about performance may choose to override this method to provide a more efficient implementation.
         /// </remarks>
-        public virtual int GetTokenizedIdsCount(string sequence, bool isSpecialToken)
+        public virtual int CountTokens(string sequence, bool isSpecialToken)
         {
             var ids = new List<int>();
             TokenizeToIds(sequence, isSpecialToken, ids);

--- a/src/Microsoft.ML.Tokenizers/Model/Model.cs
+++ b/src/Microsoft.ML.Tokenizers/Model/Model.cs
@@ -14,19 +14,12 @@ namespace Microsoft.ML.Tokenizers
     public abstract class Model
     {
         /// <summary>
-        /// Tokenize a sequence string to a list of tokens.
-        /// </summary>
-        /// <param name="sequence">The sequence to tokenize.</param>
-        /// <returns>The list of tokens generated from the sequence tokenization.</returns>
-        public abstract IReadOnlyList<Token> Tokenize(string sequence);
-
-        /// <summary>
         /// Tokenize a split sequence string to a list of tokens.
         /// </summary>
         /// <param name="sequence">The text to tokenize.</param>
         /// <param name="isSpecialToken">Indicate if the token is a special token.</param>
         /// <returns>The list of tokens generated from the sequence tokenization.</returns>
-        public virtual IReadOnlyList<Token> Tokenize(string sequence, bool isSpecialToken) => Tokenize(sequence);
+        public abstract IReadOnlyList<Token> Tokenize(string sequence, bool isSpecialToken = false);
 
         /// <summary>
         /// Tokenize a split sequence string to a list of Ids and add them to the accumulatedIds list.
@@ -34,8 +27,11 @@ namespace Microsoft.ML.Tokenizers
         /// <param name="sequence">The sequence to split.</param>
         /// <param name="isSpecialToken">Indicate if the token is a special token.</param>
         /// <param name="accumulatedIds">The list of accumulated tokenized Ids.</param>
-        /// <returns>True if the operation succeeded, false otherwise.</returns>
-        public virtual bool TokenizeToIds(string sequence, bool isSpecialToken, IList<int> accumulatedIds)
+        /// <remarks>
+        /// This method does the default implementation that uses the Tokenize method to get the token's Ids.
+        /// Tokenizer's models which care about performance may choose to override this method to provide a more efficient implementation.
+        /// </remarks>
+        public virtual void TokenizeToIds(string sequence, bool isSpecialToken, IList<int> accumulatedIds)
         {
             if (accumulatedIds is null)
             {
@@ -47,7 +43,23 @@ namespace Microsoft.ML.Tokenizers
             {
                 accumulatedIds.Add(token.Id);
             }
-            return true;
+        }
+
+        /// <summary>
+        /// Get the number of token's Ids that the input sequence will be encoded to.
+        /// </summary>
+        /// <param name="sequence">The text to tokenize.</param>
+        /// <param name="isSpecialToken">Indicate if the token is special token.</param>
+        /// <returns>The number of token's Ids that the input sequence will be encoded to.</returns>
+        /// <remarks>
+        /// This method does the default implementation that uses the TokenizeToIds method to get the number of token's Ids.
+        /// Tokenizer's models which care about performance may choose to override this method to provide a more efficient implementation.
+        /// </remarks>
+        public virtual int GetTokenizedIdsCount(string sequence, bool isSpecialToken)
+        {
+            var ids = new List<int>();
+            TokenizeToIds(sequence, isSpecialToken, ids);
+            return ids.Count;
         }
 
         /// <summary>
@@ -73,8 +85,6 @@ namespace Microsoft.ML.Tokenizers
         /// <returns>The mapped token of the Id.</returns>
         public abstract string? IdToToken(int id, bool skipSpecialTokens = false);
 
-        public abstract string? IdToString(int id, bool skipSpecialTokens = false);
-
         /// <summary>
         /// Gets the dictionary mapping tokens to Ids.
         /// </summary>
@@ -97,12 +107,5 @@ namespace Microsoft.ML.Tokenizers
         /// Gets a trainer object to use in training the model.
         /// </summary>
         public abstract Trainer? GetTrainer();
-
-        /// <summary>
-        /// Return true if the char is valid in the tokenizer; otherwise return false.
-        /// </summary>
-        /// <param name="ch"></param>
-        /// <returns></returns>
-        public abstract bool IsValidChar(char ch);
     }
 }

--- a/src/Microsoft.ML.Tokenizers/Model/Tiktoken.cs
+++ b/src/Microsoft.ML.Tokenizers/Model/Tiktoken.cs
@@ -270,12 +270,12 @@ namespace Microsoft.ML.Tokenizers
         }
 
         /// <summary>
-        /// Get the number of token's Ids that the input sequence will be encoded to.
+        /// Get the number of tokens that the input sequence will be encoded to.
         /// </summary>
         /// <param name="sequence">The text to tokenize.</param>
         /// <param name="isSpecialToken">Indicate if the token is special token.</param>
-        /// <returns>The number of token's Ids that the input sequence will be encoded to.</returns>
-        public override int GetTokenizedIdsCount(string sequence, bool isSpecialToken)
+        /// <returns>The number of tokens that the input sequence will be encoded to.</returns>
+        public override int CountTokens(string sequence, bool isSpecialToken)
         {
             if (string.IsNullOrEmpty(sequence))
             {

--- a/src/Microsoft.ML.Tokenizers/Model/Word.cs
+++ b/src/Microsoft.ML.Tokenizers/Model/Word.cs
@@ -22,7 +22,7 @@ namespace Microsoft.ML.Tokenizers
             {
                 throw new ArgumentOutOfRangeException(nameof(capacity));
             }
-            _symbols = new Vec<Symbol>((int)capacity);
+            _symbols = new Vec<Symbol>(capacity);
         }
 
         public static Word WithCapacity(int capacity) => new Word(capacity);
@@ -174,7 +174,7 @@ namespace Microsoft.ML.Tokenizers
                     int next = current.Next;
                     if ((uint)next < (uint)_symbols.Count)
                     {
-                        Symbol nextSymbol = _symbols[(int)next];
+                        Symbol nextSymbol = _symbols[next];
                         Pair<int> newPair = Pair<int>.Create(current.C, nextSymbol.C);
                         if (merges.TryGetValue(newPair, out value))
                         {
@@ -191,6 +191,14 @@ namespace Microsoft.ML.Tokenizers
                 {
                     _symbols.Remove(i);
                 }
+            }
+        }
+
+        public void PopulateIds(IList<int> accumulatedIds)
+        {
+            for (int i = 0; i < SymbolsCount; i++)
+            {
+                accumulatedIds.Add(_symbols[i].C);
             }
         }
 
@@ -223,39 +231,19 @@ namespace Microsoft.ML.Tokenizers
             return sb.ToString();
         }
 
-        public Enumerator GetIterator(SortedDictionary<int, string> vocabReverse) => new Enumerator(ref _symbols, vocabReverse);
-
-        public struct Enumerator
+        public List<Token> ToTokens(SortedDictionary<int, string> vocabReverse)
         {
-            private int _index;
-            private int _pos;
-            private Vec<Symbol> _symbols;
-            private readonly SortedDictionary<int, string> _vocabReverse;
+            List<Token> tokens = new(SymbolsCount);
+            int index = 0;
 
-            public Enumerator(ref Vec<Symbol> symbols, SortedDictionary<int, string> vocabReverse)
+            for (int i = 0; i < SymbolsCount; i++)
             {
-                _index = -1;
-                _pos = 0;
-                _symbols = symbols;
-                _vocabReverse = vocabReverse;
+                int endIndex = index + _symbols[i].Len;
+                tokens.Add(new Token(_symbols[i].C, vocabReverse[_symbols[i].C], (index, endIndex)));
+                index = endIndex;
             }
 
-            public readonly Enumerator GetEnumerator() => this;
-
-            public readonly Token Current => new Token(_symbols[_index].C, _vocabReverse[_symbols[_index].C], (_pos, _pos + _symbols[_index].Len));
-
-            public bool MoveNext()
-            {
-                if (_symbols.Count == 0 || _index >= _symbols.Count - 1)
-                {
-                    return false;
-                }
-
-                _pos = _index == -1 ? 0 : _pos + _symbols[_index].Len;
-
-                _index++;
-                return true;
-            }
+            return tokens;
         }
     }
 }

--- a/src/Microsoft.ML.Tokenizers/Tokenizer.cs
+++ b/src/Microsoft.ML.Tokenizers/Tokenizer.cs
@@ -145,14 +145,14 @@ namespace Microsoft.ML.Tokenizers
         }
 
         /// <summary>
-        /// Get the number of token's Ids that the input sequence will be encoded to.
+        /// Get the number of tokens that the input sequence will be encoded to.
         /// </summary>
         /// <param name="sequence">The text to tokenize.</param>
         /// <param name="skipSpecialTokens">Indicate if want to skip the special tokens during the encoding.</param>
-        /// <returns>The number of token's Ids that the input sequence will be encoded to.</returns>
+        /// <returns>The number of tokens Ids that the input sequence will be encoded to.</returns>
         /// <exception cref="ArgumentNullException">The input sequence is null.</exception>
         /// <exception cref="ArgumentException">Unable to tokenize the sequence.</exception>
-        public int GetEncodedIdsCount(string sequence, bool skipSpecialTokens = false)
+        public int CountTokens(string sequence, bool skipSpecialTokens = false)
         {
             if (sequence is null)
             {
@@ -164,7 +164,7 @@ namespace Microsoft.ML.Tokenizers
             int idsCount = 0;
             foreach (Split split in PreTokenizer.PreTokenize(normalized, skipSpecialTokens))
             {
-                idsCount += Model.GetTokenizedIdsCount(split.TokenString, split.IsSpecialToken);
+                idsCount += Model.CountTokens(split.TokenString, split.IsSpecialToken);
             }
 
             return idsCount;

--- a/src/Microsoft.ML.TorchSharp/Roberta/QATrainer.cs
+++ b/src/Microsoft.ML.TorchSharp/Roberta/QATrainer.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using Microsoft.ML.Data;
 using Microsoft.ML.Internal.Utilities;
@@ -62,7 +63,7 @@ namespace Microsoft.ML.TorchSharp.Roberta
             public string AnswerIndexStartColumnName = DefaultColumnNames.AnswerIndex;
 
             /// <summary>
-            /// Number of top predicted answers in question answering task. 
+            /// Number of top predicted answers in question answering task.
             /// </summary>
             public int TopKAnswers = DefaultColumnNames.TopKAnswers;
 
@@ -435,6 +436,9 @@ namespace Microsoft.ML.TorchSharp.Roberta
 
             private Dictionary<int, int> AlignAnswerPosition(IReadOnlyList<string> tokens, string text)
             {
+                EnglishRoberta robertaModel = Tokenizer.Model as EnglishRoberta;
+                Debug.Assert(robertaModel is not null);
+
                 var mapping = new Dictionary<int, int>();
                 int surrogateDeduce = 0;
                 for (var (i, j, tid) = (0, 0, 0); i < text.Length && tid < tokens.Count;)
@@ -457,7 +461,7 @@ namespace Microsoft.ML.TorchSharp.Roberta
                         ++i;
                     }
                     // Chars not included in tokenizer will not appear in tokens
-                    else if (!Tokenizer.IsValidChar(text[i]))
+                    else if (!robertaModel.CharInSupportedRange(text[i]))
                     {
                         mapping[i - surrogateDeduce] = tid;
                         ++i;

--- a/test/Microsoft.ML.Tokenizers.Tests/BpeTests.cs
+++ b/test/Microsoft.ML.Tokenizers.Tests/BpeTests.cs
@@ -146,7 +146,7 @@ namespace Microsoft.ML.Tokenizers.Tests
                 Assert.Equal(offsets.Length, encoding.Offsets.Count);
                 Assert.Equal(ids.Length, encoding.Ids.Count);
                 Assert.Equal(ids.Length, idsList.Count);
-                Assert.Equal(ids.Length, tokenizer.GetEncodedIdsCount(sentence));
+                Assert.Equal(ids.Length, tokenizer.CountTokens(sentence));
                 Assert.Equal(decodedTokens, tokenizer.Decode(encoding.Ids));
 
                 for (int i = 0; i < encoding.Tokens.Count; i++)
@@ -237,13 +237,12 @@ namespace Microsoft.ML.Tokenizers.Tests
                 {
                     TokenizerResult enc = tokenizer.Encode((string)arguments[0]!);
                     IReadOnlyList<int> ids = tokenizer.EncodeToIds((string)arguments[0]!);
-                    int idsCount = tokenizer.GetEncodedIdsCount((string)arguments[0]!);
                     Assert.Equal((string)arguments[0]!, enc.OriginalString);
                     Assert.Equal((string[])arguments[1]!, enc.Tokens);
                     (int, int)[] offsets = ((int, int)[])arguments[2]!;
                     Assert.Equal(offsets, enc.Offsets);
                     Assert.Equal(enc.Tokens.Count, ids.Count);
-                    Assert.Equal(enc.Tokens.Count, idsCount);
+                    Assert.Equal(enc.Tokens.Count, tokenizer.CountTokens((string)arguments[0]!));
 
                     Assert.Equal(enc.Tokens.Count, enc.Ids.Count);
 

--- a/test/Microsoft.ML.Tokenizers.Tests/BpeTests.cs
+++ b/test/Microsoft.ML.Tokenizers.Tests/BpeTests.cs
@@ -140,10 +140,13 @@ namespace Microsoft.ML.Tokenizers.Tests
                 Tokenizer tokenizer = new Tokenizer(bpe);
 
                 TokenizerResult encoding = tokenizer.Encode(sentence);
+                IReadOnlyList<int> idsList = tokenizer.EncodeToIds(sentence);
 
                 Assert.Equal(expectedTokens.Length, encoding.Tokens.Count);
                 Assert.Equal(offsets.Length, encoding.Offsets.Count);
                 Assert.Equal(ids.Length, encoding.Ids.Count);
+                Assert.Equal(ids.Length, idsList.Count);
+                Assert.Equal(ids.Length, tokenizer.GetEncodedIdsCount(sentence));
                 Assert.Equal(decodedTokens, tokenizer.Decode(encoding.Ids));
 
                 for (int i = 0; i < encoding.Tokens.Count; i++)
@@ -151,6 +154,7 @@ namespace Microsoft.ML.Tokenizers.Tests
                     Assert.Equal(expectedTokens[i], encoding.Tokens[i]);
                     Assert.Equal(offsets[i], encoding.Offsets[i]);
                     Assert.Equal(ids[i], encoding.Ids[i]);
+                    Assert.Equal(ids[i], idsList[i]);
                     Assert.Equal(encoding.Tokens[i], tokenizer.Model.IdToToken(encoding.Ids[i]));
                     Assert.Equal(encoding.Ids[i], tokenizer.Model.TokenToId(encoding.Tokens[i]));
                     Assert.Equal(encoding.Tokens[i], tokenizer.Decode(encoding.Ids[i]));
@@ -232,11 +236,14 @@ namespace Microsoft.ML.Tokenizers.Tests
                 foreach (object?[] arguments in BpeTestData)
                 {
                     TokenizerResult enc = tokenizer.Encode((string)arguments[0]!);
+                    IReadOnlyList<int> ids = tokenizer.EncodeToIds((string)arguments[0]!);
+                    int idsCount = tokenizer.GetEncodedIdsCount((string)arguments[0]!);
                     Assert.Equal((string)arguments[0]!, enc.OriginalString);
                     Assert.Equal((string[])arguments[1]!, enc.Tokens);
                     (int, int)[] offsets = ((int, int)[])arguments[2]!;
-                    for (int i = 0; i < offsets.Length; i++)
-                        Assert.Equal(offsets[i], enc.Offsets[i]);
+                    Assert.Equal(offsets, enc.Offsets);
+                    Assert.Equal(enc.Tokens.Count, ids.Count);
+                    Assert.Equal(enc.Tokens.Count, idsCount);
 
                     Assert.Equal(enc.Tokens.Count, enc.Ids.Count);
 
@@ -244,6 +251,7 @@ namespace Microsoft.ML.Tokenizers.Tests
                     for (int i = 0; i < enc.Ids.Count; i++)
                     {
                         Assert.Equal(vocab[enc.Tokens[i]], enc.Ids[i]);
+                        Assert.Equal(enc.Ids[i], ids[i]);
                     }
                 }
             }

--- a/test/Microsoft.ML.Tokenizers.Tests/EnglishRobertaTests.cs
+++ b/test/Microsoft.ML.Tokenizers.Tests/EnglishRobertaTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.ML.Tokenizers.Tests
                 // Sentence, Expected Ids, Expected Tokens, Expected Offsets, Decoded Tokens, Token occurrence values
                 yield return new object[]
                 {
-                    "In the night.", // Heighest occurence tokens
+                    "In the night.", // Highest occurrence tokens
                     new int[] { 818, 262, 1755, 13 },
                     new string[] { "In", "\u0120the", "\u0120night", "." },
                     new (int, int)[] { (0, 2), (2, 6), (6, 12), (12, 13) },
@@ -131,7 +131,11 @@ namespace Microsoft.ML.Tokenizers.Tests
             foreach (object[] p in BertaData)
             {
                 TokenizerResult encoding = tokenizer.Encode((string)p[0]);
+                IReadOnlyList<int> ids = tokenizer.EncodeToIds((string)p[0]);
+                int idsCount = tokenizer.GetEncodedIdsCount((string)p[0]);
                 Assert.Equal(p[1], encoding.Ids);
+                Assert.Equal(p[1], ids);
+                Assert.Equal(((int[])p[1]).Length, idsCount);
                 Assert.Equal(p[2], encoding.Tokens);
                 Assert.Equal(p[3], encoding.Offsets);
                 Assert.Equal(encoding.Ids.Count, encoding.Tokens.Count);

--- a/test/Microsoft.ML.Tokenizers.Tests/EnglishRobertaTests.cs
+++ b/test/Microsoft.ML.Tokenizers.Tests/EnglishRobertaTests.cs
@@ -132,7 +132,7 @@ namespace Microsoft.ML.Tokenizers.Tests
             {
                 TokenizerResult encoding = tokenizer.Encode((string)p[0]);
                 IReadOnlyList<int> ids = tokenizer.EncodeToIds((string)p[0]);
-                int idsCount = tokenizer.GetEncodedIdsCount((string)p[0]);
+                int idsCount = tokenizer.CountTokens((string)p[0]);
                 Assert.Equal(p[1], encoding.Ids);
                 Assert.Equal(p[1], ids);
                 Assert.Equal(((int[])p[1]).Length, idsCount);

--- a/test/Microsoft.ML.Tokenizers.Tests/TitokenTests.cs
+++ b/test/Microsoft.ML.Tokenizers.Tests/TitokenTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.ML.Tokenizers.Tests
             Assert.Equal(text, GPT4.Decode(encoded.ToArray())!);
 
             TokenizerResult result = GPT4.Encode(text);
-            int idsCount = GPT4.GetEncodedIdsCount(text);
+            int idsCount = GPT4.CountTokens(text);
             Assert.Equal(encoded, result.Ids);
             Assert.Equal(new string[] { "Hello", " World" }, result.Tokens);
             Assert.Equal(new List<(int, int)> { (0, 5), (5, 11) }, result.Offsets);
@@ -57,7 +57,7 @@ namespace Microsoft.ML.Tokenizers.Tests
             Assert.Equal(text, GPT4.Decode(encoded.ToArray()));
 
             TokenizerResult result = GPT4.Encode(text);
-            int idsCount = GPT4.GetEncodedIdsCount(text);
+            int idsCount = GPT4.CountTokens(text);
             Assert.Equal(encoded, result.Ids);
             Assert.Equal(new string[] { "<|im_start|>", "Hello", " World", "<|im_end|>" }, result.Tokens);
             Assert.Equal(new List<(int, int)> { (0, 12), (12, 17), (17, 23), (23, 33) }, result.Offsets);
@@ -71,7 +71,7 @@ namespace Microsoft.ML.Tokenizers.Tests
             string text = ReadAndSanitizeFile("./Data/lib.rs.txt");
             IReadOnlyList<int> encoded = GPT4.EncodeToIds(text, skipSpecialTokens: true);
             Assert.Equal(5584, encoded.Count);
-            int idsCount = GPT4.GetEncodedIdsCount(text, skipSpecialTokens: true);
+            int idsCount = GPT4.CountTokens(text, skipSpecialTokens: true);
             Assert.Equal(encoded.Count, idsCount);
 
             using (Stream stream = File.OpenRead("./Data/tokens.json"))
@@ -94,7 +94,7 @@ namespace Microsoft.ML.Tokenizers.Tests
             Assert.Equal(text, decoded);
 
             TokenizerResult result = GPT4.Encode(text);
-            int idsCount = GPT4.GetEncodedIdsCount(text);
+            int idsCount = GPT4.CountTokens(text);
             Assert.Equal(encoded, result.Ids);
             Assert.Equal(encoded.Count, idsCount);
             Assert.Equal(new string[] { "<|im_start|>", "Hello", "<|im_end|>", " World" }, result.Tokens);
@@ -109,7 +109,7 @@ namespace Microsoft.ML.Tokenizers.Tests
             Assert.Empty(encoded);
 
             TokenizerResult result = GPT4.Encode(text);
-            int idsCount = GPT4.GetEncodedIdsCount(text);
+            int idsCount = GPT4.CountTokens(text);
             Assert.Empty(result.Ids);
             Assert.Empty(result.Tokens);
             Assert.Empty(result.Offsets);
@@ -121,7 +121,7 @@ namespace Microsoft.ML.Tokenizers.Tests
         {
             string text = "<|im_start|>Hello ⭐ World<|im_end|>";
             IReadOnlyList<int> encoded = GPT4.EncodeToIds(text);
-            int idsCount = GPT4.GetEncodedIdsCount(text);
+            int idsCount = GPT4.CountTokens(text);
             Assert.Equal(new List<int>() { 100264, 9906, 2928, 99834, 4435, 100265 }, encoded);
             Assert.Equal(text, GPT4.Decode(encoded.ToArray()));
 
@@ -137,7 +137,7 @@ namespace Microsoft.ML.Tokenizers.Tests
         {
             string text = ReadAndSanitizeFile("./Data/lib.rs.txt");
             IReadOnlyList<int> encoded = GPT2.EncodeToIds(text);
-            int idsCount = GPT2.GetEncodedIdsCount(text);
+            int idsCount = GPT2.CountTokens(text);
             Assert.Equal(11378, encoded.Count);
             Assert.Equal(encoded.Count, idsCount);
 
@@ -156,7 +156,7 @@ namespace Microsoft.ML.Tokenizers.Tests
         {
             string text = ReadAndSanitizeFile("./Data/lib.rs.txt");
             IReadOnlyList<int> encoded = P50kBase.EncodeToIds(text);
-            int idsCount = P50kBase.GetEncodedIdsCount(text);
+            int idsCount = P50kBase.CountTokens(text);
             Assert.Equal(7230, encoded.Count);
             Assert.Equal(encoded.Count, idsCount);
 
@@ -175,7 +175,7 @@ namespace Microsoft.ML.Tokenizers.Tests
         {
             string text = ReadAndSanitizeFile("./Data/lib.rs.txt");
             IReadOnlyList<int> encoded = P50kEdit.EncodeToIds(text);
-            int idsCount = P50kEdit.GetEncodedIdsCount(text);
+            int idsCount = P50kEdit.CountTokens(text);
             Assert.Equal(7230, encoded.Count);
             Assert.Equal(encoded.Count, idsCount);
 
@@ -194,7 +194,7 @@ namespace Microsoft.ML.Tokenizers.Tests
         {
             string text = ReadAndSanitizeFile("./Data/lib.rs.txt");
             IReadOnlyList<int> encoded = R50kBase.EncodeToIds(text);
-            int idsCount = R50kBase.GetEncodedIdsCount(text);
+            int idsCount = R50kBase.CountTokens(text);
             Assert.Equal(11378, encoded.Count);
             Assert.Equal(encoded.Count, idsCount);
 

--- a/test/Microsoft.ML.Tokenizers.Tests/TitokenTests.cs
+++ b/test/Microsoft.ML.Tokenizers.Tests/TitokenTests.cs
@@ -40,9 +40,12 @@ namespace Microsoft.ML.Tokenizers.Tests
             Assert.Equal(text, GPT4.Decode(encoded.ToArray())!);
 
             TokenizerResult result = GPT4.Encode(text);
-            Assert.Equal(new List<int>() { 9906, 4435 }, result.Ids);
+            int idsCount = GPT4.GetEncodedIdsCount(text);
+            Assert.Equal(encoded, result.Ids);
             Assert.Equal(new string[] { "Hello", " World" }, result.Tokens);
             Assert.Equal(new List<(int, int)> { (0, 5), (5, 11) }, result.Offsets);
+            Assert.Equal(encoded.Count, idsCount);
+            Assert.Equal(encoded, result.Ids);
         }
 
         [Fact]
@@ -54,9 +57,12 @@ namespace Microsoft.ML.Tokenizers.Tests
             Assert.Equal(text, GPT4.Decode(encoded.ToArray()));
 
             TokenizerResult result = GPT4.Encode(text);
-            Assert.Equal(new List<int>() { 100264, 9906, 4435, 100265 }, result.Ids);
+            int idsCount = GPT4.GetEncodedIdsCount(text);
+            Assert.Equal(encoded, result.Ids);
             Assert.Equal(new string[] { "<|im_start|>", "Hello", " World", "<|im_end|>" }, result.Tokens);
             Assert.Equal(new List<(int, int)> { (0, 12), (12, 17), (17, 23), (23, 33) }, result.Offsets);
+            Assert.Equal(encoded.Count, idsCount);
+            Assert.Equal(encoded, result.Ids);
         }
 
         [Fact]
@@ -65,6 +71,8 @@ namespace Microsoft.ML.Tokenizers.Tests
             string text = ReadAndSanitizeFile("./Data/lib.rs.txt");
             IReadOnlyList<int> encoded = GPT4.EncodeToIds(text, skipSpecialTokens: true);
             Assert.Equal(5584, encoded.Count);
+            int idsCount = GPT4.GetEncodedIdsCount(text, skipSpecialTokens: true);
+            Assert.Equal(encoded.Count, idsCount);
 
             using (Stream stream = File.OpenRead("./Data/tokens.json"))
             {
@@ -86,7 +94,9 @@ namespace Microsoft.ML.Tokenizers.Tests
             Assert.Equal(text, decoded);
 
             TokenizerResult result = GPT4.Encode(text);
-            Assert.Equal(new List<int>() { 100264, 9906, 100265, 4435 }, result.Ids);
+            int idsCount = GPT4.GetEncodedIdsCount(text);
+            Assert.Equal(encoded, result.Ids);
+            Assert.Equal(encoded.Count, idsCount);
             Assert.Equal(new string[] { "<|im_start|>", "Hello", "<|im_end|>", " World" }, result.Tokens);
             Assert.Equal(new List<(int, int)> { (0, 12), (12, 17), (17, 27), (27, 33) }, result.Offsets);
         }
@@ -99,9 +109,11 @@ namespace Microsoft.ML.Tokenizers.Tests
             Assert.Empty(encoded);
 
             TokenizerResult result = GPT4.Encode(text);
+            int idsCount = GPT4.GetEncodedIdsCount(text);
             Assert.Empty(result.Ids);
             Assert.Empty(result.Tokens);
             Assert.Empty(result.Offsets);
+            Assert.Equal(result.Ids.Count, idsCount);
         }
 
         [Fact]
@@ -109,11 +121,13 @@ namespace Microsoft.ML.Tokenizers.Tests
         {
             string text = "<|im_start|>Hello ⭐ World<|im_end|>";
             IReadOnlyList<int> encoded = GPT4.EncodeToIds(text);
+            int idsCount = GPT4.GetEncodedIdsCount(text);
             Assert.Equal(new List<int>() { 100264, 9906, 2928, 99834, 4435, 100265 }, encoded);
             Assert.Equal(text, GPT4.Decode(encoded.ToArray()));
 
             TokenizerResult result = GPT4.Encode(text);
-            Assert.Equal(new List<int>() { 100264, 9906, 2928, 99834, 4435, 100265 }, result.Ids);
+            Assert.Equal(encoded, result.Ids);
+            Assert.Equal(encoded.Count, idsCount);
             Assert.Equal(new string[] { "<|im_start|>", "Hello", " ⭐", "", " World", "<|im_end|>" }, result.Tokens);
             Assert.Equal(new List<(int, int)> { (0, 12), (12, 17), (17, 19), (19, 19), (19, 25), (25, 35) }, result.Offsets);
         }
@@ -123,7 +137,9 @@ namespace Microsoft.ML.Tokenizers.Tests
         {
             string text = ReadAndSanitizeFile("./Data/lib.rs.txt");
             IReadOnlyList<int> encoded = GPT2.EncodeToIds(text);
+            int idsCount = GPT2.GetEncodedIdsCount(text);
             Assert.Equal(11378, encoded.Count);
+            Assert.Equal(encoded.Count, idsCount);
 
             using (Stream stream = File.OpenRead("./Data/tokens_gpt2.json"))
             {
@@ -140,7 +156,9 @@ namespace Microsoft.ML.Tokenizers.Tests
         {
             string text = ReadAndSanitizeFile("./Data/lib.rs.txt");
             IReadOnlyList<int> encoded = P50kBase.EncodeToIds(text);
+            int idsCount = P50kBase.GetEncodedIdsCount(text);
             Assert.Equal(7230, encoded.Count);
+            Assert.Equal(encoded.Count, idsCount);
 
             using (Stream stream = File.OpenRead("./Data/tokens_p50k_base.json"))
             {
@@ -157,7 +175,9 @@ namespace Microsoft.ML.Tokenizers.Tests
         {
             string text = ReadAndSanitizeFile("./Data/lib.rs.txt");
             IReadOnlyList<int> encoded = P50kEdit.EncodeToIds(text);
+            int idsCount = P50kEdit.GetEncodedIdsCount(text);
             Assert.Equal(7230, encoded.Count);
+            Assert.Equal(encoded.Count, idsCount);
 
             using (Stream stream = File.OpenRead("./Data/tokens_p50k_edit.json"))
             {
@@ -174,7 +194,9 @@ namespace Microsoft.ML.Tokenizers.Tests
         {
             string text = ReadAndSanitizeFile("./Data/lib.rs.txt");
             IReadOnlyList<int> encoded = R50kBase.EncodeToIds(text);
+            int idsCount = R50kBase.GetEncodedIdsCount(text);
             Assert.Equal(11378, encoded.Count);
+            Assert.Equal(encoded.Count, idsCount);
 
             using (Stream stream = File.OpenRead("./Data/tokens_r50k_base.json"))
             {


### PR DESCRIPTION
This update encompasses the following:

- Introduction of the `Tokenizer.GetEncodedIdsCount` API, essential for supporting crucial scenarios and implemented it in all supported tokenizers.
- The implementation of `EncodeToIds` and `GetEncodedIdsCount` has been customized for other tokenizer models like `Bpe` and `EnglishRoberta`. This adaptation aims to enhance the performance of these APIs specifically when invoked from those respective tokenizers.
- Removal of a couple of APIs that did not align well with our interfaces.
- Conducted cleanup and performance optimizations in various sections across the supported tokenizers.