### PR TITLE
Prototype using spans in Model

### DIFF
--- a/src/Microsoft.ML.Tokenizers/Model/BPE.cs
+++ b/src/Microsoft.ML.Tokenizers/Model/BPE.cs
@@ -95,7 +95,7 @@ namespace Microsoft.ML.Tokenizers
 
             (Dictionary<string, int>? vocab1, Vec<(string, string)> merges) = ReadFile(vocabFile, mergesFile);
             Vocab = vocab1 ?? new Dictionary<string, int>();
-            Cache = new Cache<string, Word>();
+            Cache = new Cache<Word>();
 
             VocabReverse = new();
 
@@ -274,7 +274,7 @@ namespace Microsoft.ML.Tokenizers
         internal Dictionary<Pair<int>, (int, int)> Merges { get; set; }
 
         /// Contains the cache for optimizing the encoding step.
-        internal Cache<string, Word>? Cache { get; set; }
+        internal Cache<Word>? Cache { get; set; }
 
         internal static readonly int DefaultCacheCapacity = 10_000;
 
@@ -314,9 +314,6 @@ namespace Microsoft.ML.Tokenizers
 
             return merges;
         }
-
-        /// Reset the cache.
-        internal void ClearCache() => Cache?.Clear();
 
         private readonly Dictionary<char, string> _charToString = new Dictionary<char, string>();
 
@@ -425,7 +422,7 @@ namespace Microsoft.ML.Tokenizers
             Word word;
             if (Cache is not null)
             {
-                if (Cache.TryGet(sequence, out word))
+                if (Cache.TryGetValue(sequence, out word))
                 {
                     return WordToTokens(ref word);
                 }
@@ -457,7 +454,7 @@ namespace Microsoft.ML.Tokenizers
 
             if (Cache is not null)
             {
-                if (Cache.TryGet(sequence, out Word hit))
+                if (Cache.TryGetValue(sequence, out Word hit))
                 {
                     return WordToIds(ref hit, accumulatedIds);
                 }

--- a/src/Microsoft.ML.Tokenizers/Model/EnglishRoberta.cs
+++ b/src/Microsoft.ML.Tokenizers/Model/EnglishRoberta.cs
@@ -24,7 +24,7 @@ namespace Microsoft.ML.Tokenizers
         private readonly IReadOnlyDictionary<char, char> _byteToUnicode;
         private readonly IReadOnlyDictionary<char, char> _unicodeToByte;
         private readonly string[] _charToString;
-        private readonly Cache<string, List<Token>> _cache;
+        private readonly Cache<List<Token>> _cache;
 
         /// <summary>
         /// Construct tokenizer object to use with the English Robert model.
@@ -69,7 +69,7 @@ namespace Microsoft.ML.Tokenizers
             }
 
             _unicodeToByte = _byteToUnicode.Reverse();
-            _cache = new Cache<string, List<Token>>();
+            _cache = new Cache<List<Token>>();
         }
 
         /// <summary>
@@ -107,7 +107,7 @@ namespace Microsoft.ML.Tokenizers
             }
 
             _unicodeToByte = _byteToUnicode.Reverse();
-            _cache = new Cache<string, List<Token>>();
+            _cache = new Cache<List<Token>>();
         }
 
         //
@@ -226,7 +226,7 @@ namespace Microsoft.ML.Tokenizers
                 return Array.Empty<Token>();
             }
 
