### PR TITLE
Temp fix for the race condition during the tests.

### DIFF
--- a/test/Microsoft.ML.Tests/DatabaseLoaderTests.cs
+++ b/test/Microsoft.ML.Tests/DatabaseLoaderTests.cs
@@ -20,6 +20,9 @@ using Xunit.Abstractions;
 
 namespace Microsoft.ML.Tests
 {
+    [CollectionDefinition(nameof(NoParallelizationDefinition), DisableParallelization = true)]
+    public class NoParallelizationDefinition { }
+    [Collection(nameof(NoParallelizationDefinition))]
     public class DatabaseLoaderTests : BaseTestClass
     {
         public DatabaseLoaderTests(ITestOutputHelper output)

--- a/test/Microsoft.ML.Tests/Transformers/WordEmbeddingsTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/WordEmbeddingsTests.cs
@@ -12,6 +12,9 @@ using Xunit.Abstractions;
 
 namespace Microsoft.ML.Tests.Transformers
 {
+    [CollectionDefinition(nameof(NoParallelizationDefinition), DisableParallelization = true)]
+    public class NoParallelizationDefinition { }
+    [Collection(nameof(NoParallelizationDefinition))]
     public sealed class WordEmbeddingsTests : TestDataPipeBase
     {
         public WordEmbeddingsTests(ITestOutputHelper helper)


### PR DESCRIPTION
Temporarily fixes the race condition that seems to be happening during the tests by making the offending tests run sequentially.