### PR TITLE
Tokenizer's APIs Polishing

### DIFF
--- a/src/Microsoft.ML.Tokenizers/Model/BPE.cs
+++ b/src/Microsoft.ML.Tokenizers/Model/BPE.cs
@@ -178,7 +178,7 @@ namespace Microsoft.ML.Tokenizers
         /// </summary>
         /// <param name="text">The text to encode.</param>
         /// <returns>The list of tokens generated from the text tokenization.</returns>
-        public override IReadOnlyList<Token> Encode(string text)
+        public override IReadOnlyList<Token> Encode(ReadOnlySpan<char> text)
         {
             if (text.Length == 0)
             {
@@ -429,7 +429,7 @@ namespace Microsoft.ML.Tokenizers
 
         internal List<Token> WordToTokens(ref Word word) => word.ToTokens(VocabReverse);
 
-        internal List<Token> EncodeWithCache(string text)
+        internal List<Token> EncodeWithCache(ReadOnlySpan<char> text)
         {
             Word word;
             if (Cache is not null)
@@ -439,12 +439,12 @@ namespace Microsoft.ML.Tokenizers
                     return WordToTokens(ref word);
                 }
 
-                word = MergeWord(text.AsSpan());
-                Cache.Set(text, word);
+                word = MergeWord(text);
+                Cache.Set(text.ToString(), word);
             }
             else
             {
-                word = MergeWord(text.AsSpan());
+                word = MergeWord(text);
             }
 
             return WordToTokens(ref word);

--- a/src/Microsoft.ML.Tokenizers/Model/BPE.cs
+++ b/src/Microsoft.ML.Tokenizers/Model/BPE.cs
@@ -176,10 +176,9 @@ namespace Microsoft.ML.Tokenizers
         /// <summary>
         /// Encode a text string to a list of tokens.
         /// </summary>
-        /// <param name="text">The text to encode. If the value of the parameter <paramref name="isSpecialToken"/> is true, the entire text will be treated as a special token.</param>
-        /// <param name="isSpecialToken">Specifies whether the entire <paramref name="text"/> is considered a special token. This parameter is ignored in this model.</param>
+        /// <param name="text">The text to encode.</param>
         /// <returns>The list of tokens generated from the text tokenization.</returns>
-        public override IReadOnlyList<Token> Encode(string text, bool isSpecialToken = false)
+        public override IReadOnlyList<Token> Encode(string text)
         {
             if (text.Length == 0)
             {
@@ -192,34 +191,30 @@ namespace Microsoft.ML.Tokenizers
         /// <summary>
         /// Encode a split text string to a list of Ids and add them to the accumulatedIds list.
         /// </summary>
-        /// <param name="text">The text to encode. If the value of the parameter <paramref name="isSpecialToken"/> is true, the entire text will be treated as a special token.</param>
-        /// <param name="isSpecialToken">Specifies whether the entire <paramref name="text"/> is considered a special token. This parameter is ignored in this model.</param>
+        /// <param name="text">The text to encode.</param>
         /// <param name="accumulatedIds">The list of accumulated encoded Ids.</param>
-        public override void EncodeToIds(ReadOnlySpan<char> text, bool isSpecialToken, IList<int> accumulatedIds) => EncodeToIdsWithCache(text, accumulatedIds);
+        public override void EncodeToIds(ReadOnlySpan<char> text, IList<int> accumulatedIds) => EncodeToIdsWithCache(text, accumulatedIds);
 
         /// <summary>
         /// Get the number of tokens that the input text will be encoded to.
         /// </summary>
-        /// <param name="text">The text to encode. If the value of the parameter <paramref name="isSpecialToken"/> is true, the entire text will be treated as a special token.</param>
-        /// <param name="isSpecialToken">Specifies whether the entire <paramref name="text"/> is considered a special token. This parameter is ignored in this model.</param>
+        /// <param name="text">The text to encode.</param>
         /// <returns>The number of tokens that the input text will be encoded to. This parameter is ignored in this model.</returns>
-        public override int CountTokens(ReadOnlySpan<char> text, bool isSpecialToken) => EncodeToIdsWithCache(text, null);
+        public override int CountTokens(ReadOnlySpan<char> text) => EncodeToIdsWithCache(text, null);
 
         /// <summary>
         /// Map the token to encoded Id.
         /// </summary>
         /// <param name="token">The token to map to the Id.</param>
-        /// <param name="considerSpecialTokens">Indicate if want to consider the special tokens during the encoding.</param>
         /// <returns>The mapped Id of the token.</returns>
-        public override int? MapTokenToId(ReadOnlySpan<char> token, bool considerSpecialTokens = true) => _vocab.TryGetValue(token, out int value) ? value : null;
+        public override int? MapTokenToId(ReadOnlySpan<char> token) => _vocab.TryGetValue(token, out int value) ? value : null;
 
         /// <summary>
         /// Map the encoded Id to the token.
         /// </summary>
         /// <param name="id">The Id to map to the token.</param>
-        /// <param name="considerSpecialTokens">Indicate if want to consider the special tokens during the decoding.</param>
         /// <returns>The mapped token of the Id.</returns>
-        public override string? MapIdToToken(int id, bool considerSpecialTokens = true)
+        public override string? MapIdToToken(int id)
         {
             if (VocabReverse.TryGetValue(id, out string? value))
             {

--- a/src/Microsoft.ML.Tokenizers/Model/EnglishRoberta.cs
+++ b/src/Microsoft.ML.Tokenizers/Model/EnglishRoberta.cs
@@ -219,33 +219,114 @@ namespace Microsoft.ML.Tokenizers
         /// </summary>
         /// <param name="text">The text to encode.</param>
         /// <param name="accumulatedIds">The list of accumulated encoded Ids.</param>
-        public override void EncodeToIds(ReadOnlySpan<char> text, IList<int> accumulatedIds) => EncodeToIdsInternal(text, accumulatedIds);
+        /// <param name="textLength">The length of the text that encompasses the maximum encoded tokens.</param>
+        /// <param name="maxTokens">The maximum number of tokens to encode.</param>
+        /// <returns>The number of tokens that the input text will be encoded to.</returns>
+        public override int EncodeToIds(ReadOnlySpan<char> text, IList<int> accumulatedIds, out int textLength, int maxTokens = int.MaxValue) => EncodeToIdsInternal(text, accumulatedIds, out textLength, maxTokens);
 
         /// <summary>
         /// Get the number of tokens that the input text will be encoded to.
         /// </summary>
         /// <param name="text">The text to encode.</param>
+        /// <param name="textLength">The length of the text that encompasses the maximum encoded tokens.</param>
+        /// <param name="maxTokens">The maximum number of tokens to encode.</param>
         /// <returns>The number of tokens that the input text will be encoded to.</returns>
-        public override int CountTokens(ReadOnlySpan<char> text) => EncodeToIdsInternal(text, null);
+        public override int CountTokens(ReadOnlySpan<char> text, out int textLength, int maxTokens = int.MaxValue) => EncodeToIdsInternal(text, null, out textLength, maxTokens);
 
-        private int EncodeToIdsInternal(ReadOnlySpan<char> text, IList<int>? accumulatedIds)
+        /// <summary>
+        /// Get the number of tokens that the input text will be encoded to.
+        /// </summary>
+        /// <param name="text">The text to encode.</param>
+        /// <param name="textIndex">Starting from this index to the end of the text will encompasses the maximum encoded tokens.</param>
+        /// <param name="maxTokens">The maximum number of tokens to encode.</param>
+        /// <returns>The number of tokens that the input text will be encoded to.</returns>
+        public override int CountTokensFromEnd(ReadOnlySpan<char> text, out int textIndex, int maxTokens = int.MaxValue) => EncodeToIdsFromEndInternal(text, null, out textIndex, maxTokens);
+
+        private int EncodeToIdsResult(List<Token> tokens, IList<int>? accumulatedIds, int maxTokens, int fullTextLength, out int textLength)
         {
-            if (text.IsEmpty)
-            {
-                return 0;
-            }
+            textLength = 0;
 
-            if (_cache.TryGetValue(text, out List<Token>? hit))
+            if (tokens.Count <= maxTokens)
             {
                 if (accumulatedIds is not null)
                 {
-                    foreach (var t in hit)
+                    foreach (var t in tokens)
                     {
                         accumulatedIds.Add(t.Id);
                     }
                 }
 
-                return hit.Count;
+                textLength = fullTextLength;
+                return tokens.Count;
+            }
+
+            if (accumulatedIds is not null)
+            {
+                for (int i = 0; i < maxTokens; i++)
+                {
+                    accumulatedIds.Add(tokens[i].Id);
+                    textLength += tokens[i].Offset.Length;
+                }
+            }
+            else
+            {
+                for (int i = 0; i < maxTokens; i++)
+                {
+                    textLength += tokens[i].Offset.Length;
+                }
+            }
+
+            return maxTokens;
+        }
+
+        private int EncodeToIdsFromEndResult(List<Token> tokens, IList<int>? accumulatedIds, int maxTokens, int fullTextLength, out int textIndex)
+        {
+            textIndex = fullTextLength;
+
+            if (tokens.Count <= maxTokens)
+            {
+                if (accumulatedIds is not null)
+                {
+                    foreach (var t in tokens)
+                    {
+                        accumulatedIds.Add(t.Id);
+                    }
+                }
+
+                textIndex = 0;
+                return tokens.Count;
+            }
+
+            if (accumulatedIds is not null)
+            {
+                for (int i = tokens.Count - maxTokens; i < tokens.Count; i++)
+                {
+                    accumulatedIds.Add(tokens[i].Id);
+                    textIndex -= tokens[i].Offset.Length;
+                }
+            }
+            else
+            {
+                for (int i = tokens.Count - maxTokens; i < tokens.Count; i++)
+                {
+                    textIndex -= tokens[i].Offset.Length;
+                }
+            }
+
+            return maxTokens;
+        }
+
+        private int EncodeToIdsInternal(ReadOnlySpan<char> text, IList<int>? accumulatedIds, out int textLength, int maxTokens)
+        {
+            if (text.IsEmpty)
+            {
+                textLength = 0;
+                return 0;
+            }
+
+            if (_cache.TryGetValue(text, out List<Token>? hit))
+            {
+                return EncodeToIdsResult(hit, accumulatedIds, maxTokens, text.Length, out textLength);
             }
 
             char[] token = ArrayPool<char>.Shared.Rent(text.Length);
@@ -266,6 +347,7 @@ namespace Microsoft.ML.Tokenizers
             {
                 ArrayPool<char>.Shared.Return(token);
                 ArrayPool<int>.Shared.Return(indexMapping);
+                textLength = 0;
                 return 0;
             }
 
@@ -274,15 +356,50 @@ namespace Microsoft.ML.Tokenizers
             ArrayPool<char>.Shared.Return(token);
             ArrayPool<int>.Shared.Return(indexMapping);
 
-            if (accumulatedIds is not null)
+            return EncodeToIdsResult(result, accumulatedIds, maxTokens, text.Length, out textLength);
+        }
+
+        private int EncodeToIdsFromEndInternal(ReadOnlySpan<char> text, IList<int>? accumulatedIds, out int textIndex, int maxTokens)
+        {
+            if (text.IsEmpty)
             {
-                foreach (var t in result)
+                textIndex = text.Length;
+                return 0;
+            }
+
+            if (_cache.TryGetValue(text, out List<Token>? hit))
+            {
+                return EncodeToIdsFromEndResult(hit, accumulatedIds, maxTokens, text.Length, out textIndex);
+            }
+
+            char[] token = ArrayPool<char>.Shared.Rent(text.Length);
+            int[] indexMapping = ArrayPool<int>.Shared.Rent(text.Length);
+
+            int newTokenIndex = 0;
+            for (int i = 0; i < text.Length; i++)
+            {
+                if (_byteToUnicode.TryGetValue(text[i], out var value))
                 {
-                    accumulatedIds.Add(t.Id);
+                    token[newTokenIndex] = value;
+                    indexMapping[newTokenIndex] = i;
+                    newTokenIndex++;
                 }
             }
 
-            return result.Count;
+            if (newTokenIndex == 0)
+            {
+                ArrayPool<char>.Shared.Return(token);
+                ArrayPool<int>.Shared.Return(indexMapping);
+                textIndex = text.Length;
+                return 0;
+            }
+
+            List<Token> result = EncodeToTokens(token.AsSpan().Slice(0, newTokenIndex), indexMapping);
+            _cache.Set(text.ToString(), result);
+            ArrayPool<char>.Shared.Return(token);
+            ArrayPool<int>.Shared.Return(indexMapping);
+
+            return EncodeToIdsFromEndResult(result, accumulatedIds, maxTokens, text.Length, out textIndex);
         }
 
         /// <summary>

--- a/src/Microsoft.ML.Tokenizers/Model/EnglishRoberta.cs
+++ b/src/Microsoft.ML.Tokenizers/Model/EnglishRoberta.cs
@@ -172,9 +172,9 @@ namespace Microsoft.ML.Tokenizers
         /// </summary>
         /// <param name="text">The text to encode.</param>
         /// <returns>The list of tokens generated from the text tokenization.</returns>
-        public override IReadOnlyList<Token> Encode(string text)
+        public override IReadOnlyList<Token> Encode(ReadOnlySpan<char> text)
         {
-            if (string.IsNullOrEmpty(text))
+            if (text.IsEmpty)
             {
                 return Bpe.EmptyTokensList;
             }
@@ -208,7 +208,7 @@ namespace Microsoft.ML.Tokenizers
             }
 
             List<Token> result = EncodeToTokens(token.AsSpan().Slice(0, newTokenIndex), indexMapping);
-            _cache.Set(text, result);
+            _cache.Set(text.ToString(), result);
             ArrayPool<char>.Shared.Return(token);
             ArrayPool<int>.Shared.Return(indexMapping);
             return result;

--- a/src/Microsoft.ML.Tokenizers/Model/EnglishRoberta.cs
+++ b/src/Microsoft.ML.Tokenizers/Model/EnglishRoberta.cs
@@ -135,15 +135,9 @@ namespace Microsoft.ML.Tokenizers
         /// Map the encoded Id to the token.
         /// </summary>
         /// <param name="id">The Id to map to the string.</param>
-        /// <param name="considerSpecialTokens">Indicate if want to consider the special tokens during the decoding.</param>
         /// <returns>The mapped token of the Id.</returns>
-        public override string? MapIdToToken(int id, bool considerSpecialTokens = true)
+        public override string? MapIdToToken(int id)
         {
-            if (!considerSpecialTokens && id < 0)
-            {
-                return null;
-            }
-
             if (_vocabReverse.TryGetValue(id, out var value))
             {
                 string v = value.Data!;
@@ -176,10 +170,9 @@ namespace Microsoft.ML.Tokenizers
         /// <summary>
         /// Encode a text string to a list of tokens.
         /// </summary>
-        /// <param name="text">The text to encode. If the value of the parameter <paramref name="isSpecialToken"/> is true, the entire text will be treated as a special token.</param>
-        /// <param name="isSpecialToken">Specifies whether the entire <paramref name="text"/> is considered a special token. This parameter is ignored in this model.</param>
+        /// <param name="text">The text to encode.</param>
         /// <returns>The list of tokens generated from the text tokenization.</returns>
-        public override IReadOnlyList<Token> Encode(string text, bool isSpecialToken = false)
+        public override IReadOnlyList<Token> Encode(string text)
         {
             if (string.IsNullOrEmpty(text))
             {
@@ -224,20 +217,18 @@ namespace Microsoft.ML.Tokenizers
         /// <summary>
         /// Encode a split text string to a list of Ids and add them to the accumulatedIds list.
         /// </summary>
-        /// <param name="text">The text to encode. If the value of the parameter <paramref name="isSpecialToken"/> is true, the entire text will be treated as a special token.</param>
-        /// <param name="isSpecialToken">Specifies whether the entire <paramref name="text"/> is considered a special token. This parameter is ignored in this model.</param>
+        /// <param name="text">The text to encode.</param>
         /// <param name="accumulatedIds">The list of accumulated encoded Ids.</param>
-        public override void EncodeToIds(ReadOnlySpan<char> text, bool isSpecialToken, IList<int> accumulatedIds) => EncodeToIds(text, accumulatedIds);
+        public override void EncodeToIds(ReadOnlySpan<char> text, IList<int> accumulatedIds) => EncodeToIdsInternal(text, accumulatedIds);
 
         /// <summary>
         /// Get the number of tokens that the input text will be encoded to.
         /// </summary>
-        /// <param name="text">The text to encode. If the value of the parameter <paramref name="isSpecialToken"/> is true, the entire text will be treated as a special token.</param>
-        /// <param name="isSpecialToken">Specifies whether the entire <paramref name="text"/> is considered a special token. This parameter is ignored in this model.</param>
+        /// <param name="text">The text to encode.</param>
         /// <returns>The number of tokens that the input text will be encoded to.</returns>
-        public override int CountTokens(ReadOnlySpan<char> text, bool isSpecialToken) => EncodeToIds(text, null);
+        public override int CountTokens(ReadOnlySpan<char> text) => EncodeToIdsInternal(text, null);
 
-        private int EncodeToIds(ReadOnlySpan<char> text, IList<int>? accumulatedIds)
+        private int EncodeToIdsInternal(ReadOnlySpan<char> text, IList<int>? accumulatedIds)
         {
             if (text.IsEmpty)
             {
@@ -298,9 +289,8 @@ namespace Microsoft.ML.Tokenizers
         /// Map the token to encoded Id.
         /// </summary>
         /// <param name="token">The token to map to the Id.</param>
-        /// <param name="considerSpecialTokens">Indicate if want to consider the special tokens during the encoding.</param>
         /// <returns>The mapped Id of the token.</returns>
-        public override int? MapTokenToId(ReadOnlySpan<char> token, bool considerSpecialTokens = true) => _vocab.TryGetValue(token, out int value) ? value : null;
+        public override int? MapTokenToId(ReadOnlySpan<char> token) => _vocab.TryGetValue(token, out int value) ? value : null;
 
         /// <summary>
         /// Convert a list of tokens Ids to highest occurrence rankings.

--- a/src/Microsoft.ML.Tokenizers/Model/Model.cs
+++ b/src/Microsoft.ML.Tokenizers/Model/Model.cs
@@ -18,7 +18,7 @@ namespace Microsoft.ML.Tokenizers
         /// </summary>
         /// <param name="text">The text to encode.</param>
         /// <returns>The list of tokens generated from the text tokenization.</returns>
-        public abstract IReadOnlyList<Token> Encode(string text);
+        public abstract IReadOnlyList<Token> Encode(ReadOnlySpan<char> text);
 
         /// <summary>
         /// Encode a text to a list of Ids and add them to the accumulatedIds list.
@@ -37,7 +37,7 @@ namespace Microsoft.ML.Tokenizers
             }
 
             // Default implementation is not optimized for memory allocation. It is recommended to override this method for the sake of the performance.
-            var tokens = Encode(text.ToString());
+            var tokens = Encode(text);
             foreach (var token in tokens)
             {
                 accumulatedIds.Add(token.Id);

--- a/src/Microsoft.ML.Tokenizers/Model/Model.cs
+++ b/src/Microsoft.ML.Tokenizers/Model/Model.cs
@@ -16,22 +16,20 @@ namespace Microsoft.ML.Tokenizers
         /// <summary>
         /// Encode a text to a list of tokens.
         /// </summary>
-        /// <param name="text">The text to encode. If the value of the parameter <paramref name="isSpecialToken"/> is true, the entire text will be treated as a special token.</param>
-        /// <param name="isSpecialToken">Specifies whether the entire <paramref name="text"/> is considered a special token.</param>
+        /// <param name="text">The text to encode.</param>
         /// <returns>The list of tokens generated from the text tokenization.</returns>
-        public abstract IReadOnlyList<Token> Encode(string text, bool isSpecialToken = false);
+        public abstract IReadOnlyList<Token> Encode(string text);
 
         /// <summary>
         /// Encode a text to a list of Ids and add them to the accumulatedIds list.
         /// </summary>
-        /// <param name="text">The text to encode. If the value of the parameter <paramref name="isSpecialToken"/> is true, the entire text will be treated as a special token.</param>
-        /// <param name="isSpecialToken">Specifies whether the entire <paramref name="text"/> is considered a special token.</param>
+        /// <param name="text">The text to encode. </param>
         /// <param name="accumulatedIds">The list of accumulated encoded Ids.</param>
         /// <remarks>
         /// This method does the default implementation that uses the Encode method to get the token's Ids.
         /// Tokenizer's models which care about performance may choose to override this method to provide a more efficient implementation.
         /// </remarks>
-        public virtual void EncodeToIds(ReadOnlySpan<char> text, bool isSpecialToken, IList<int> accumulatedIds)
+        public virtual void EncodeToIds(ReadOnlySpan<char> text, IList<int> accumulatedIds)
         {
             if (accumulatedIds is null)
             {
@@ -49,17 +47,16 @@ namespace Microsoft.ML.Tokenizers
         /// <summary>
         /// Get the number of tokens that the input text will be encoded to.
         /// </summary>
-        /// <param name="text">The text to encode. If the value of the parameter <paramref name="isSpecialToken"/> is true, the entire text will be treated as a special token.</param>
-        /// <param name="isSpecialToken">Specifies whether the entire <paramref name="text"/> is considered a special token.</param>
+        /// <param name="text">The text to encode.</param>
         /// <returns>The number of tokens that the input text will be encoded to.</returns>
         /// <remarks>
         /// This method does the default implementation that uses the EncodeToIds method to get the number of token's Ids.
         /// Tokenizer's models which care about performance may choose to override this method to provide a more efficient implementation.
         /// </remarks>
-        public virtual int CountTokens(ReadOnlySpan<char> text, bool isSpecialToken)
+        public virtual int CountTokens(ReadOnlySpan<char> text)
         {
             var ids = new List<int>();
-            EncodeToIds(text, isSpecialToken, ids);
+            EncodeToIds(text, ids);
             return ids.Count;
         }
 
@@ -67,32 +64,29 @@ namespace Microsoft.ML.Tokenizers
         /// Map the token to encoded id with the option to skip the special tokens.
         /// </summary>
         /// <param name="token">The token to map to Id</param>
-        /// <param name="considerSpecialTokens">Indicate if want to consider the special tokens during the encoding.</param>
         /// <returns>The mapped Id of the token.</returns>
-        public abstract int? MapTokenToId(ReadOnlySpan<char> token, bool considerSpecialTokens = true);
+        public abstract int? MapTokenToId(ReadOnlySpan<char> token);
 
         /// <summary>
         /// Map the encoded Id to the token.
         /// </summary>
         /// <param name="id">The Id to map to the token.</param>
-        /// <param name="considerSpecialTokens">Indicate if want to consider the special tokens during the decoding.</param>
         /// <returns>The mapped token of the Id.</returns>
-        public abstract string? MapIdToToken(int id, bool considerSpecialTokens = true);
+        public abstract string? MapIdToToken(int id);
 
         /// <summary>
         /// Decode the given ids, back to a String.
         /// </summary>
         /// <param name="ids">The list of ids that we want to decode.</param>
-        /// <param name="considerSpecialTokens">Whether the special tokens should be kept in the decoded string.</param>
         /// <param name="decoder">The optional Decoder to merge the given list of tokens in a string.</param>
         /// <returns>The decoded string.</returns>
-        public virtual string? Decode(IEnumerable<int> ids, TokenizerDecoder? decoder = null, bool considerSpecialTokens = true)
+        public virtual string? Decode(IEnumerable<int> ids, TokenizerDecoder? decoder = null)
         {
             List<string> tokens = new List<string>();
 
             foreach (int id in ids)
             {
-                if (MapIdToToken(id, considerSpecialTokens) is string s)
+                if (MapIdToToken(id) is string s)
                 {
                     tokens.Add(s);
                 }

--- a/src/Microsoft.ML.Tokenizers/Model/SentencePieceBpe.cs
+++ b/src/Microsoft.ML.Tokenizers/Model/SentencePieceBpe.cs
@@ -154,11 +154,10 @@ namespace Microsoft.ML.Tokenizers
         /// <summary>
         /// Encode a text to a list of tokens.
         /// </summary>
-        /// <param name="text">The text to encode. If the value of the parameter <paramref name="isSpecialToken"/> is true, the entire text will be treated as a special token.</param>
-        /// <param name="isSpecialToken">Specifies whether the entire <paramref name="text"/> is considered a special token.</param>
+        /// <param name="text">The text to encode.</param>
         /// <returns>The list of tokens generated from the text tokenization.</returns>
         /// <remarks>The input text has to be normalized before calling this method.</remarks>
-        public override IReadOnlyList<Token> Encode(string text, bool isSpecialToken = false) => Encode(text, AddBeginningOfSentence, AddEndOfSentence);
+        public override IReadOnlyList<Token> Encode(string text) => Encode(text, AddBeginningOfSentence, AddEndOfSentence);
 
         /// <summary>
         /// Encode a text to a list of tokens.
@@ -314,11 +313,10 @@ namespace Microsoft.ML.Tokenizers
         /// <summary>
         /// Encode a text to a list of Ids and add them to the accumulatedIds list.
         /// </summary>
-        /// <param name="text">The text to encode. If the value of the parameter <paramref name="isSpecialToken"/> is true, the entire text will be treated as a special token.</param>
-        /// <param name="isSpecialToken">Specifies whether the entire <paramref name="text"/> is considered a special token.</param>
+        /// <param name="text">The text to encode.</param>
         /// <param name="accumulatedIds">The list of accumulated encoded Ids.</param>
         /// <remarks>The input text has to be normalized before calling this method.</remarks>
-        public override void EncodeToIds(ReadOnlySpan<char> text, bool isSpecialToken, IList<int> accumulatedIds) => EncodeToIds(text, AddBeginningOfSentence, AddEndOfSentence, accumulatedIds);
+        public override void EncodeToIds(ReadOnlySpan<char> text, IList<int> accumulatedIds) => EncodeToIds(text, AddBeginningOfSentence, AddEndOfSentence, accumulatedIds);
 
         /// <summary>
         /// Encode a text to a list of Ids and add them to the accumulatedIds list.
@@ -458,11 +456,10 @@ namespace Microsoft.ML.Tokenizers
         /// <summary>
         /// Get the number of tokens that the input text will be encoded to.
         /// </summary>
-        /// <param name="text">The text to encode. If the value of the parameter <paramref name="isSpecialToken"/> is true, the entire text will be treated as a special token.</param>
-        /// <param name="isSpecialToken">Specifies whether the entire <paramref name="text"/> is considered a special token.</param>
+        /// <param name="text">The text to encode.</param>
         /// <returns>The number of tokens that the input text will be encoded to.</returns>
         /// <remarks>The input text has to be normalized before calling this method.</remarks>
-        public override int CountTokens(ReadOnlySpan<char> text, bool isSpecialToken) => CountTokens(text, AddBeginningOfSentence, AddEndOfSentence);
+        public override int CountTokens(ReadOnlySpan<char> text) => CountTokens(text, AddBeginningOfSentence, AddEndOfSentence);
 
         /// <summary>
         /// Get the number of tokens that the input text will be encoded to.
@@ -589,32 +586,28 @@ namespace Microsoft.ML.Tokenizers
         /// Map the token to encoded id with the option to skip the special tokens.
         /// </summary>
         /// <param name="token">The token to map to Id</param>
-        /// <param name="considerSpecialTokens">Indicate if want to consider the special tokens during the encoding.</param>
         /// <returns>The mapped Id of the token.</returns>
-        public override int? MapTokenToId(ReadOnlySpan<char> token, bool considerSpecialTokens = true)
+        public override int? MapTokenToId(ReadOnlySpan<char> token)
             => _vocab.TryGetValue(token, out (int Id, float Score, byte Type) value) ? value.Id : null;
 
         /// <summary>
         /// Map the encoded Id to the token.
         /// </summary>
         /// <param name="id">The Id to map to the token.</param>
-        /// <param name="considerSpecialTokens">Indicate if want to consider the special tokens during the decoding.</param>
         /// <returns>The mapped token of the Id.</returns>
-        public override string? MapIdToToken(int id, bool considerSpecialTokens = true)
+        public override string? MapIdToToken(int id)
             => _vocabReverse.TryGetValue(id, out string? value) ? value : null;
 
         /// <summary>
         /// Decode the given ids, back to a String.
         /// </summary>
         /// <param name="ids">The list of ids that we want to decode.</param>
-        /// <param name="considerSpecialTokens">Whether the special tokens should be kept in the decoded string.</param>
         /// <param name="decoder">The optional Decoder to merge the given list of tokens in a string.</param>
         /// <returns>The decoded string.</returns>
         /// <remarks>
         /// The decoder is not used here because the SentencePiece Bpe model knows how to decode the ids in additions to avoid any performance overhead.
-        /// considerSpecialTokens is not used here because the SentencePiece Bpe model always remove unknown or control tokens during the decoding.
         /// </remarks>
-        public override string? Decode(IEnumerable<int> ids, TokenizerDecoder? decoder = null, bool considerSpecialTokens = true)
+        public override string? Decode(IEnumerable<int> ids, TokenizerDecoder? decoder = null)
         {
             if (ids is null)
             {

--- a/src/Microsoft.ML.Tokenizers/Model/Tiktoken.cs
+++ b/src/Microsoft.ML.Tokenizers/Model/Tiktoken.cs
@@ -89,7 +89,7 @@ namespace Microsoft.ML.Tokenizers
             try
             {
                 _cache = new LruCache<int[]>(cacheSize);
-                (_encoder, _vocab, _decoder) = LoadTikTokenBpeAsync(vocabStream, useAsync: false).GetAwaiter().GetResult();
+                (_encoder, _vocab, _decoder) = LoadTiktokenBpeAsync(vocabStream, useAsync: false).GetAwaiter().GetResult();
 
                 SpecialTokens = specialTokens;
                 CacheSpecialTokensEncoding(specialTokens);
@@ -138,7 +138,7 @@ namespace Microsoft.ML.Tokenizers
             }
 
             (Dictionary<ReadOnlyMemory<byte>, int> encoder, Dictionary<StringSpanOrdinalKey, int> vocab, Dictionary<int, ReadOnlyMemory<byte>> decoder) =
-                        await LoadTikTokenBpeAsync(vocabStream, useAsync: true, cancellationToken).ConfigureAwait(false);
+                        await LoadTiktokenBpeAsync(vocabStream, useAsync: true, cancellationToken).ConfigureAwait(false);
 
             return new Tiktoken(encoder, decoder, vocab, specialTokens, cacheSize);
         }
@@ -174,7 +174,7 @@ namespace Microsoft.ML.Tokenizers
         /// <param name="cancellationToken"><see cref="CancellationToken"/> used to request cancellation of the operation.</param>
         /// <returns>Map of byte[] to integer token id</returns>
         /// <exception cref="InvalidOperationException"></exception>
-        internal static async ValueTask<(Dictionary<ReadOnlyMemory<byte>, int>, Dictionary<StringSpanOrdinalKey, int>, Dictionary<int, ReadOnlyMemory<byte>>)> LoadTikTokenBpeAsync(
+        internal static async ValueTask<(Dictionary<ReadOnlyMemory<byte>, int>, Dictionary<StringSpanOrdinalKey, int>, Dictionary<int, ReadOnlyMemory<byte>>)> LoadTiktokenBpeAsync(
             Stream vocabStream, bool useAsync, CancellationToken cancellationToken = default)
         {
             var encoder = new Dictionary<ReadOnlyMemory<byte>, int>(ReadOnlyMemoryByteComparer.Instance);
@@ -677,24 +677,24 @@ namespace Microsoft.ML.Tokenizers
                 case ModelEncoding.Cl100kBase:
                     var specialTokens = new Dictionary<string, int>
                         { { EndOfText, 100257}, { FimPrefix, 100258}, { FimMiddle, 100259}, { FimSuffix, 100260}, { EndOfPrompt, 100276} };
-                    return CreateTikTokenTokenizerAsync(Cl100kBaseRegex(), Cl100kBaseVocabUrl, specialTokens, extraSpecialTokens, normalizer, cancellationToken);
+                    return CreateTiktokenTokenizerAsync(Cl100kBaseRegex(), Cl100kBaseVocabUrl, specialTokens, extraSpecialTokens, normalizer, cancellationToken);
 
                 case ModelEncoding.P50kBase:
                     specialTokens = new Dictionary<string, int> { { EndOfText, 50256 } };
-                    return CreateTikTokenTokenizerAsync(P50kBaseRegex(), P50RanksUrl, specialTokens, extraSpecialTokens, normalizer, cancellationToken);
+                    return CreateTiktokenTokenizerAsync(P50kBaseRegex(), P50RanksUrl, specialTokens, extraSpecialTokens, normalizer, cancellationToken);
 
                 case ModelEncoding.P50kEdit:
                     specialTokens = new Dictionary<string, int>
                         { { EndOfText, 50256 }, { FimPrefix, 50281 }, { FimMiddle, 50282 }, { FimSuffix, 50283 } };
-                    return CreateTikTokenTokenizerAsync(P50kBaseRegex(), P50RanksUrl, specialTokens, extraSpecialTokens, normalizer, cancellationToken);
+                    return CreateTiktokenTokenizerAsync(P50kBaseRegex(), P50RanksUrl, specialTokens, extraSpecialTokens, normalizer, cancellationToken);
 
                 case ModelEncoding.R50kBase:
                     specialTokens = new Dictionary<string, int> { { EndOfText, 50256 } };
-                    return CreateTikTokenTokenizerAsync(P50kBaseRegex(), R50RanksUrl, specialTokens, extraSpecialTokens, normalizer, cancellationToken);
+                    return CreateTiktokenTokenizerAsync(P50kBaseRegex(), R50RanksUrl, specialTokens, extraSpecialTokens, normalizer, cancellationToken);
 
                 case ModelEncoding.GPT2:
                     specialTokens = new Dictionary<string, int> { { EndOfText, 50256 }, };
-                    return CreateTikTokenTokenizerAsync(P50kBaseRegex(), GPT2Url, specialTokens, extraSpecialTokens, normalizer, cancellationToken);
+                    return CreateTiktokenTokenizerAsync(P50kBaseRegex(), GPT2Url, specialTokens, extraSpecialTokens, normalizer, cancellationToken);
 
                 default:
                     throw new NotSupportedException($"The encoder '{modelEncoding}' is not supported.");
@@ -713,7 +713,7 @@ namespace Microsoft.ML.Tokenizers
         /// <param name="normalizer">To normalize the text before tokenization</param>
         /// <param name="cancellationToken"><see cref="CancellationToken"/> used to request cancellation of the operation.</param>
         /// <returns>The tokenizer</returns>
-        private static async Task<Tokenizer> CreateTikTokenTokenizerAsync(
+        private static async Task<Tokenizer> CreateTiktokenTokenizerAsync(
             Regex regex,
             string mergeableRanksFileUrl,
             Dictionary<string, int> specialTokens,
@@ -733,13 +733,13 @@ namespace Microsoft.ML.Tokenizers
             {
                 using (Stream stream = await Helpers.GetStreamAsync(_httpClient, mergeableRanksFileUrl, cancellationToken).ConfigureAwait(false))
                 {
-                    cache = await LoadTikTokenBpeAsync(stream, useAsync: true, cancellationToken).ConfigureAwait(false);
+                    cache = await LoadTiktokenBpeAsync(stream, useAsync: true, cancellationToken).ConfigureAwait(false);
                 }
 
                 _tiktokenCache.TryAdd(mergeableRanksFileUrl, cache);
             }
 
-            return new Tokenizer(new Tiktoken(cache.encoder, cache.decoder, cache.vocab, specialTokens), new TikTokenPreTokenizer(regex, specialTokens), normalizer);
+            return new Tokenizer(new Tiktoken(cache.encoder, cache.decoder, cache.vocab, specialTokens), new TiktokenPreTokenizer(regex, specialTokens), normalizer);
         }
 
         internal static Tokenizer CreateTokenizerForModel(
@@ -766,14 +766,14 @@ namespace Microsoft.ML.Tokenizers
                     out (Dictionary<ReadOnlyMemory<byte>, int> encoder, Dictionary<StringSpanOrdinalKey, int> vocab, Dictionary<int, ReadOnlyMemory<byte>> decoder) cache))
             {
                 using Stream stream = Helpers.GetStream(_httpClient, tiktokenConfiguration.Url);
-                cache = LoadTikTokenBpeAsync(stream, useAsync: false).GetAwaiter().GetResult();
+                cache = LoadTiktokenBpeAsync(stream, useAsync: false).GetAwaiter().GetResult();
 
                 _tiktokenCache.TryAdd(tiktokenConfiguration.Url, cache);
             }
 
             return new Tokenizer(
                             new Tiktoken(cache.encoder, cache.decoder, cache.vocab, tiktokenConfiguration.SpecialTokens, LruCache<int[]>.DefaultCacheSize),
-                            new TikTokenPreTokenizer(tiktokenConfiguration.Regex, tiktokenConfiguration.SpecialTokens),
+                            new TiktokenPreTokenizer(tiktokenConfiguration.Regex, tiktokenConfiguration.SpecialTokens),
                             normalizer);
         }
     }

--- a/src/Microsoft.ML.Tokenizers/Model/Word.cs
+++ b/src/Microsoft.ML.Tokenizers/Model/Word.cs
@@ -202,6 +202,64 @@ namespace Microsoft.ML.Tokenizers
             }
         }
 
+        public int PopulateIdsUpToMax(IList<int> accumulatedIds, int maxTokens, out int textLength)
+        {
+            textLength = 0;
+
+            int count = Math.Min(SymbolsCount, maxTokens);
+
+            for (int i = 0; i < count; i++)
+            {
+                accumulatedIds.Add(_symbols[i].C);
+                textLength += _symbols[i].Len;
+            }
+
+            return count;
+        }
+
+        public int PopulateIdsUpToMaxFromEnd(IList<int> accumulatedIds, int maxTokens, int fullTextLength, out int textIndex)
+        {
+            textIndex = fullTextLength;
+
+            int count = Math.Min(SymbolsCount, maxTokens);
+
+            for (int i = SymbolsCount - count; i < SymbolsCount; i++)
+            {
+                accumulatedIds.Add(_symbols[i].C);
+                textIndex -= _symbols[i].Len;
+            }
+
+            return count;
+        }
+
+        public int CountIdsUpToMax(int maxTokens, out int textLength)
+        {
+            textLength = 0;
+
+            int count = Math.Min(SymbolsCount, maxTokens);
+
+            for (int i = 0; i < count; i++)
+            {
+                textLength += _symbols[i].Len;
+            }
+
+            return count;
+        }
+
+        public int CountIdsUpToMaxFromEnd(int maxTokens, int fullTextLength, out int textIndex)
+        {
+            textIndex = fullTextLength;
+
+            int count = Math.Min(SymbolsCount, maxTokens);
+
+            for (int i = SymbolsCount - count; i < SymbolsCount; i++)
+            {
+                textIndex -= _symbols[i].Len;
+            }
+
+            return count;
+        }
+
         public Vec<int> GetChars()
         {
             Vec<int> chars = new Vec<int>();

--- a/src/Microsoft.ML.Tokenizers/PACKAGE.md
+++ b/src/Microsoft.ML.Tokenizers/PACKAGE.md
@@ -68,7 +68,7 @@ The main types provided by this library are:
 * `Microsoft.ML.Tokenizers.Tokenizer`
 * `Microsoft.ML.Tokenizers.Bpe`
 * `Microsoft.ML.Tokenizers.EnglishRoberta`
-* `Microsoft.ML.Tokenizers.TikToken`
+* `Microsoft.ML.Tokenizers.Tiktoken`
 * `Microsoft.ML.Tokenizers.TokenizerDecoder`
 * `Microsoft.ML.Tokenizers.Normalizer`
 * `Microsoft.ML.Tokenizers.PreTokenizer`

--- a/src/Microsoft.ML.Tokenizers/PreTokenizer/PreTokenizer.cs
+++ b/src/Microsoft.ML.Tokenizers/PreTokenizer/PreTokenizer.cs
@@ -40,26 +40,18 @@ namespace Microsoft.ML.Tokenizers
         /// </summary>
         /// <param name="token">The token string</param>
         /// <param name="offset">The offset mapping to the original string</param>
-        /// <param name="isSpecialToken">Indicates whether the token is a special token</param>
-        public Split(string token, (int Index, int Length) offset, bool isSpecialToken = false)
+        public Split(string token, (int Index, int Length) offset)
         {
             _tokenString = token;
             Offset = offset;
-            IsSpecialToken = isSpecialToken;
         }
 
-        internal Split(string originalString, string? token, (int Index, int Length) offset, bool isSpecialToken = false)
+        internal Split(string originalString, string? token, (int Index, int Length) offset)
         {
             _originalString = originalString;
             _tokenString = token;
             Offset = offset;
-            IsSpecialToken = isSpecialToken;
         }
-
-        /// <summary>
-        /// Gets if the current Split is a special token.
-        /// </summary>
-        public bool IsSpecialToken { get; }
 
         /// <summary>
         /// Indicates whether the current Split object is equal to another Split object.
@@ -67,7 +59,6 @@ namespace Microsoft.ML.Tokenizers
         /// <param name="other">The Split object to compare with the current object.</param>
         public bool Equals(Split other) =>
             (_originalString == other._originalString || TokenString == other.TokenString) &&
-            IsSpecialToken == other.IsSpecialToken &&
             Offset.Index == other.Offset.Index &&
             Offset.Length == other.Offset.Length;
     }
@@ -82,9 +73,8 @@ namespace Microsoft.ML.Tokenizers
         /// Splits the given string in multiple substrings at the word boundary, keeping track of the offsets of said substrings from the original string.
         /// </summary>
         /// <param name="text">The string to split into tokens.</param>
-        /// <param name="considerSpecialTokens">Indicates whether to consider the special tokens.</param>
         /// <returns>The list of the splits containing the tokens and the token's offsets to the original string.</returns>
-        public abstract IEnumerable<Split> PreTokenize(string text, bool considerSpecialTokens = true);
+        public abstract IEnumerable<Split> PreTokenize(string text);
 
         internal static IEnumerable<Split> SplitText(string text, Regex regex)
         {

--- a/src/Microsoft.ML.Tokenizers/PreTokenizer/Roberta.cs
+++ b/src/Microsoft.ML.Tokenizers/PreTokenizer/Roberta.cs
@@ -21,9 +21,8 @@ namespace Microsoft.ML.Tokenizers
         /// Splits the given string in multiple substrings at the word boundary, keeping track of the offsets of said substrings from the original string.
         /// </summary>
         /// <param name="text">The string to split into tokens.</param>
-        /// <param name="considerSpecialTokens">Indicates whether to keep the special tokens.</param>
         /// <returns>The list of the splits containing the tokens and the token's offsets to the original string.</returns>
-        public override IEnumerable<Split> PreTokenize(string text, bool considerSpecialTokens = true)
+        public override IEnumerable<Split> PreTokenize(string text)
         {
             if (string.IsNullOrEmpty(text))
             {

--- a/src/Microsoft.ML.Tokenizers/PreTokenizer/SentencePiecePreTokenizer.cs
+++ b/src/Microsoft.ML.Tokenizers/PreTokenizer/SentencePiecePreTokenizer.cs
@@ -21,9 +21,8 @@ namespace Microsoft.ML.Tokenizers
         /// Return the whole text as one chunk.
         /// </summary>
         /// <param name="text">The string to split into tokens.</param>
-        /// <param name="considerSpecialTokens">Indicates whether to keep the special tokens.</param>
         /// <returns>The original string as one chunk.</returns>
-        public override IEnumerable<Split> PreTokenize(string text, bool considerSpecialTokens = true)
+        public override IEnumerable<Split> PreTokenize(string text)
         {
             if (string.IsNullOrEmpty(text))
             {

--- a/src/Microsoft.ML.Tokenizers/PreTokenizer/TikTokenPreTokenizer.cs
+++ b/src/Microsoft.ML.Tokenizers/PreTokenizer/TikTokenPreTokenizer.cs
@@ -21,7 +21,7 @@ namespace Microsoft.ML.Tokenizers
         /// Initializes a new instance of the <see cref="TikTokenPreTokenizer"/> class.
         /// </summary>
         /// <param name="regex">The regex to use for splitting the text into smaller tokens in the pre-tokenization process.</param>
-        /// <param name="specialTokensEncoder">Encode the special token to Id.</param>
+        /// <param name="specialTokensEncoder">The dictionary containing the special tokens and their corresponding ids.</param>
         /// <exception cref="ArgumentNullException">When regex is null</exception>
         public TikTokenPreTokenizer(Regex regex, IReadOnlyDictionary<string, int>? specialTokensEncoder)
         {
@@ -42,16 +42,15 @@ namespace Microsoft.ML.Tokenizers
         /// Splits the given string in multiple substrings at the word boundary, keeping track of the offsets of said substrings from the original string.
         /// </summary>
         /// <param name="text">The string to split into tokens.</param>
-        /// <param name="considerSpecialTokens">Indicates whether to consider the special tokens.</param>
         /// <returns>The list of the splits containing the tokens and the token's offsets to the original string.</returns>
-        public override IEnumerable<Split> PreTokenize(string text, bool considerSpecialTokens = true)
+        public override IEnumerable<Split> PreTokenize(string text)
         {
             if (string.IsNullOrEmpty(text))
             {
                 return Array.Empty<Split>();
             }
 
-            return SplitText(text, _regex, considerSpecialTokens ? _specialTokensRegex : null);
+            return SplitText(text, _regex, _specialTokensRegex);
 
             static IEnumerable<Split> SplitText(string text, Regex regex, Regex? specialTokensRegex)
             {
@@ -74,7 +73,7 @@ namespace Microsoft.ML.Tokenizers
                             beginning = match.Offset + match.Length;
                         }
 
-                        yield return new Split(text, null, (specialMatch.Offset, specialMatch.Length), isSpecialToken: true);
+                        yield return new Split(text, null, (specialMatch.Offset, specialMatch.Length));
                         beginning = specialMatch.Offset + specialMatch.Length;
                     }
                 }

--- a/src/Microsoft.ML.Tokenizers/PreTokenizer/TiktokenPreTokenizer.cs
+++ b/src/Microsoft.ML.Tokenizers/PreTokenizer/TiktokenPreTokenizer.cs
@@ -12,18 +12,18 @@ namespace Microsoft.ML.Tokenizers
     /// <summary>
     /// The pre-tokenizer for Tiktoken tokenizer.
     /// </summary>
-    public sealed class TikTokenPreTokenizer : PreTokenizer
+    public sealed class TiktokenPreTokenizer : PreTokenizer
     {
         private readonly Regex? _specialTokensRegex;
         private readonly Regex _regex;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="TikTokenPreTokenizer"/> class.
+        /// Initializes a new instance of the <see cref="TiktokenPreTokenizer"/> class.
         /// </summary>
         /// <param name="regex">The regex to use for splitting the text into smaller tokens in the pre-tokenization process.</param>
         /// <param name="specialTokensEncoder">The dictionary containing the special tokens and their corresponding ids.</param>
         /// <exception cref="ArgumentNullException">When regex is null</exception>
-        public TikTokenPreTokenizer(Regex regex, IReadOnlyDictionary<string, int>? specialTokensEncoder)
+        public TiktokenPreTokenizer(Regex regex, IReadOnlyDictionary<string, int>? specialTokensEncoder)
         {
             if (regex is null)
             {

--- a/src/Microsoft.ML.Tokenizers/PreTokenizer/Whitespace.cs
+++ b/src/Microsoft.ML.Tokenizers/PreTokenizer/Whitespace.cs
@@ -32,9 +32,8 @@ namespace Microsoft.ML.Tokenizers
         /// Splits the given string in multiple substrings at the word boundary, keeping track of the offsets of said substrings from the original string.
         /// </summary>
         /// <param name="text">The string to split into tokens.</param>
-        /// <param name="considerSpecialTokens">Indicates whether to consider the special tokens.</param>
         /// <returns>The list of the splits containing the tokens and the token's offsets to the original string.</returns>
-        public override IEnumerable<Split> PreTokenize(string text, bool considerSpecialTokens = false)
+        public override IEnumerable<Split> PreTokenize(string text)
         {
             if (string.IsNullOrEmpty(text))
             {

--- a/src/Microsoft.ML.Tokenizers/Tokenizer.cs
+++ b/src/Microsoft.ML.Tokenizers/Tokenizer.cs
@@ -245,7 +245,7 @@ namespace Microsoft.ML.Tokenizers
 
             return new Tokenizer(
                             new Tiktoken(vocabStream, tiktokenConfiguration.SpecialTokens, cacheSize),
-                            new TikTokenPreTokenizer(tiktokenConfiguration.Regex, tiktokenConfiguration.SpecialTokens),
+                            new TiktokenPreTokenizer(tiktokenConfiguration.Regex, tiktokenConfiguration.SpecialTokens),
                             normalizer);
         }
 
@@ -284,7 +284,7 @@ namespace Microsoft.ML.Tokenizers
 
             return new Tokenizer(
                             await Tiktoken.CreateAsync(vocabStream, tiktokenConfiguration.SpecialTokens, cacheSize, cancellationToken).ConfigureAwait(false),
-                            new TikTokenPreTokenizer(tiktokenConfiguration.Regex, tiktokenConfiguration.SpecialTokens),
+                            new TiktokenPreTokenizer(tiktokenConfiguration.Regex, tiktokenConfiguration.SpecialTokens),
                             normalizer);
         }
 

--- a/src/Microsoft.ML.Tokenizers/Tokenizer.cs
+++ b/src/Microsoft.ML.Tokenizers/Tokenizer.cs
@@ -73,7 +73,7 @@ namespace Microsoft.ML.Tokenizers
 
             foreach (Split split in encoding.Splits)
             {
-                IReadOnlyList<Token> tokens = Model.Encode(split.TokenString);
+                IReadOnlyList<Token> tokens = Model.Encode(split.TokenString.AsSpan());
                 foreach (Token token in tokens)
                 {
                     token.Offset = (token.Offset.Index + split.Offset.Index, token.Offset.Length);

--- a/src/Microsoft.ML.Tokenizers/Tokenizer.cs
+++ b/src/Microsoft.ML.Tokenizers/Tokenizer.cs
@@ -58,9 +58,8 @@ namespace Microsoft.ML.Tokenizers
         /// Encodes input text to object has the tokens list, tokens Ids, tokens offset mapping.
         /// </summary>
         /// <param name="text">The text to encode.</param>
-        /// <param name="considerSpecialTokens">Indicate if want to consider the special tokens during the encoding.</param>
         /// <returns>The tokenization result includes the tokens list, tokens Ids, tokens offset mapping.</returns>
-        public EncodingResult Encode(string text, bool considerSpecialTokens = true)
+        public EncodingResult Encode(string text)
         {
             if (text is null)
             {
@@ -70,11 +69,11 @@ namespace Microsoft.ML.Tokenizers
             string normalized = Normalizer is null ? text : Normalizer.Normalize(text);
             bool offsetsMappedToOriginal = true;
 
-            EncodingResult encoding = new(text, normalized, PreTokenizer.PreTokenize(normalized, considerSpecialTokens), offsetsMappedToOriginal);
+            EncodingResult encoding = new(text, normalized, PreTokenizer.PreTokenize(normalized), offsetsMappedToOriginal);
 
             foreach (Split split in encoding.Splits)
             {
-                IReadOnlyList<Token> tokens = Model.Encode(split.TokenString, split.IsSpecialToken);
+                IReadOnlyList<Token> tokens = Model.Encode(split.TokenString);
                 foreach (Token token in tokens)
                 {
                     token.Offset = (token.Offset.Index + split.Offset.Index, token.Offset.Length);
@@ -90,9 +89,8 @@ namespace Microsoft.ML.Tokenizers
         /// Encodes input text to tokens Ids.
         /// </summary>
         /// <param name="text">The text to encode.</param>
-        /// <param name="considerSpecialTokens">Indicate if want to consider the special tokens during the encoding.</param>
         /// <returns>The tokenization result includes the tokens list, tokens Ids, tokens offset mapping.</returns>
-        public IReadOnlyList<int> EncodeToIds(string text, bool considerSpecialTokens = true)
+        public IReadOnlyList<int> EncodeToIds(string text)
         {
             if (text is null)
             {
@@ -102,9 +100,9 @@ namespace Microsoft.ML.Tokenizers
             string normalized = Normalizer is not null ? Normalizer.Normalize(text) : text;
             List<int> idsList = new();
 
-            foreach (Split split in PreTokenizer.PreTokenize(normalized, considerSpecialTokens))
+            foreach (Split split in PreTokenizer.PreTokenize(normalized))
             {
-                Model.EncodeToIds(split.TokenSpan, split.IsSpecialToken, idsList);
+                Model.EncodeToIds(split.TokenSpan, idsList);
             }
 
             return idsList;
@@ -114,11 +112,10 @@ namespace Microsoft.ML.Tokenizers
         /// Get the number of tokens that the input text will be encoded to.
         /// </summary>
         /// <param name="text">The text to encode.</param>
-        /// <param name="considerSpecialTokens">Indicate if want to consider the special tokens during the encoding.</param>
         /// <returns>The number of tokens Ids that the input text will be encoded to.</returns>
         /// <exception cref="ArgumentNullException">The input text is null.</exception>
         /// <exception cref="ArgumentException">Unable to encode the text.</exception>
-        public int CountTokens(string text, bool considerSpecialTokens = true)
+        public int CountTokens(string text)
         {
             if (text is null)
             {
@@ -128,9 +125,9 @@ namespace Microsoft.ML.Tokenizers
             string normalized = Normalizer is not null ? Normalizer.Normalize(text) : text;
 
             int idsCount = 0;
-            foreach (Split split in PreTokenizer.PreTokenize(normalized, considerSpecialTokens))
+            foreach (Split split in PreTokenizer.PreTokenize(normalized))
             {
-                idsCount += Model.CountTokens(split.TokenSpan, split.IsSpecialToken);
+                idsCount += Model.CountTokens(split.TokenSpan);
             }
 
             return idsCount;
@@ -143,15 +140,14 @@ namespace Microsoft.ML.Tokenizers
         /// <param name="maxTokenCount">The maximum token count to limit the encoding capacity.</param>
         /// <param name="processedText">If the tokenizer's normalization is enabled, the input text will be represented in its normalization form; otherwise, it will remain unchanged as the input text.</param>
         /// <param name="tokenCount">The token count can be generated which should be smaller than the maximum token count.</param>
-        /// <param name="considerSpecialTokens">Indicate if want to consider the special tokens during the encoding.</param>
         /// <returns>
         /// The index of the maximum encoding capacity within the processed text without surpassing the token limit.
         /// It represents the index immediately following the last character to be included. In cases where no tokens fit, the result will be 0; conversely, if all tokens fit, the result will be length of the <paramref name="processedText"/>.
         /// </returns>
         /// <exception cref="ArgumentNullException">The input text is null.</exception>
         /// <exception cref="ArgumentOutOfRangeException">The maximum token count must be greater than 0.</exception>
-        public int IndexOfTokenCount(string text, int maxTokenCount, out string processedText, out int tokenCount, bool considerSpecialTokens = true)
-            => IndexOf(text, maxTokenCount, fromStart: true, considerSpecialTokens, out processedText, out tokenCount);
+        public int IndexOfTokenCount(string text, int maxTokenCount, out string processedText, out int tokenCount)
+            => IndexOf(text, maxTokenCount, fromStart: true, out processedText, out tokenCount);
 
         /// <summary>
         /// Find the index of the maximum encoding capacity from the end within the text without surpassing the token limit.
@@ -160,7 +156,6 @@ namespace Microsoft.ML.Tokenizers
         /// <param name="maxTokenCount">The maximum token count to limit the encoding capacity.</param>
         /// <param name="processedText">If the tokenizer's normalization is enabled, the input text will be represented in its normalization form; otherwise, it will remain unchanged as the input text.</param>
         /// <param name="tokenCount">The token count can be generated which should be smaller than the maximum token count.</param>
-        /// <param name="considerSpecialTokens">Indicate if want to consider the special tokens during the encoding.</param>
         /// <returns>
         /// The start index of the maximum encoding capacity within the processed text without surpassing the token limit.
         /// It represents the index at the first character to be included. In cases where no tokens fit, the result will be length of the <paramref name="processedText"/>; conversely, if all tokens fit, the result will be 0.
@@ -170,10 +165,10 @@ namespace Microsoft.ML.Tokenizers
         /// <remarks>
         /// If the whole text can be encoded within the token limit, the returned index will be 0.
         /// </remarks>
-        public int LastIndexOfTokenCount(string text, int maxTokenCount, out string processedText, out int tokenCount, bool considerSpecialTokens = true)
-            => IndexOf(text, maxTokenCount, fromStart: false, considerSpecialTokens, out processedText, out tokenCount);
+        public int LastIndexOfTokenCount(string text, int maxTokenCount, out string processedText, out int tokenCount)
+            => IndexOf(text, maxTokenCount, fromStart: false, out processedText, out tokenCount);
 
-        private int IndexOf(string text, int maxTokenCount, bool fromStart, bool considerSpecialTokens, out string processedText, out int tokenCount)
+        private int IndexOf(string text, int maxTokenCount, bool fromStart, out string processedText, out int tokenCount)
         {
             if (text is null)
             {
@@ -188,10 +183,10 @@ namespace Microsoft.ML.Tokenizers
             processedText = Normalizer is not null ? Normalizer.Normalize(text) : text;
             tokenCount = 0;
 
-            IEnumerable<Split> splits = PreTokenizer.PreTokenize(processedText, considerSpecialTokens);
+            IEnumerable<Split> splits = PreTokenizer.PreTokenize(processedText);
             foreach (Split split in (fromStart ? splits : splits.Reverse()))
             {
-                int count = Model.CountTokens(split.TokenSpan, split.IsSpecialToken);
+                int count = Model.CountTokens(split.TokenSpan);
                 if (tokenCount > maxTokenCount - count)
                 {
                     return fromStart ? split.Offset.Index : split.Offset.Index + split.Offset.Length;
@@ -207,17 +202,15 @@ namespace Microsoft.ML.Tokenizers
         /// Decodes the Id to the mapped token.
         /// </summary>
         /// <param name="id">The id to map to the token.</param>
-        /// <param name="considerSpecialTokens">Indicate if want to consider the special tokens during the decoding.</param>
         /// <returns>The decoded string or null if there is no token mapped to the input id.</returns>
-        public string? Decode(int id, bool considerSpecialTokens = true) => Model.MapIdToToken(id, considerSpecialTokens);
+        public string? Decode(int id) => Model.MapIdToToken(id);
 
         /// <summary>
         /// Decode the given ids, back to a String.
         /// </summary>
         /// <param name="ids">The list of ids that we want to decode.</param>
-        /// <param name="considerSpecialTokens">Whether the special tokens should be kept in the decoded string.</param>
         /// <returns>The decoded string.</returns>
-        public string? Decode(IEnumerable<int> ids, bool considerSpecialTokens = true) => Model.Decode(ids, Decoder, considerSpecialTokens);
+        public string? Decode(IEnumerable<int> ids) => Model.Decode(ids, Decoder);
 
         /// <summary>
         /// Create a Tiktoken tokenizer based on model name and vocab file.

--- a/test/Microsoft.ML.Tokenizers.Tests/EnglishRobertaTests.cs
+++ b/test/Microsoft.ML.Tokenizers.Tests/EnglishRobertaTests.cs
@@ -193,13 +193,13 @@ namespace Microsoft.ML.Tokenizers.Tests
                     if (robertaModel.FilterUnsupportedChars)
                     {
                         string[]? filteredToken = p[5] as string[];
-                        Assert.Equal(filteredToken![i], tokenizer.Model.MapIdToToken(encoding.Ids[i], considerSpecialTokens: false));
+                        Assert.Equal(filteredToken![i], tokenizer.Model.MapIdToToken(encoding.Ids[i]));
                     }
                     else
                     {
-                        Assert.Equal(encoding.Tokens[i], tokenizer.Model.MapIdToToken(encoding.Ids[i], considerSpecialTokens: false));
+                        Assert.Equal(encoding.Tokens[i], tokenizer.Model.MapIdToToken(encoding.Ids[i]));
                         string[]? unfilteredToken = p[2] as string[];
-                        Assert.Equal(unfilteredToken![i], tokenizer.Model.MapIdToToken(encoding.Ids[i], considerSpecialTokens: false));
+                        Assert.Equal(unfilteredToken![i], tokenizer.Model.MapIdToToken(encoding.Ids[i]));
                     }
 
                     Assert.Equal(encoding.Ids[i], tokenizer.Model.MapTokenToId(encoding.Tokens[i].AsSpan()));

--- a/test/Microsoft.ML.Tokenizers.Tests/LlamaTests.cs
+++ b/test/Microsoft.ML.Tokenizers.Tests/LlamaTests.cs
@@ -208,7 +208,7 @@ namespace Microsoft.ML.Tokenizers.Tests
 
             bool isEmptyInput = string.IsNullOrEmpty(input);
 
-            IReadOnlyList<Token> bpeTokens = bpe.Encode(normalizedInput, addBeginOfSentence: false, addEndOfSentence: false);
+            IReadOnlyList<Token> bpeTokens = bpe.Encode(normalizedInput.AsSpan(), addBeginOfSentence: false, addEndOfSentence: false);
             Assert.Equal(ids.Skip(1), bpeTokens.Select(token => token.Id));
             Assert.Equal(tokens.Skip(1), bpeTokens.Select(token => token.Value));
             Assert.Equal(input, llamaTokenizer.Decode(bpeTokens.Select(token => token.Id)));
@@ -217,7 +217,7 @@ namespace Microsoft.ML.Tokenizers.Tests
             Assert.Equal(ids.Skip(1), encodedIds);
             Assert.Equal(isEmptyInput ? 0 : ids.Length - 1, bpe.CountTokens(normalizedInput.AsSpan(), addBeginOfSentence: false, addEndOfSentence: false));
 
-            bpeTokens = bpe.Encode(normalizedInput, addBeginOfSentence: false, addEndOfSentence: true);
+            bpeTokens = bpe.Encode(normalizedInput.AsSpan(), addBeginOfSentence: false, addEndOfSentence: true);
             Assert.Equal(isEmptyInput ? Array.Empty<int>() : ids.Skip(1).Concat(new[] { bpe.EndOfSentenceId }), bpeTokens.Select(token => token.Id));
             Assert.Equal(isEmptyInput ? Array.Empty<string>() : tokens.Skip(1).Concat(new[] { bpe.EndOfSentenceToken }), bpeTokens.Select(token => token.Value));
             Assert.Equal(input, llamaTokenizer.Decode(bpeTokens.Select(token => token.Id)));
@@ -226,7 +226,7 @@ namespace Microsoft.ML.Tokenizers.Tests
             Assert.Equal(isEmptyInput ? Array.Empty<int>() : ids.Skip(1).Concat(new[] { bpe.EndOfSentenceId }), encodedIds);
             Assert.Equal(isEmptyInput ? 0 : ids.Length, bpe.CountTokens(normalizedInput.AsSpan(), addBeginOfSentence: false, addEndOfSentence: true));
 
-            bpeTokens = bpe.Encode(normalizedInput, addBeginOfSentence: true, addEndOfSentence: true);
+            bpeTokens = bpe.Encode(normalizedInput.AsSpan(), addBeginOfSentence: true, addEndOfSentence: true);
             Assert.Equal(isEmptyInput ? Array.Empty<int>() : ids.Concat(new[] { bpe.EndOfSentenceId }), bpeTokens.Select(token => token.Id));
             Assert.Equal(isEmptyInput ? Array.Empty<string>() : tokens.Concat(new[] { bpe.EndOfSentenceToken }), bpeTokens.Select(token => token.Value));
             Assert.Equal(input, llamaTokenizer.Decode(bpeTokens.Select(token => token.Id)));
@@ -250,7 +250,6 @@ namespace Microsoft.ML.Tokenizers.Tests
             Assert.Throws<ArgumentNullException>(() => llamaTokenizer.EncodeToIds(null!));
             Assert.Throws<ArgumentNullException>(() => llamaTokenizer.CountTokens(null!));
             Assert.Throws<ArgumentNullException>(() => llamaTokenizer.Decode(null!));
-            Assert.Throws<ArgumentNullException>(() => (llamaTokenizer.Model as SentencePieceBpe)!.Encode(null!));
         }
 
         [Theory]

--- a/test/Microsoft.ML.Tokenizers.Tests/LlamaTests.cs
+++ b/test/Microsoft.ML.Tokenizers.Tests/LlamaTests.cs
@@ -213,27 +213,27 @@ namespace Microsoft.ML.Tokenizers.Tests
             Assert.Equal(tokens.Skip(1), bpeTokens.Select(token => token.Value));
             Assert.Equal(input, llamaTokenizer.Decode(bpeTokens.Select(token => token.Id)));
             List<int> encodedIds = new();
-            bpe.EncodeToIds(normalizedInput.AsSpan(), addBeginOfSentence: false, addEndOfSentence: false, accumulatedIds: encodedIds);
+            bpe.EncodeToIds(normalizedInput.AsSpan(), addBeginOfSentence: false, addEndOfSentence: false, accumulatedIds: encodedIds, out _);
             Assert.Equal(ids.Skip(1), encodedIds);
-            Assert.Equal(isEmptyInput ? 0 : ids.Length - 1, bpe.CountTokens(normalizedInput.AsSpan(), addBeginOfSentence: false, addEndOfSentence: false));
+            Assert.Equal(isEmptyInput ? 0 : ids.Length - 1, bpe.CountTokens(normalizedInput.AsSpan(), addBeginOfSentence: false, addEndOfSentence: false, out _));
 
             bpeTokens = bpe.Encode(normalizedInput.AsSpan(), addBeginOfSentence: false, addEndOfSentence: true);
             Assert.Equal(isEmptyInput ? Array.Empty<int>() : ids.Skip(1).Concat(new[] { bpe.EndOfSentenceId }), bpeTokens.Select(token => token.Id));
             Assert.Equal(isEmptyInput ? Array.Empty<string>() : tokens.Skip(1).Concat(new[] { bpe.EndOfSentenceToken }), bpeTokens.Select(token => token.Value));
             Assert.Equal(input, llamaTokenizer.Decode(bpeTokens.Select(token => token.Id)));
             encodedIds.Clear();
-            bpe.EncodeToIds(normalizedInput.AsSpan(), addBeginOfSentence: false, addEndOfSentence: true, accumulatedIds: encodedIds);
+            bpe.EncodeToIds(normalizedInput.AsSpan(), addBeginOfSentence: false, addEndOfSentence: true, accumulatedIds: encodedIds, out _);
             Assert.Equal(isEmptyInput ? Array.Empty<int>() : ids.Skip(1).Concat(new[] { bpe.EndOfSentenceId }), encodedIds);
-            Assert.Equal(isEmptyInput ? 0 : ids.Length, bpe.CountTokens(normalizedInput.AsSpan(), addBeginOfSentence: false, addEndOfSentence: true));
+            Assert.Equal(isEmptyInput ? 0 : ids.Length, bpe.CountTokens(normalizedInput.AsSpan(), addBeginOfSentence: false, addEndOfSentence: true, out _));
 
             bpeTokens = bpe.Encode(normalizedInput.AsSpan(), addBeginOfSentence: true, addEndOfSentence: true);
             Assert.Equal(isEmptyInput ? Array.Empty<int>() : ids.Concat(new[] { bpe.EndOfSentenceId }), bpeTokens.Select(token => token.Id));
             Assert.Equal(isEmptyInput ? Array.Empty<string>() : tokens.Concat(new[] { bpe.EndOfSentenceToken }), bpeTokens.Select(token => token.Value));
             Assert.Equal(input, llamaTokenizer.Decode(bpeTokens.Select(token => token.Id)));
             encodedIds.Clear();
-            bpe.EncodeToIds(normalizedInput.AsSpan(), addBeginOfSentence: true, addEndOfSentence: true, accumulatedIds: encodedIds);
+            bpe.EncodeToIds(normalizedInput.AsSpan(), addBeginOfSentence: true, addEndOfSentence: true, accumulatedIds: encodedIds, out _);
             Assert.Equal(isEmptyInput ? Array.Empty<int>() : ids.Concat(new[] { bpe.EndOfSentenceId }), encodedIds);
-            Assert.Equal(isEmptyInput ? 0 : ids.Length + 1, bpe.CountTokens(normalizedInput.AsSpan(), addBeginOfSentence: true, addEndOfSentence: true));
+            Assert.Equal(isEmptyInput ? 0 : ids.Length + 1, bpe.CountTokens(normalizedInput.AsSpan(), addBeginOfSentence: true, addEndOfSentence: true, out _));
         }
 
         public static IEnumerable<object[]> LlamaTokenizersListData()
@@ -279,6 +279,8 @@ namespace Microsoft.ML.Tokenizers.Tests
             Assert.True(bpe.AddDummyPrefix);
             Assert.True(bpe.EscapeWhiteSpaces);
             Assert.False(bpe.TreatWhitespaceAsSuffix);
+
+            TokenizerTests.TestTokenLimits(llamaTokenizer);
         }
 
         [Fact]

--- a/test/Microsoft.ML.Tokenizers.Tests/PreTokenizerTests.cs
+++ b/test/Microsoft.ML.Tokenizers.Tests/PreTokenizerTests.cs
@@ -68,7 +68,7 @@ namespace Microsoft.ML.Tokenizers.Tests
 
         public class SpacePreTokenizer : PreTokenizer
         {
-            public override IEnumerable<Split> PreTokenize(string text, bool considerSpecialTokens = true)
+            public override IEnumerable<Split> PreTokenize(string text)
             {
                 List<Split> splits = new();
                 if (string.IsNullOrEmpty(text))

--- a/test/Microsoft.ML.Tokenizers.Tests/TitokenTests.cs
+++ b/test/Microsoft.ML.Tokenizers.Tests/TitokenTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.ML.Tokenizers.Tests
             TestGPT4TokenizationEncoding(GPT4);
 
             Assert.True(GPT4.Model is Tiktoken);
-            IReadOnlyDictionary<string, int>? specialTokensEncoder = (GPT4.Model as Tiktoken)!.SpecialTokensEncoder;
+            IReadOnlyDictionary<string, int>? specialTokensEncoder = (GPT4.Model as Tiktoken)!.SpecialTokens;
 
             string tokenizerDataFileName = Utils.CreateTemporaryFile("tiktoken");
             await Utils.DownloadFile(@"https://openaipublic.blob.core.windows.net/encodings/cl100k_base.tiktoken", tokenizerDataFileName);
@@ -122,9 +122,9 @@ namespace Microsoft.ML.Tokenizers.Tests
         private void TestGPT4Tokenizer(Tokenizer gpt4Tokenizer)
         {
             string text = ReadAndSanitizeFile("./Data/lib.rs.txt");
-            IReadOnlyList<int> encoded = gpt4Tokenizer.EncodeToIds(text, considerSpecialTokens: false);
+            IReadOnlyList<int> encoded = gpt4Tokenizer.EncodeToIds(text);
             Assert.Equal(5584, encoded.Count);
-            int idsCount = gpt4Tokenizer.CountTokens(text, considerSpecialTokens: false);
+            int idsCount = gpt4Tokenizer.CountTokens(text);
             Assert.Equal(encoded.Count, idsCount);
 
             using (Stream stream = File.OpenRead("./Data/tokens.json"))

--- a/test/Microsoft.ML.Tokenizers.Tests/TokenizerTests.cs
+++ b/test/Microsoft.ML.Tokenizers.Tests/TokenizerTests.cs
@@ -29,14 +29,26 @@ namespace Microsoft.ML.Tokenizers.Tests
                 int index1 = tokenizer.IndexOfTokenCount(input, maxTokenCount: i, out string processedText1, out int tokenCount1);
                 int index2 = tokenizer.LastIndexOfTokenCount(input, maxTokenCount: i, out string processedText2, out int tokenCount2);
 
-
                 IReadOnlyList<int>? prefixIds = null;
                 IReadOnlyList<int>? suffixIds = null;
 
-                if (tokenCount1 > 0)
+                // It is possible with Llama tokenizer to produce start of sentence token <s> token only if we have the maxTokenCount is 1.
+                // In this case, we'll get index1 equal to zero and nothing really will need to be tested.
+                if (tokenCount1 > 0 && index1 > 0)
                 {
                     string prefixString = processedText1.Substring(0, index1);
-                    prefixIds = tokenizer.EncodeToIds(prefixString);
+
+                    if (tokenizer.Model is SentencePieceBpe)
+                    {
+                        // SentencePieceBpe model normalize the text and insert more characters.
+                        // We call the model directly to bypass the normalization step
+                        prefixIds = new List<int>();
+                        tokenizer.Model.EncodeToIds(prefixString.AsSpan(), (prefixIds as IList<int>)!, out _);
+                    }
+                    else
+                    {
+                        prefixIds = tokenizer.EncodeToIds(prefixString);
+                    }
                     Assert.Equal(tokenCount1, prefixIds.Count);
                     Assert.Equal(prefixIds, fullIdsList.Take(prefixIds.Count));
                 }
@@ -44,15 +56,45 @@ namespace Microsoft.ML.Tokenizers.Tests
                 if (tokenCount2 > 0)
                 {
                     string suffixString = processedText2.Substring(index2);
-                    suffixIds = tokenizer.EncodeToIds(suffixString);
+
+                    if (tokenizer.Model is SentencePieceBpe)
+                    {
+                        // SentencePieceBpe model normalize the text and insert more characters.
+                        // We call the model directly to bypass the normalization step
+                        suffixIds = new List<int>();
+                        tokenizer.Model.EncodeToIds(suffixString.AsSpan(), (suffixIds as IList<int>)!, out _);
+                        if (i < fullIdsList.Count)
+                        {
+                            suffixIds = suffixIds.Skip(1).ToList(); // Skip the start of sentence token <s>
+                        }
+                    }
+                    else
+                    {
+                        suffixIds = tokenizer.EncodeToIds(suffixString);
+                    }
+
                     Assert.Equal(tokenCount2, suffixIds.Count);
                     Assert.Equal(suffixIds, fullIdsList.Skip(fullIdsList.Count - suffixIds.Count));
                 }
 
                 if (i == fullIdsList.Count)
                 {
-                    Assert.Equal(processedText1.Length, index1);
-                    Assert.Equal(0, index2);
+                    if (index1 != processedText1.Length)
+                    {
+                        // It's possible that the remaining text on the left doesn't produce any tokens, as in the case of BPE,
+                        // where the pre-tokenizer removes spaces and the left text consists entirely of spaces.
+                        Assert.True(index1 < processedText1.Length);
+                        Assert.Equal(0, tokenizer.CountTokens(processedText1.Substring(index1)));
+                    }
+
+                    if (index2 != 0)
+                    {
+                        // It's possible that the remaining text on the right doesn't produce any tokens, as in the case of BPE,
+                        // where the pre-tokenizer removes spaces and the left text consists entirely of spaces.
+                        Assert.True(index2 > 0);
+                        Assert.Equal(0, tokenizer.CountTokens(processedText1.Substring(0, index2)));
+                    }
+
                     Assert.Equal(fullIdsList, prefixIds);
                     Assert.Equal(fullIdsList, suffixIds);
                 }


### PR DESCRIPTION
- Eliminate the perplexing specialTokens flag parameter from all APIs.
- Standardize the casing of the Tiktoken name throughout the entire codebase and public interfaces.
- Modify Model.Encode to operate with spans instead of strings. This change maintains consistency across all Model APIs and enables the possibility of incorporating Tokenizer's APIs that also operate with spans in the future.
- Introduce support for precise Last/IndexOf functionality. This enhancement enables the retrieval of indices even within pre-tokenized unit strings passed to the Model. For instance, the Llama model, which does not pre-tokenize, requires this capability to be supported effectively.