### PR TITLE
Don't trigger PR validation builds for docs only changes

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -8,6 +8,15 @@ pr:
     - main
     - feature/*
     - release/*
+  paths:
+    include:
+    - '*'
+    exclude:
+    - '**.md'
+    - .github/*
+    - docs/*
+    - LICENSE
+    - THIRD-PARTY-NOTICES.TXT
 
 trigger:
   branches:

--- a/build/codecoverage-ci.yml
+++ b/build/codecoverage-ci.yml
@@ -8,6 +8,15 @@ pr:
     - main
     - feature/*
     - release/*
+  paths:
+    include:
+    - '*'
+    exclude:
+    - '**.md'
+    - .github/*
+    - docs/*
+    - LICENSE
+    - THIRD-PARTY-NOTICES.TXT
 
 trigger:
   branches:


### PR DESCRIPTION
This applies the same filters we use in runtime to avoid building the repo when only docs change.

I tried to do this previously but I missed that the filter only applied to the rolling build and not PR validation.