-            if (_cache.TryGet(sequence, out List<Token>? hit))
+            if (_cache.TryGetValue(sequence, out List<Token>? hit))
             {
                 ArrayPool<char>.Shared.Return(token);
                 ArrayPool<int>.Shared.Return(indexMapping);
@@ -258,7 +258,7 @@ namespace Microsoft.ML.Tokenizers
 
         private int TokenizeToIds(string sequence, IList<int>? accumulatedIds)
         {
-            if (_cache.TryGet(sequence, out List<Token>? hit))
+            if (_cache.TryGetValue(sequence, out List<Token>? hit))
             {
                 if (accumulatedIds is not null)
                 {

--- a/src/Microsoft.ML.Tokenizers/Model/Model.cs
+++ b/src/Microsoft.ML.Tokenizers/Model/Model.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Microsoft.ML.Tokenizers
 {
@@ -46,6 +45,19 @@ namespace Microsoft.ML.Tokenizers
         }
 
         /// <summary>
+        /// Tokenize a split sequence string to a list of Ids and add them to the accumulatedIds list.
+        /// </summary>
+        /// <param name="sequence">The sequence to split.</param>
+        /// <param name="isSpecialToken">Indicate if the token is a special token.</param>
+        /// <param name="accumulatedIds">The list of accumulated tokenized Ids.</param>
+        /// <remarks>
+        /// This method does the default implementation that uses the Tokenize method to get the token's Ids.
+        /// Tokenizer's models which care about performance may choose to override this method to provide a more efficient implementation.
+        /// </remarks>
+        public virtual void TokenizeToIds(ReadOnlySpan<char> sequence, bool isSpecialToken, IList<int> accumulatedIds) =>
+            TokenizeToIds(sequence.ToString(), isSpecialToken, accumulatedIds);
+
+        /// <summary>
         /// Get the number of tokens that the input sequence will be encoded to.
         /// </summary>
         /// <param name="sequence">The text to tokenize.</param>
@@ -63,11 +75,31 @@ namespace Microsoft.ML.Tokenizers
         }
 
         /// <summary>
+        /// Get the number of tokens that the input sequence will be encoded to.
+        /// </summary>
+        /// <param name="sequence">The text to tokenize.</param>
+        /// <param name="isSpecialToken">Indicate if the token is special token.</param>
+        /// <returns>The number of tokens that the input sequence will be encoded to.</returns>
+        /// <remarks>
+        /// This method does the default implementation that uses the TokenizeToIds method to get the number of token's Ids.
+        /// Tokenizer's models which care about performance may choose to override this method to provide a more efficient implementation.
+        /// </remarks>
+        public virtual int CountTokens(ReadOnlySpan<char> sequence, bool isSpecialToken) =>
+            CountTokens(sequence.ToString(), isSpecialToken);
+
+        /// <summary>
         /// Map the token to tokenized Id.
         /// </summary>
         /// <param name="token">The token to map to the Id.</param>
         /// <returns>The mapped Id of the token.</returns>
         public abstract int? TokenToId(string token);
+
+        /// <summary>
+        /// Map the token to tokenized Id.
+        /// </summary>
+        /// <param name="token">The token to map to the Id.</param>
+        /// <returns>The mapped Id of the token.</returns>
+        public virtual int? TokenToId(ReadOnlySpan<char> token) => TokenToId(token.ToString());
 
         /// <summary>
         /// Map the token to tokenized id with the option to skip the special tokens.
@@ -76,6 +108,14 @@ namespace Microsoft.ML.Tokenizers
         /// <param name="skipSpecialTokens">Indicate if want to skip the special tokens during the encoding.</param>
         /// <returns>The mapped Id of the token.</returns>
         public virtual int? TokenToId(string token, bool skipSpecialTokens) => TokenToId(token);
+
+        /// <summary>
+        /// Map the token to tokenized id with the option to skip the special tokens.
+        /// </summary>
+        /// <param name="token">The token to map to Id</param>
+        /// <param name="skipSpecialTokens">Indicate if want to skip the special tokens during the encoding.</param>
+        /// <returns>The mapped Id of the token.</returns>
+        public virtual int? TokenToId(ReadOnlySpan<char> token, bool skipSpecialTokens) => TokenToId(token, skipSpecialTokens);
 
         /// <summary>
         /// Map the tokenized Id to the token.

--- a/src/Microsoft.ML.Tokenizers/Model/Tiktoken.cs
+++ b/src/Microsoft.ML.Tokenizers/Model/Tiktoken.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.ML.Tokenizers
@@ -104,9 +105,11 @@ namespace Microsoft.ML.Tokenizers
         /// </summary>
         /// <param name="tikTokenBpeFileStream">Stream to the BPE rank file</param>
         /// <param name="useAsync">Whether to perform I/O synchronously or asynchronously.</param>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> used to request cancellation of the operation.</param>
         /// <returns>Map of byte[] to integer token id</returns>
         /// <exception cref="InvalidOperationException"></exception>
-        internal static async ValueTask<(Dictionary<ReadOnlyMemory<byte>, int>, Dictionary<string, int>, IReadOnlyDictionary<int, byte[]>)> LoadTikTokenBpeAsync(Stream tikTokenBpeFileStream, bool useAsync)
+        internal static async ValueTask<(Dictionary<ReadOnlyMemory<byte>, int>, Dictionary<string, int>, IReadOnlyDictionary<int, byte[]>)> LoadTikTokenBpeAsync(
+            Stream tikTokenBpeFileStream, bool useAsync, CancellationToken cancellationToken = default)
         {
             var encoder = new Dictionary<ReadOnlyMemory<byte>, int>(ReadOnlyMemoryByteComparer.Instance);
             var vocab = new Dictionary<string, int>();
@@ -119,7 +122,7 @@ namespace Microsoft.ML.Tokenizers
                     while (true)
                     {
                         string? line = useAsync ?
-                            await reader.ReadLineAsync().ConfigureAwait(false) :
+                            await Helpers.ReadLineAsync(reader, cancellationToken).ConfigureAwait(false) :
                             reader.ReadLine();
                         if (string.IsNullOrWhiteSpace(line))
                         {
@@ -136,10 +139,10 @@ namespace Microsoft.ML.Tokenizers
                             throw new FormatException($"Invalid format in the BPE encoder file stream");
                         }
 
-                        byte[] tokenBytes = Helpers.FromBase64String(line, 0, spaceIndex);
-
                         if (Helpers.TryParseInt32(line, spaceIndex + 1, out int rank))
                         {
+                            byte[] tokenBytes = Helpers.FromBase64String(line, 0, spaceIndex);
+
                             encoder[tokenBytes] = rank;
                             decoder[rank] = tokenBytes;
 
@@ -214,7 +217,7 @@ namespace Microsoft.ML.Tokenizers
             // cache miss
             if (_vocab.TryGetValue(sequence, out int mappedId))
             {
-                return new List<Token> { new(mappedId, sequence, (0, sequence.Length)) };
+                return new Token[1] { new(mappedId, sequence, (0, sequence.Length)) };
             }
 
             byte[] arrayPoolArray = ArrayPool<byte>.Shared.Rent(Encoding.UTF8.GetMaxByteCount(sequence.Length));

--- a/src/Microsoft.ML.Tokenizers/Tokenizer.cs
+++ b/src/Microsoft.ML.Tokenizers/Tokenizer.cs
@@ -139,7 +139,7 @@ namespace Microsoft.ML.Tokenizers
 
             foreach (Split split in PreTokenizer.PreTokenize(normalized, skipSpecialTokens))
             {
-                Model.TokenizeToIds(split.TokenString, split.IsSpecialToken, idsList);
+                Model.TokenizeToIds(split.TokenSpan, split.IsSpecialToken, idsList);
             }
 
             return idsList;
@@ -165,7 +165,7 @@ namespace Microsoft.ML.Tokenizers
             int idsCount = 0;
             foreach (Split split in PreTokenizer.PreTokenize(normalized, skipSpecialTokens))
             {
-                idsCount += Model.CountTokens(split.TokenString, split.IsSpecialToken);
+                idsCount += Model.CountTokens(split.TokenSpan, split.IsSpecialToken);
             }
 
             return idsCount;
@@ -451,7 +451,7 @@ namespace Microsoft.ML.Tokenizers
             }
         }
 
-        private static readonly ConcurrentDictionary<string, (Dictionary<ReadOnlyMemory<byte>, int>, Dictionary<string, int>, IReadOnlyDictionary<int, byte[]>)> _tiktokenCache = new(StringComparer.OrdinalIgnoreCase);
+        private static readonly ConcurrentDictionary<string, (Dictionary<ReadOnlyMemory<byte>, int>, Dictionary<StringSpanOrdinalKey, int>, Dictionary<int, byte[]>)> _tiktokenCache = new(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// Create tokenizer based on regex pattern, BPE rank file and special tokens
@@ -479,7 +479,7 @@ namespace Microsoft.ML.Tokenizers
                 }
             }
 
-            if (!_tiktokenCache.TryGetValue(mergeableRanksFileUrl, out (Dictionary<ReadOnlyMemory<byte>, int> encoder, Dictionary<string, int> vocab, IReadOnlyDictionary<int, byte[]> decoder) cache))
+            if (!_tiktokenCache.TryGetValue(mergeableRanksFileUrl, out (Dictionary<ReadOnlyMemory<byte>, int> encoder, Dictionary<StringSpanOrdinalKey, int> vocab, Dictionary<int, byte[]> decoder) cache))
             {
                 using (Stream stream = await Helpers.GetStreamAsync(_httpClient, mergeableRanksFileUrl, cancellationToken).ConfigureAwait(false))
                 {

--- a/src/Microsoft.ML.Tokenizers/Utils/Helpers.netcoreapp.cs
+++ b/src/Microsoft.ML.Tokenizers/Utils/Helpers.netcoreapp.cs
@@ -1,26 +1,41 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Buffers.Text;
+using System.Diagnostics;
 using System.Globalization;
+using System.IO;
+using System.Threading.Tasks;
+using System.Threading;
+using System.Net.Http;
 
 namespace Microsoft.ML.Tokenizers
 {
     internal static class Helpers
     {
+        public static ValueTask<string?> ReadLineAsync(StreamReader reader, CancellationToken cancellationToken) =>
+            reader.ReadLineAsync(cancellationToken);
+
+        public static Task<Stream> GetStreamAsync(HttpClient client, string url, CancellationToken cancellationToken) =>
+            client.GetStreamAsync(url, cancellationToken);
+
         public static byte[] FromBase64String(string base64String, int offset, int length)
         {
-            Span<byte> bytes = stackalloc byte[300];
-            if (!Convert.TryFromBase64Chars(base64String.AsSpan().Slice(offset, length), bytes, out int bytesWritten))
+            if (!Base64.IsValid(base64String.AsSpan(offset, length), out int decodedLength))
             {
-                throw new System.FormatException($"Invalid base64 string '{base64String.Substring(offset, length)}'");
+                throw new FormatException($"Invalid base64 string '{base64String.Substring(offset, length)}'");
             }
-            return bytes.Slice(0, bytesWritten).ToArray();
+
+            byte[] bytes = new byte[decodedLength];
+            bool success = Convert.TryFromBase64Chars(base64String.AsSpan(offset, length), bytes, out int bytesWritten);
+            Debug.Assert(success);
+            Debug.Assert(bytes.Length == bytesWritten);
+            return bytes;
         }
 
         internal static bool TryParseInt32(string s, int offset, out int result)
             => int.TryParse(s.AsSpan().Slice(offset), NumberStyles.None, CultureInfo.InvariantCulture, out result);
     }
 }
-

--- a/src/Microsoft.ML.Tokenizers/Utils/Helpers.netstandard.cs
+++ b/src/Microsoft.ML.Tokenizers/Utils/Helpers.netstandard.cs
@@ -1,13 +1,30 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.ML.Tokenizers
 {
     internal static class Helpers
     {
+        public static ValueTask<string> ReadLineAsync(StreamReader reader, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return new ValueTask<string>(reader.ReadLineAsync());
+        }
+
+        public static async Task<Stream> GetStreamAsync(HttpClient client, string url, CancellationToken cancellationToken)
+        {
+            HttpResponseMessage response = await client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+        }
+
         public static byte[] FromBase64String(string base64String, int offset, int length) => Convert.FromBase64String(base64String.Substring(offset, length));
 
         // Not support signed number

--- a/src/Microsoft.ML.Tokenizers/Utils/LruCache.cs
+++ b/src/Microsoft.ML.Tokenizers/Utils/LruCache.cs
@@ -1,48 +1,33 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.ML.Tokenizers
 {
-    internal class LruCache<TKey, TValue> where TKey : notnull where TValue : notnull
+    internal sealed class LruCache<TValue>
     {
         /// <summary>
         /// The default LRU cache size.
         /// </summary>
-        public const int DefaultCacheSize = 8192; // 4096;
+        public const int DefaultCacheSize = 8192;
 
-        private readonly object _lockObject = new object();
-
-        private class CacheItem
-        {
-            public readonly TKey Key;
-            public TValue Value;
-
-            public CacheItem(TKey key, TValue value)
-            {
-                Key = key;
-                Value = value;
-            }
-        }
-
-        private readonly Dictionary<TKey, LinkedListNode<CacheItem>> _cache;
-        private readonly LinkedList<CacheItem> _lruList;
+        private readonly Dictionary<StringSpanOrdinalKey, LinkedListNode<KeyValuePair<string, TValue>>> _cache = new();
+        private readonly LinkedList<KeyValuePair<string, TValue>> _lruList = new();
         private readonly int _cacheSize;
 
+        private object SyncObj => _cache;
+
         /// <summary>
-        /// Constructs an <see cref="LruCache{TKey,TValue}" /> object.
+        /// Constructs an <see cref="LruCache{TValue}" /> object.
         /// </summary>
         /// <param name="cacheSize">
-        /// The maximum number of <typeparamref name="TKey" /> to <typeparamref name="TValue" /> mappings
-        /// that can be cached. This defaults to <see cref="DefaultCacheSize" />, which is set to
-        /// <value>4096</value>.
+        /// The maximum number of mappings that can be cached. This defaults to <see cref="DefaultCacheSize" />, which is set to <value>8192</value>.
         /// </param>
         public LruCache(int cacheSize = DefaultCacheSize)
         {
-            _cache = new Dictionary<TKey, LinkedListNode<CacheItem>>();
-            _lruList = new LinkedList<CacheItem>();
             _cacheSize = cacheSize;
         }
 
@@ -54,11 +39,11 @@ namespace Microsoft.ML.Tokenizers
         /// <returns>
         /// true if the cache contains a mapping for key, false otherwise.
         /// </returns>
-        public bool Lookup(TKey key, out TValue value)
+        public bool TryGetValue(string key, out TValue value)
         {
-            lock (_lockObject)
+            lock (SyncObj)
             {
-                if (_cache.TryGetValue(key, out LinkedListNode<CacheItem>? cached))
+                if (_cache.TryGetValue(new StringSpanOrdinalKey(key), out LinkedListNode<KeyValuePair<string, TValue>>? cached))
                 {
                     _lruList.Remove(cached);
                     _lruList.AddFirst(cached);
@@ -71,16 +56,31 @@ namespace Microsoft.ML.Tokenizers
             }
         }
 
-        protected virtual void OnEviction(TValue evictedValue) { }
-
-        private void EvictIfNeeded()
+        /// <summary>
+        /// Retrieves the value associated with the specified key /> object.
+        /// </summary>
+        /// <param name="key">The object to be used as a key.</param>
+        /// <param name="value">An out parameter that is set to the value of the key if key contains a mapping in the cache.</param>
+        /// <returns>
+        /// true if the cache contains a mapping for key, false otherwise.
+        /// </returns>
+        public unsafe bool TryGetValue(ReadOnlySpan<char> key, out TValue value)
         {
-            while (_cache.Count >= _cacheSize)
+            lock (SyncObj)
             {
-                LinkedListNode<CacheItem>? nodeToEvict = _lruList.Last;
-                _lruList.RemoveLast();
-                _cache.Remove(nodeToEvict!.Value.Key);
-                OnEviction(nodeToEvict.Value.Value);
+                fixed (char* ptr = key)
+                {
+                    if (_cache.TryGetValue(new StringSpanOrdinalKey(ptr, key.Length), out LinkedListNode<KeyValuePair<string, TValue>>? cached))
+                    {
+                        _lruList.Remove(cached);
+                        _lruList.AddFirst(cached);
+                        value = cached.Value.Value;
+                        return true;
+                    }
+                }
+
+                value = default!;
+                return false;
             }
         }
 
@@ -89,46 +89,29 @@ namespace Microsoft.ML.Tokenizers
         /// </summary>
         /// <param name="key">The key whose mapped <paramref name="value" /> is to be created or replaced.</param>
         /// <param name="value">The new value to be mapped to the <paramref name="key" />.</param>
-        public void Add(TKey key, TValue value) => Replace(key, value, out _);
-
-        public bool Replace(TKey key, TValue value, out TValue oldValue)
+        public void Add(string key, TValue value)
         {
-            lock (_lockObject)
+            lock (SyncObj)
             {
-                return ReplaceInternal(key, value, out oldValue);
+                if (_cache.TryGetValue(new StringSpanOrdinalKey(key), out LinkedListNode<KeyValuePair<string, TValue>>? cached))
+                {
+                    cached.Value = new KeyValuePair<string, TValue>(key, value);
+                    _lruList.Remove(cached);
+                    _lruList.AddFirst(cached);
+                    return;
+                }
+
+                while (_cache.Count >= _cacheSize)
+                {
+                    LinkedListNode<KeyValuePair<string, TValue>>? nodeToEvict = _lruList.Last;
+                    _lruList.RemoveLast();
+                    _cache.Remove(new StringSpanOrdinalKey(nodeToEvict!.Value.Key));
+                }
+
+                var node = new LinkedListNode<KeyValuePair<string, TValue>>(new KeyValuePair<string, TValue>(key, value));
+                _cache[new StringSpanOrdinalKey(key)] = node;
+                _lruList.AddFirst(node);
             }
-        }
-
-        private bool ReplaceInternal(TKey key, TValue value, out TValue oldValue)
-        {
-            if (_cache.TryGetValue(key, out LinkedListNode<CacheItem>? cached))
-            {
-                oldValue = cached.Value.Value;
-                cached.Value.Value = value;
-                _lruList.Remove(cached);
-                _lruList.AddFirst(cached);
-                return true;
-            }
-            EvictIfNeeded();
-            var node = new LinkedListNode<CacheItem>(new CacheItem(key, value));
-            _cache[key] = node;
-            _lruList.AddFirst(node);
-            oldValue = default!;
-            return false;
-        }
-
-        /// <summary>
-        /// The number of entries currently present in the cache.
-        /// </summary>
-        public int Count => _cache.Count;
-
-        /// <summary>
-        /// Clears the contents of this cache.
-        /// </summary>
-        public void Clear()
-        {
-            _cache.Clear();
-            _lruList.Clear();
         }
     }
 }

--- a/src/Microsoft.ML.Tokenizers/Utils/StringSpanOrdinalKey.cs
+++ b/src/Microsoft.ML.Tokenizers/Utils/StringSpanOrdinalKey.cs
@@ -1,0 +1,55 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Linq;
+
+namespace Microsoft.ML.Tokenizers
+{
+    /// <summary>Used as a key in a dictionary to enable querying with either a string or a span.</summary>
+    /// <remarks>
+    /// This should only be used with a Ptr/Length for querying. For storing in a dictionary, this should
+    /// always be used with a string.
+    /// </remarks>
+    internal unsafe readonly struct StringSpanOrdinalKey : IEquatable<StringSpanOrdinalKey>
+    {
+        public readonly char* Ptr;
+        public readonly int Length;
+        public readonly string? Data;
+
+        public StringSpanOrdinalKey(char* ptr, int length)
+        {
+            Ptr = ptr;
+            Length = length;
+        }
+
+        public StringSpanOrdinalKey(string data) =>
+            Data = data;
+
+        private ReadOnlySpan<char> Span => Ptr is not null ?
+            new ReadOnlySpan<char>(Ptr, Length) :
+            Data.AsSpan();
+
+        public override bool Equals(object? obj) =>
+            obj is StringSpanOrdinalKey wrapper && Equals(wrapper);
+
+        public bool Equals(StringSpanOrdinalKey other) =>
+            Span.SequenceEqual(other.Span);
+
+        public override int GetHashCode()
+        {
+#if NET5_0_OR_GREATER
+            return string.GetHashCode(Span);
+#else
+            int hash = 17;
+            foreach (char c in Span)
+            {
+                hash = hash * 31 + c;
+            }
+
+            return hash;
+#endif
+        }
+    }
+}


### PR DESCRIPTION
@tarekgh, this isn't for merging, but it shows appx what I had in mind for incorporating spans into Model (I know you're currently revising the surface area, so take this with a grain of salt). This eliminates a majority of the remaining allocation that occurs when using Tokenizer.CountTokens/EncodeToIds, as it avoids allocating strings for each token that's already in the cache.

Feel free to crib liberally from the second commit and close this PR.  Ignore the first commit, which I submitted separately.