### PR TITLE
Implement DataFrameColumn Apply method and DropNulls methods

### DIFF
--- a/src/Microsoft.Data.Analysis/DataFrame.cs
+++ b/src/Microsoft.Data.Analysis/DataFrame.cs
@@ -8,7 +8,6 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Text;
-using Microsoft.ML.Data;
 
 namespace Microsoft.Data.Analysis
 {

--- a/src/Microsoft.Data.Analysis/DataFrame.cs
+++ b/src/Microsoft.Data.Analysis/DataFrame.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Text;
+using Microsoft.ML.Data;
 
 namespace Microsoft.Data.Analysis
 {
@@ -192,15 +193,15 @@ namespace Microsoft.Data.Analysis
         /// </summary>
         public DataFrame Clone()
         {
-            return Clone(mapIndices: null, invertMapIndices: false);
+            return Clone(mapIndices: null);
         }
 
-        private DataFrame Clone(DataFrameColumn mapIndices = null, bool invertMapIndices = false)
+        private DataFrame Clone(DataFrameColumn mapIndices = null)
         {
             List<DataFrameColumn> newColumns = new List<DataFrameColumn>(Columns.Count);
             for (int i = 0; i < Columns.Count; i++)
             {
-                newColumns.Add(Columns[i].Clone(mapIndices, invertMapIndices));
+                newColumns.Add(Columns[i].Clone(mapIndices));
             }
             return new DataFrame(newColumns);
         }
@@ -408,31 +409,46 @@ namespace Microsoft.Data.Analysis
         /// <param name="options"></param>
         public DataFrame DropNulls(DropNullOptions options = DropNullOptions.Any)
         {
-            DataFrame ret = new DataFrame();
-            PrimitiveDataFrameColumn<bool> filter = new PrimitiveDataFrameColumn<bool>("Filter");
+            var filter = new BooleanDataFrameColumn("Filter");
+
             if (options == DropNullOptions.Any)
             {
                 filter.AppendMany(true, Rows.Count);
+                var buffers = filter.ColumnContainer.Buffers;
 
-                for (int i = 0; i < Columns.Count; i++)
+                foreach (var column in Columns)
                 {
-                    DataFrameColumn column = Columns[i];
-                    filter.ApplyElementwise((bool? value, long index) =>
+                    long index = 0;
+                    for (int b = 0; b < buffers.Count; b++)
                     {
-                        return value.Value && (column[index] == null ? false : true);
-                    });
+                        var span = buffers.GetOrCreateMutable(b).Span;
+
+                        for (int i = 0; i < span.Length; i++)
+                        {
+                            span[i] = span[i] && column.IsValid(index);
+                            index++;
+                        }
+                    }
                 }
             }
             else
             {
                 filter.AppendMany(false, Rows.Count);
-                for (int i = 0; i < Columns.Count; i++)
+                var buffers = filter.ColumnContainer.Buffers;
+
+                foreach (var column in Columns)
                 {
-                    DataFrameColumn column = Columns[i];
-                    filter.ApplyElementwise((bool? value, long index) =>
+                    long index = 0;
+                    for (int b = 0; b < buffers.Count; b++)
                     {
-                        return value.Value || (column[index] == null ? false : true);
-                    });
+                        var span = buffers.GetOrCreateMutable(b).Span;
+
+                        for (int i = 0; i < span.Length; i++)
+                        {
+                            span[i] = span[i] || column.IsValid(index);
+                            index++;
+                        }
+                    }
                 }
             }
             return this[filter];

--- a/src/Microsoft.Data.Analysis/DataFrameColumn.cs
+++ b/src/Microsoft.Data.Analysis/DataFrameColumn.cs
@@ -141,6 +141,13 @@ namespace Microsoft.Data.Analysis
         public void SetName(string newName, DataFrame dataFrame) => SetName(newName);
 
         /// <summary>
+        /// Indicates if the value at this <paramref name="index"/> is valid (not <see langword="null"/>).
+        /// </summary>
+        /// <param name="index">The index to look up.</param>
+        /// <returns>A boolean value indicating the validity at this <paramref name="index"/>.</returns>
+        public virtual bool IsValid(long index) => this[index] != null;
+
+        /// <summary>
         /// The type of data this column holds.
         /// </summary>
         public Type DataType { get; }

--- a/src/Microsoft.Data.Analysis/DataFrameColumn.cs
+++ b/src/Microsoft.Data.Analysis/DataFrameColumn.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Data.Analysis
         /// </summary>
         /// <param name="index">The index to look up.</param>
         /// <returns>A boolean value indicating the validity at this <paramref name="index"/>.</returns>
-        public virtual bool IsValid(long index) => this[index] != null;
+        public virtual bool IsValid(long index) => NullCount == 0 || this[index] != null;
 
         /// <summary>
         /// The type of data this column holds.
@@ -307,6 +307,13 @@ namespace Microsoft.Data.Analysis
         public virtual DataFrameColumn FillNulls(object value, bool inPlace = false) => FillNullsImplementation(value, inPlace);
 
         protected abstract DataFrameColumn FillNullsImplementation(object value, bool inPlace);
+
+        /// <summary>
+        /// Returns a <see cref="DataFrameColumn"/> with no missing values.
+        /// </summary>
+        public virtual DataFrameColumn DropNulls() => DropNullsImplementation();
+
+        protected abstract DataFrameColumn DropNullsImplementation();
 
         // Arrow related APIs
         protected internal virtual Field GetArrowField() => throw new NotImplementedException();

--- a/src/Microsoft.Data.Analysis/DataFrameColumn.cs
+++ b/src/Microsoft.Data.Analysis/DataFrameColumn.cs
@@ -306,7 +306,7 @@ namespace Microsoft.Data.Analysis
         /// <param name="inPlace">Indicates if the operation should be performed in place</param>
         public virtual DataFrameColumn FillNulls(object value, bool inPlace = false) => FillNullsImplementation(value, inPlace);
 
-        protected virtual DataFrameColumn FillNullsImplementation(object value, bool inPlace) => throw new NotImplementedException();
+        protected abstract DataFrameColumn FillNullsImplementation(object value, bool inPlace);
 
         // Arrow related APIs
         protected internal virtual Field GetArrowField() => throw new NotImplementedException();

--- a/src/Microsoft.Data.Analysis/DataFrameColumns/ArrowStringDataFrameColumn.cs
+++ b/src/Microsoft.Data.Analysis/DataFrameColumns/ArrowStringDataFrameColumn.cs
@@ -69,12 +69,8 @@ namespace Microsoft.Data.Analysis
         /// <inheritdoc/>
         public override long NullCount => _nullCount;
 
-        /// <summary>
-        /// Indicates if the value at this <paramref name="index"/> is <see langword="null" />.
-        /// </summary>
-        /// <param name="index">The index to look up.</param>
-        /// <returns>A boolean value indicating the validity at this <paramref name="index"/>.</returns>
-        public bool IsValid(long index) => NullCount == 0 || GetValidityBit(index);
+        /// <inheritdoc/>
+        public override bool IsValid(long index) => NullCount == 0 || GetValidityBit(index);
 
         private bool GetValidityBit(long index)
         {

--- a/src/Microsoft.Data.Analysis/DataFrameColumns/ArrowStringDataFrameColumn.cs
+++ b/src/Microsoft.Data.Analysis/DataFrameColumns/ArrowStringDataFrameColumn.cs
@@ -432,24 +432,42 @@ namespace Microsoft.Data.Analysis
             return ret;
         }
 
-        private ArrowStringDataFrameColumn CloneImplementation<U>(PrimitiveDataFrameColumn<U> mapIndices, bool invertMapIndices)
-            where U : unmanaged
+        private ArrowStringDataFrameColumn CloneImplementation(PrimitiveDataFrameColumn<int> mapIndices, bool invertMapIndices)
         {
             ArrowStringDataFrameColumn ret = new ArrowStringDataFrameColumn(Name);
 
-            mapIndices.ApplyElementwise((U? mapIndex, long rowIndex) =>
+            for (long i = 0; i < mapIndices.Length; i++)
             {
-                if (mapIndex == null)
+                int? index = mapIndices[invertMapIndices ? mapIndices.Length - 1 - i : i];
+
+                if (index == null)
                 {
                     ret.Append(default);
-                    return mapIndex;
+                    continue;
                 }
 
-                long index = invertMapIndices ? mapIndices.Length - 1 - rowIndex : rowIndex;
-                ret.Append(IsValid(index) ? GetBytes(index) : default(ReadOnlySpan<byte>));
+                ret.Append(IsValid(index.Value) ? GetBytes(index.Value) : default(ReadOnlySpan<byte>));
+            }
 
-                return mapIndex;
-            });
+            return ret;
+        }
+
+        private ArrowStringDataFrameColumn CloneImplementation(PrimitiveDataFrameColumn<long> mapIndices, bool invertMapIndices)
+        {
+            ArrowStringDataFrameColumn ret = new ArrowStringDataFrameColumn(Name);
+
+            for (long i = 0; i < mapIndices.Length; i++)
+            {
+                long? index = mapIndices[invertMapIndices ? mapIndices.Length - 1 - i : i];
+
+                if (index == null)
+                {
+                    ret.Append(default);
+                    continue;
+                }
+
+                ret.Append(IsValid(index.Value) ? GetBytes(index.Value) : default(ReadOnlySpan<byte>));
+            }
 
             return ret;
         }

--- a/src/Microsoft.Data.Analysis/DataFrameColumns/ArrowStringDataFrameColumn.cs
+++ b/src/Microsoft.Data.Analysis/DataFrameColumns/ArrowStringDataFrameColumn.cs
@@ -556,6 +556,25 @@ namespace Microsoft.Data.Analysis
             }
         }
 
+        /// <inheritdoc/>
+        public new ArrowStringDataFrameColumn DropNulls()
+        {
+            return (ArrowStringDataFrameColumn)DropNullsImplementation();
+        }
+
+        protected override DataFrameColumn DropNullsImplementation()
+        {
+            var ret = new ArrowStringDataFrameColumn(Name);
+
+            for (long i = 0; i < Length; i++)
+            {
+                if (IsValid(i))
+                    ret.Append(GetBytes(i));
+            }
+
+            return ret;
+        }
+
         public override DataFrameColumn Clamp<U>(U min, U max, bool inPlace = false) => throw new NotSupportedException();
 
         public override DataFrameColumn Filter<U>(U min, U max) => throw new NotSupportedException();

--- a/src/Microsoft.Data.Analysis/DataFrameColumns/StringDataFrameColumn.cs
+++ b/src/Microsoft.Data.Analysis/DataFrameColumns/StringDataFrameColumn.cs
@@ -434,6 +434,12 @@ namespace Microsoft.Data.Analysis
             }
         }
 
+        /// <summary>
+        /// Returns a new column with <see langword="null" /> elements replaced by <paramref name="value"/>.
+        /// </summary>
+        /// <remarks>Tries to convert value to the column's DataType</remarks>
+        /// <param name="value"></param>
+        /// <param name="inPlace">Indicates if the operation should be performed in place</param>
         public StringDataFrameColumn FillNulls(string value, bool inPlace = false)
         {
             if (value == null)
@@ -454,6 +460,30 @@ namespace Microsoft.Data.Analysis
                 return FillNulls(valueString, inPlace);
             else
                 throw new ArgumentException(String.Format(Strings.MismatchedValueType, typeof(string)), nameof(value));
+        }
+
+        /// <inheritdoc/>
+        public new StringDataFrameColumn DropNulls()
+        {
+            return (StringDataFrameColumn)DropNullsImplementation();
+        }
+
+        protected override DataFrameColumn DropNullsImplementation()
+        {
+            var ret = new StringDataFrameColumn(Name, Length - NullCount);
+
+            long j = 0;
+            for (long i = 0; i < Length; i++)
+            {
+                var value = this[i];
+
+                if (value != null)
+                {
+                    ret[j++] = value;
+                }
+            }
+
+            return ret;
         }
 
         protected internal override void AddDataViewColumn(DataViewSchema.Builder builder)

--- a/src/Microsoft.Data.Analysis/DataFrameColumns/StringDataFrameColumn.cs
+++ b/src/Microsoft.Data.Analysis/DataFrameColumns/StringDataFrameColumn.cs
@@ -79,6 +79,27 @@ namespace Microsoft.Data.Analysis
             Length++;
         }
 
+        /// <summary>
+        /// Applies a function to all values in the column, that are not null.
+        /// </summary>
+        /// <param name="func">The function to apply.</param>
+        /// /// <param name="inPlace">A boolean flag to indicate if the operation should be in place.</param>
+        /// <returns>A new <see cref="PrimitiveDataFrameColumn{T}"/> if <paramref name="inPlace"/> is not set. Returns this column otherwise.</returns>
+        public StringDataFrameColumn Apply(Func<string, string> func, bool inPlace = false)
+        {
+            var column = inPlace ? this : Clone();
+
+            for (long i = 0; i < column.Length; i++)
+            {
+                var value = column[i];
+
+                if (value != null)
+                    column[i] = func(value);
+            }
+
+            return column;
+        }
+
         private int GetBufferIndexContainingRowIndex(long rowIndex)
         {
             if (rowIndex >= Length)

--- a/src/Microsoft.Data.Analysis/DataFrameColumns/VBufferDataFrameColumn.cs
+++ b/src/Microsoft.Data.Analysis/DataFrameColumns/VBufferDataFrameColumn.cs
@@ -223,68 +223,45 @@ namespace Microsoft.Data.Analysis
             return ret;
         }
 
-        private VBufferDataFrameColumn<T> CloneImplementation<U>(PrimitiveDataFrameColumn<U> mapIndices, bool invertMapIndices = false, long numberOfNullsToAppend = 0)
-           where U : unmanaged
+        private VBufferDataFrameColumn<T> CloneImplementation(PrimitiveDataFrameColumn<long> mapIndices, bool invertMapIndices = false)
         {
             mapIndices = mapIndices ?? throw new ArgumentNullException(nameof(mapIndices));
-            VBufferDataFrameColumn<T> ret = new VBufferDataFrameColumn<T>(Name, mapIndices.Length);
+            var ret = new VBufferDataFrameColumn<T>(Name, mapIndices.Length);
 
-            List<VBuffer<T>> setBuffer = ret._vBuffers[0];
-            long setBufferMinRange = 0;
-            long setBufferMaxRange = MaxCapacity;
-            List<VBuffer<T>> getBuffer = _vBuffers[0];
-            long getBufferMinRange = 0;
-            long getBufferMaxRange = MaxCapacity;
-            long maxCapacity = MaxCapacity;
-            if (mapIndices.DataType == typeof(long))
+            long rowIndex = 0;
+            for (int b = 0; b < mapIndices.ColumnContainer.Buffers.Count; b++)
             {
-                PrimitiveDataFrameColumn<long> longMapIndices = mapIndices as PrimitiveDataFrameColumn<long>;
-                longMapIndices.ApplyElementwise((long? mapIndex, long rowIndex) =>
+                var span = mapIndices.ColumnContainer.Buffers[b].ReadOnlySpan;
+                var validitySpan = mapIndices.ColumnContainer.NullBitMapBuffers[b].ReadOnlySpan;
+
+                for (int i = 0; i < span.Length; i++)
                 {
-                    long index = rowIndex;
-                    if (invertMapIndices)
-                        index = longMapIndices.Length - 1 - index;
-                    if (index < setBufferMinRange || index >= setBufferMaxRange)
-                    {
-                        int bufferIndex = (int)(index / maxCapacity);
-                        setBuffer = ret._vBuffers[bufferIndex];
-                        setBufferMinRange = bufferIndex * maxCapacity;
-                        setBufferMaxRange = (bufferIndex + 1) * maxCapacity;
-                    }
-                    index -= setBufferMinRange;
-
-                    if (mapIndex.Value < getBufferMinRange || mapIndex.Value >= getBufferMaxRange)
-                    {
-                        int bufferIndex = (int)(mapIndex.Value / maxCapacity);
-                        getBuffer = _vBuffers[bufferIndex];
-                        getBufferMinRange = bufferIndex * maxCapacity;
-                        getBufferMaxRange = (bufferIndex + 1) * maxCapacity;
-                    }
-                    int bufferLocalMapIndex = (int)(mapIndex - getBufferMinRange);
-                    VBuffer<T> value = getBuffer[bufferLocalMapIndex];
-                    setBuffer[(int)index] = value;
-
-                    return mapIndex;
-                });
+                    long index = invertMapIndices ? mapIndices.Length - 1 - rowIndex : rowIndex;
+                    ret[index] = BitUtility.IsValid(validitySpan, i) ? this[span[i]] : default;
+                    rowIndex++;
+                }
             }
-            else if (mapIndices.DataType == typeof(int))
+
+            return ret;
+        }
+
+        private VBufferDataFrameColumn<T> CloneImplementation(PrimitiveDataFrameColumn<int> mapIndices, bool invertMapIndices = false)
+        {
+            mapIndices = mapIndices ?? throw new ArgumentNullException(nameof(mapIndices));
+            var ret = new VBufferDataFrameColumn<T>(Name, mapIndices.Length);
+
+            long rowIndex = 0;
+            for (int b = 0; b < mapIndices.ColumnContainer.Buffers.Count; b++)
             {
-                PrimitiveDataFrameColumn<int> intMapIndices = mapIndices as PrimitiveDataFrameColumn<int>;
-                intMapIndices.ApplyElementwise((int? mapIndex, long rowIndex) =>
+                var span = mapIndices.ColumnContainer.Buffers[b].ReadOnlySpan;
+                var validitySpan = mapIndices.ColumnContainer.NullBitMapBuffers[b].ReadOnlySpan;
+
+                for (int i = 0; i < span.Length; i++)
                 {
-                    long index = rowIndex;
-                    if (invertMapIndices)
-                        index = intMapIndices.Length - 1 - index;
-
-                    VBuffer<T> value = getBuffer[mapIndex.Value];
-                    setBuffer[(int)index] = value;
-
-                    return mapIndex;
-                });
-            }
-            else
-            {
-                Debug.Assert(false, nameof(mapIndices.DataType));
+                    long index = invertMapIndices ? mapIndices.Length - 1 - rowIndex : rowIndex;
+                    ret[index] = BitUtility.IsValid(validitySpan, i) ? this[span[i]] : default;
+                    rowIndex++;
+                }
             }
 
             return ret;

--- a/src/Microsoft.Data.Analysis/DataFrameColumns/VBufferDataFrameColumn.cs
+++ b/src/Microsoft.Data.Analysis/DataFrameColumns/VBufferDataFrameColumn.cs
@@ -371,5 +371,11 @@ namespace Microsoft.Data.Analysis
 
             throw new NotSupportedException();
         }
+
+        protected override DataFrameColumn FillNullsImplementation(object value, bool inPlace)
+        {
+            //Do nothing as VBufferColumn doesn't have null values
+            return inPlace ? this : Clone();
+        }
     }
 }

--- a/src/Microsoft.Data.Analysis/DataFrameColumns/VBufferDataFrameColumn.cs
+++ b/src/Microsoft.Data.Analysis/DataFrameColumns/VBufferDataFrameColumn.cs
@@ -377,5 +377,11 @@ namespace Microsoft.Data.Analysis
             //Do nothing as VBufferColumn doesn't have null values
             return inPlace ? this : Clone();
         }
+
+        protected override DataFrameColumn DropNullsImplementation()
+        {
+            //Do nothing as VBufferColumn doesn't have null values
+            return Clone();
+        }
     }
 }

--- a/src/Microsoft.Data.Analysis/PrimitiveColumnContainer.cs
+++ b/src/Microsoft.Data.Analysis/PrimitiveColumnContainer.cs
@@ -194,6 +194,24 @@ namespace Microsoft.Data.Analysis
             }
         }
 
+        public void Apply(Func<T, T> func)
+        {
+            for (int b = 0; b < Buffers.Count; b++)
+            {
+                var span = Buffers.GetOrCreateMutable(b).Span;
+                var validitySpan = NullBitMapBuffers.GetOrCreateMutable(b).Span;
+
+                for (int i = 0; i < span.Length; i++)
+                {
+                    if (NullCount == 0 || BitUtility.IsValid(validitySpan, i))
+                    {
+                        span[i] = func(span[i]);
+                    }
+                }
+            }
+        }
+
+        [Obsolete]
         public void Apply<TResult>(Func<T?, TResult?> func, PrimitiveColumnContainer<TResult> resultContainer)
             where TResult : unmanaged
         {

--- a/src/Microsoft.Data.Analysis/PrimitiveColumnContainer.cs
+++ b/src/Microsoft.Data.Analysis/PrimitiveColumnContainer.cs
@@ -177,8 +177,6 @@ namespace Microsoft.Data.Analysis
 
         public void ApplyElementwise(Func<T?, long, T?> func)
         {
-            var bufferMaxCapacity = ReadOnlyDataFrameBuffer<T>.MaxCapacity;
-
             long curIndex = 0;
             for (int b = 0; b < Buffers.Count; b++)
             {
@@ -199,24 +197,46 @@ namespace Microsoft.Data.Analysis
         public void Apply<TResult>(Func<T?, TResult?> func, PrimitiveColumnContainer<TResult> resultContainer)
             where TResult : unmanaged
         {
-            var bufferMaxCapacity = ReadOnlyDataFrameBuffer<T>.MaxCapacity;
             for (int b = 0; b < Buffers.Count; b++)
             {
-                long prevLength = checked(bufferMaxCapacity * b);
                 var sourceBuffer = Buffers[b];
                 var sourceNullBitMap = NullBitMapBuffers[b].ReadOnlySpan;
 
                 Span<TResult> mutableResultBuffer = resultContainer.Buffers.GetOrCreateMutable(b).Span;
-                Span<byte> mutableResultNullBitMapBuffers = resultContainer.NullBitMapBuffers.GetOrCreateMutable(b).Span;
+                Span<byte> mutableResultNullBitMapBuffer = resultContainer.NullBitMapBuffers.GetOrCreateMutable(b).Span;
 
                 for (int i = 0; i < sourceBuffer.Length; i++)
                 {
                     bool isValid = BitUtility.IsValid(sourceNullBitMap, i);
                     TResult? value = func(isValid ? sourceBuffer[i] : null);
                     mutableResultBuffer[i] = value.GetValueOrDefault();
-                    resultContainer.SetValidityBit(mutableResultNullBitMapBuffers, i, value != null);
+                    //Actually there is a bug in the previouse line. This code will not work correctly with containers having more than 1 buffers
+                    //As buffer size for type T (sourceBuffer) is different from the size of buffer for type TResult (mutableResultBuffer) in case sizeof(T) not equal to sizeof(TResult)
+                    //TODO fix (https://github.com/dotnet/machinelearning/issues/7122)
+                    resultContainer.SetValidityBit(mutableResultNullBitMapBuffer, i, value != null);
                 }
             }
+        }
+
+        public void FillNulls(T value)
+        {
+
+            for (int b = 0; b < Buffers.Count; b++)
+            {
+                var span = Buffers.GetOrCreateMutable(b).Span;
+                var validitySpan = NullBitMapBuffers.GetOrCreateMutable(b).Span;
+
+                for (int i = 0; i < span.Length; i++)
+                {
+                    if (BitUtility.IsValid(validitySpan, i))
+                        continue;
+
+                    span[i] = value;
+                    BitUtility.SetBit(validitySpan, i, true);
+                }
+            }
+
+            NullCount = 0;
         }
 
         public bool IsValid(long index) => NullCount == 0 || GetValidityBit(index);

--- a/src/Microsoft.Data.Analysis/PrimitiveColumnContainer.cs
+++ b/src/Microsoft.Data.Analysis/PrimitiveColumnContainer.cs
@@ -178,20 +178,20 @@ namespace Microsoft.Data.Analysis
         public void ApplyElementwise(Func<T?, long, T?> func)
         {
             var bufferMaxCapacity = ReadOnlyDataFrameBuffer<T>.MaxCapacity;
+
+            long curIndex = 0;
             for (int b = 0; b < Buffers.Count; b++)
             {
-                long prevLength = checked(bufferMaxCapacity * b);
-
                 Span<T> mutableBuffer = Buffers.GetOrCreateMutable(b).Span;
                 Span<byte> mutableNullBitMapBuffer = NullBitMapBuffers.GetOrCreateMutable(b).Span;
 
                 for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    long curIndex = i + prevLength;
                     bool isValid = BitUtility.IsValid(mutableNullBitMapBuffer, i);
                     T? value = func(isValid ? mutableBuffer[i] : null, curIndex);
                     mutableBuffer[i] = value.GetValueOrDefault();
                     SetValidityBit(mutableNullBitMapBuffer, i, value != null);
+                    curIndex++;
                 }
             }
         }

--- a/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.cs
+++ b/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.cs
@@ -628,7 +628,21 @@ namespace Microsoft.Data.Analysis
         /// Applies a function to all column values in place.
         /// </summary>
         /// <param name="func">The function to apply</param>
+        [Obsolete]
         public void ApplyElementwise(Func<T?, long, T?> func) => _columnContainer.ApplyElementwise(func);
+
+        /// <summary>
+        /// Applies a function to all values in the column, that are not null.
+        /// </summary>
+        /// <param name="func">The function to apply.</param>
+        /// /// <param name="inPlace">A boolean flag to indicate if the operation should be in place.</param>
+        /// <returns>A new <see cref="PrimitiveDataFrameColumn{T}"/> if <paramref name="inPlace"/> is not set. Returns this column otherwise.</returns>
+        public PrimitiveDataFrameColumn<T> Apply(Func<T, T> func, bool inPlace = false)
+        {
+            var column = inPlace ? this : this.Clone();
+            column.ColumnContainer.Apply(func);
+            return column;
+        }
 
         /// <summary>
         /// Applies a function to all column values.
@@ -636,6 +650,7 @@ namespace Microsoft.Data.Analysis
         /// <typeparam name="TResult">The new column's type</typeparam>
         /// <param name="func">The function to apply</param>
         /// <returns>A new PrimitiveDataFrameColumn containing the new values</returns>
+        [Obsolete]
         public PrimitiveDataFrameColumn<TResult> Apply<TResult>(Func<T?, TResult?> func) where TResult : unmanaged
         {
             var resultColumn = new PrimitiveDataFrameColumn<TResult>("Result", Length);

--- a/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.cs
+++ b/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.cs
@@ -252,6 +252,7 @@ namespace Microsoft.Data.Analysis
             set => _columnContainer[rowIndex] = value;
         }
 
+        /// <inheritdoc/>
         public override double Median()
         {
             // Not the most efficient implementation. Using a selection algorithm here would be O(n) instead of O(nLogn)
@@ -271,6 +272,7 @@ namespace Microsoft.Data.Analysis
             }
         }
 
+        /// <inheritdoc/>
         public override double Mean()
         {
             if (Length == 0)
@@ -296,6 +298,7 @@ namespace Microsoft.Data.Analysis
             Length += count;
         }
 
+        /// <inheritdoc/>
         public override long NullCount
         {
             get
@@ -305,18 +308,29 @@ namespace Microsoft.Data.Analysis
             }
         }
 
-        public bool IsValid(long index) => _columnContainer.IsValid(index);
+        /// <inheritdoc/>
+        public override bool IsValid(long index) => _columnContainer.IsValid(index);
 
         public IEnumerator<T?> GetEnumerator() => _columnContainer.GetEnumerator();
 
         protected override IEnumerator GetEnumeratorCore() => GetEnumerator();
 
+        /// <inheritdoc/>
         public override bool IsNumericColumn()
         {
-            bool ret = true;
-            if (typeof(T) == typeof(char) || typeof(T) == typeof(bool) || typeof(T) == typeof(DateTime))
-                ret = false;
-            return ret;
+            var type = typeof(T);
+
+            return type == typeof(byte)
+                || type == typeof(sbyte)
+                || type == typeof(ushort)
+                || type == typeof(short)
+                || type == typeof(uint)
+                || type == typeof(int)
+                || type == typeof(ulong)
+                || type == typeof(long)
+                || type == typeof(float)
+                || type == typeof(double)
+                || type == typeof(decimal);
         }
 
         /// <summary>
@@ -343,6 +357,7 @@ namespace Microsoft.Data.Analysis
             return FillNulls(convertedValue, inPlace);
         }
 
+        /// <inheritdoc/>
         public override DataFrame ValueCounts()
         {
             Dictionary<T, ICollection<long>> groupedValues = GroupColumnValues<T>(out HashSet<long> _);

--- a/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.cs
+++ b/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.cs
@@ -334,20 +334,14 @@ namespace Microsoft.Data.Analysis
         }
 
         /// <summary>
-        /// Returns a new column with nulls replaced by value
+        /// Returns a new column with <see langword="null" /> elements replaced by <paramref name="value"/>.
         /// </summary>
         /// <param name="value"></param>
-        /// <param name="inPlace">Indicates if the operation should be performed in place</param>
+        /// <param name="inPlace">Indicates if the operation should be performed in place.</param>
         public PrimitiveDataFrameColumn<T> FillNulls(T value, bool inPlace = false)
         {
             PrimitiveDataFrameColumn<T> column = inPlace ? this : Clone();
-            column.ApplyElementwise((T? columnValue, long index) =>
-            {
-                if (columnValue.HasValue == false)
-                    return value;
-                else
-                    return columnValue.Value;
-            });
+            column.ColumnContainer.FillNulls(value);
             return column;
         }
 
@@ -630,10 +624,14 @@ namespace Microsoft.Data.Analysis
             }
         }
 
+        /// <summary>
+        /// Applies a function to all column values in place.
+        /// </summary>
+        /// <param name="func">The function to apply</param>
         public void ApplyElementwise(Func<T?, long, T?> func) => _columnContainer.ApplyElementwise(func);
 
         /// <summary>
-        /// Applies a function to all the values
+        /// Applies a function to all column values.
         /// </summary>
         /// <typeparam name="TResult">The new column's type</typeparam>
         /// <param name="func">The function to apply</param>

--- a/test/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
+++ b/test/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
@@ -824,6 +824,7 @@ namespace Microsoft.Data.Analysis.Tests
             Assert.Equal((long)5, valueCounts.Columns["Counts"][1]);
         }
 
+#pragma warning disable CS0612 // Type or member is obsolete
         [Fact]
         public void TestApplyElementwiseNullCount()
         {
@@ -832,12 +833,14 @@ namespace Microsoft.Data.Analysis.Tests
             Assert.Equal(1, column.NullCount);
 
             // Change all existing values to null
+
             column.ApplyElementwise((int? value, long rowIndex) =>
             {
                 if (!(value is null))
                     return null;
                 return value;
             });
+
             Assert.Equal(column.Length, column.NullCount);
 
             // Don't change null values
@@ -862,6 +865,7 @@ namespace Microsoft.Data.Analysis.Tests
             Assert.Equal(0, column.NullCount);
 
         }
+#pragma warning restore CS0612 // Type or member is obsolete
 
         [Theory]
         [InlineData(10, 5)]
@@ -1172,10 +1176,12 @@ namespace Microsoft.Data.Analysis.Tests
         }
 
         [Fact]
+#pragma warning disable CS0612 // Type or member is obsolete
         public void TestApply()
         {
             int[] values = { 1, 2, 3, 4, 5 };
             var col = new Int32DataFrameColumn("Ints", values);
+
             PrimitiveDataFrameColumn<double> newCol = col.Apply(i => i + 0.5d);
 
             Assert.Equal(values.Length, newCol.Length);
@@ -1186,6 +1192,7 @@ namespace Microsoft.Data.Analysis.Tests
                 Assert.Equal(newCol[i], values[i] + 0.5d);
             }
         }
+#pragma warning disable CS0612 // Type or member is obsolete
 
         [Fact]
         public void TestDataFrameCreate()

--- a/test/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
+++ b/test/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
@@ -743,9 +743,12 @@ namespace Microsoft.Data.Analysis.Tests
         [Fact]
         public void TestDropNulls()
         {
+            //Create dataframe with 20 rows, where 1 row has only 1 null value and 1 row has all null values
             DataFrame df = MakeDataFrameWithAllMutableColumnTypes(20);
+            df[0, 0] = null;
+
             DataFrame anyNulls = df.DropNulls();
-            Assert.Equal(19, anyNulls.Rows.Count);
+            Assert.Equal(18, anyNulls.Rows.Count);
 
             DataFrame allNulls = df.DropNulls(DropNullOptions.All);
             Assert.Equal(19, allNulls.Rows.Count);

--- a/test/Microsoft.Data.Analysis.Tests/PrimitiveDataFrameColumnTests.cs
+++ b/test/Microsoft.Data.Analysis.Tests/PrimitiveDataFrameColumnTests.cs
@@ -3,10 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using Apache.Arrow;
 using Microsoft.ML.TestFramework.Attributes;
 using Xunit;
 
@@ -270,21 +267,6 @@ namespace Microsoft.Data.Analysis.Tests
         }
 
         [Fact]
-        public void TestClone_StringColumn()
-        {
-            var strColumn = new StringDataFrameColumn("Str", ["str1", "str2", "srt3", null]);
-            var copy = strColumn.Clone();
-
-            Assert.Equal(strColumn.Name, copy.Name);
-            Assert.Equal(strColumn.Length, copy.Length);
-            Assert.Equal(strColumn.DataType, copy.DataType);
-            Assert.Equal(strColumn.NullCount, copy.NullCount);
-
-            for (int i = 0; i < strColumn.Length; i++)
-                Assert.Equal(strColumn[i], copy[i]);
-        }
-
-        [Fact]
         public void TestNotNullableColumnClone()
         {
             //Arrange
@@ -326,7 +308,7 @@ namespace Microsoft.Data.Analysis.Tests
         }
 
         [Fact]
-        public void TestNotNullableColumnCloneWithIndicesMap()
+        public void TestNotNullableColumnClone_WithIntIndicesMap()
         {
             //Arrange
             var column = new Int32DataFrameColumn("Int column", values: new[] { 0, 5, 2, 4, 1, 3 });
@@ -344,6 +326,69 @@ namespace Microsoft.Data.Analysis.Tests
 
             for (int i = 0; i < indicesMap.Length; i++)
                 Assert.Equal(column[indicesMap[i].Value], clonedColumn[i]);
+        }
+
+        [Fact]
+        public void TestNotNullableColumnClone_WithIntIndicesMap_Invert()
+        {
+            //Arrange
+            var column = new Int32DataFrameColumn("Int column", values: new int?[] { 0, 5, null, 4, 1, 3 });
+            var indicesMap = new Int32DataFrameColumn("Indices", new[] { 0, 1, 2, 2, 5, 3, 4 });
+
+            //Act
+            var clonedColumn = column.Clone(indicesMap, true);
+
+            //Assert
+            Assert.NotSame(column, clonedColumn);
+            Assert.Equal(column.Name, clonedColumn.Name);
+            Assert.Equal(column.DataType, clonedColumn.DataType);
+            Assert.Equal(2, clonedColumn.NullCount);
+            Assert.Equal(indicesMap.Length, clonedColumn.Length);
+
+            for (int i = 0; i < indicesMap.Length; i++)
+                Assert.Equal(column[indicesMap[indicesMap.Length - 1 - i].Value], clonedColumn[i]);
+        }
+
+        [Fact]
+        public void TestNotNullableColumnClone_WithLongIndicesMap()
+        {
+            //Arrange
+            var column = new Int32DataFrameColumn("Int column", values: new[] { 0, 5, 2, 4, 1, 3 });
+            var indicesMap = new Int64DataFrameColumn("Indices", new long[] { 0, 1, 2, 5, 3, 4 });
+
+            //Act
+            var clonedColumn = column.Clone(indicesMap);
+
+            //Assert
+            Assert.NotSame(column, clonedColumn);
+            Assert.Equal(column.Name, clonedColumn.Name);
+            Assert.Equal(column.DataType, clonedColumn.DataType);
+            Assert.Equal(column.NullCount, clonedColumn.NullCount);
+            Assert.Equal(indicesMap.Length, clonedColumn.Length);
+
+            for (int i = 0; i < indicesMap.Length; i++)
+                Assert.Equal(column[indicesMap[i].Value], clonedColumn[i]);
+        }
+
+        [Fact]
+        public void TestNotNullableColumnClone_WithLongIndicesMap_Invert()
+        {
+            //Arrange
+            var column = new Int32DataFrameColumn("Int column", values: new int?[] { 0, 5, null, 4, 1, 3 });
+            var indicesMap = new Int64DataFrameColumn("Indices", new long[] { 0, 1, 2, 5, 3, 4, 4, 2 });
+
+            //Act
+            var clonedColumn = column.Clone(indicesMap, true);
+
+            //Assert
+            Assert.NotSame(column, clonedColumn);
+            Assert.Equal(column.Name, clonedColumn.Name);
+            Assert.Equal(column.DataType, clonedColumn.DataType);
+            Assert.Equal(2, clonedColumn.NullCount);
+            Assert.Equal(indicesMap.Length, clonedColumn.Length);
+
+            for (int i = 0; i < indicesMap.Length; i++)
+                Assert.Equal(column[indicesMap[indicesMap.Length - 1 - i].Value], clonedColumn[i]);
         }
 
         [Fact]

--- a/test/Microsoft.Data.Analysis.Tests/PrimitiveDataFrameColumnTests.cs
+++ b/test/Microsoft.Data.Analysis.Tests/PrimitiveDataFrameColumnTests.cs
@@ -626,7 +626,7 @@ namespace Microsoft.Data.Analysis.Tests
         }
 
         [Fact]
-        public void Test_Apply_InPlace()
+        public void TestApply_InPlace()
         {
             // Arrange
             var column = new Int32DataFrameColumn("int", new int?[] { 0, 1, 2, null, null, 5 });
@@ -640,6 +640,24 @@ namespace Microsoft.Data.Analysis.Tests
             Assert.Null(column[3]);
             Assert.Null(column[4]);
             Assert.Equal(10, column[5]);
+        }
+
+        [Fact]
+        public void TestDropNulls()
+        {
+            // Arrange
+            var column = new Int32DataFrameColumn("int", new int?[] { null, 0, 1, 2, null, null, 3, null });
+
+            var res = column.DropNulls();
+
+            // Assert
+            Assert.Equal(4, res.Length);
+            Assert.Equal(0, res.NullCount);
+
+            Assert.Equal(0, res[0]);
+            Assert.Equal(1, res[1]);
+            Assert.Equal(2, res[2]);
+            Assert.Equal(3, res[3]);
         }
 
         //#if !NETFRAMEWORK // https://github.com/dotnet/corefxlab/issues/2796

--- a/test/Microsoft.Data.Analysis.Tests/PrimitiveDataFrameColumnTests.cs
+++ b/test/Microsoft.Data.Analysis.Tests/PrimitiveDataFrameColumnTests.cs
@@ -625,6 +625,23 @@ namespace Microsoft.Data.Analysis.Tests
             Assert.Null(div[3]); // null / null
         }
 
+        [Fact]
+        public void Test_Apply_InPlace()
+        {
+            // Arrange
+            var column = new Int32DataFrameColumn("int", new int?[] { 0, 1, 2, null, null, 5 });
+
+            column.Apply(x => x * 2, true);
+
+            // Assert
+            Assert.Equal(0, column[0]);
+            Assert.Equal(2, column[1]);
+            Assert.Equal(4, column[2]);
+            Assert.Null(column[3]);
+            Assert.Null(column[4]);
+            Assert.Equal(10, column[5]);
+        }
+
         //#if !NETFRAMEWORK // https://github.com/dotnet/corefxlab/issues/2796
         //        [Fact]
         //        public void TestPrimitiveColumnGetReadOnlyBuffers()

--- a/test/Microsoft.Data.Analysis.Tests/StringDataFrameColumnTests.cs
+++ b/test/Microsoft.Data.Analysis.Tests/StringDataFrameColumnTests.cs
@@ -1,0 +1,95 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Data.Analysis.Tests
+{
+    public class StringDataFrameColumnTests
+    {
+        [Fact]
+        public void TestColumnClone()
+        {
+            var stringColumn = new StringDataFrameColumn("Test", new[] { "Zero", "One", "Two", null, "Four", "Five" });
+            var clonedColumn = stringColumn.Clone();
+
+            Assert.NotSame(stringColumn, clonedColumn);
+            Assert.Equal(stringColumn.Name, clonedColumn.Name);
+            Assert.Equal(stringColumn.Length, clonedColumn.Length);
+            Assert.Equal(stringColumn.NullCount, clonedColumn.NullCount);
+
+            for (int i = 0; i < stringColumn.Length; i++)
+                Assert.Equal(stringColumn[i], clonedColumn[i]);
+        }
+
+        [Fact]
+        public void TestColumnClone_WithIntMapIndices()
+        {
+            var mapIndices = new[] { 0, 1, 2, 2, 3, 4, 5 };
+            var stringColumn = new StringDataFrameColumn("Test", ["Zero", "One", null, "Three", "Four", "Five"]);
+            var clonedColumn = stringColumn.Clone(new Int32DataFrameColumn("Map Indices", mapIndices));
+
+            Assert.NotSame(stringColumn, clonedColumn);
+            Assert.Equal(stringColumn.Name, clonedColumn.Name);
+            Assert.Equal(mapIndices.Length, clonedColumn.Length);
+            Assert.Equal(2, clonedColumn.NullCount);
+
+            for (int i = 0; i < mapIndices.Length; i++)
+                Assert.Equal(stringColumn[mapIndices[i]], clonedColumn[i]);
+        }
+
+        [Fact]
+        public void TestColumnClone_WithIntMapIndices_InvertIndices()
+        {
+            var mapIndices = new[] { 0, 1, 2, 2, 3, 4, 5 };
+            var stringColumn = new StringDataFrameColumn("Test", ["Zero", "One", null, "Three", "Four", "Five"]);
+            var clonedColumn = stringColumn.Clone(new Int32DataFrameColumn("Map Indices", mapIndices), true);
+
+            Assert.NotSame(stringColumn, clonedColumn);
+            Assert.Equal(stringColumn.Name, clonedColumn.Name);
+            Assert.Equal(mapIndices.Length, clonedColumn.Length);
+            Assert.Equal(2, clonedColumn.NullCount);
+
+            for (int i = 0; i < mapIndices.Length; i++)
+                Assert.Equal(stringColumn[mapIndices[mapIndices.Length - 1 - i]], clonedColumn[i]);
+        }
+
+        [Fact]
+        public void TestColumnClone_WithLongMapIndices()
+        {
+            var mapIndices = new long[] { 0, 1, 2, 2, 3, 4, 5 };
+            var stringColumn = new StringDataFrameColumn("Test", ["Zero", "One", null, "Three", "Four", "Five"]);
+            var clonedColumn = stringColumn.Clone(new Int64DataFrameColumn("Map Indices", mapIndices));
+
+            Assert.NotSame(stringColumn, clonedColumn);
+            Assert.Equal(stringColumn.Name, clonedColumn.Name);
+            Assert.Equal(mapIndices.Length, clonedColumn.Length);
+            Assert.Equal(2, clonedColumn.NullCount);
+
+            for (int i = 0; i < mapIndices.Length; i++)
+                Assert.Equal(stringColumn[mapIndices[i]], clonedColumn[i]);
+        }
+
+        [Fact]
+        public void TestColumnClone_WithLongMapIndices_InvertIndices()
+        {
+            var mapIndices = new long[] { 0, 1, 2, 2, 3, 4, 5 };
+            var stringColumn = new StringDataFrameColumn("Test", ["Zero", "One", "Two", null, "Four", "Five"]);
+            var clonedColumn = stringColumn.Clone(new Int64DataFrameColumn("Map Indices", mapIndices), true);
+            Assert.Equal(1, clonedColumn.NullCount);
+
+            Assert.NotSame(stringColumn, clonedColumn);
+            Assert.Equal(stringColumn.Name, clonedColumn.Name);
+            Assert.Equal(mapIndices.Length, clonedColumn.Length);
+
+            for (int i = 0; i < mapIndices.Length; i++)
+                Assert.Equal(stringColumn[mapIndices[mapIndices.Length - 1 - i]], clonedColumn[i]);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #7107 as was asked in https://github.com/dotnet/machinelearning/issues/6144#issuecomment-2018430389

Additionaly:

1) Fix incorrect IsNumeric method
2) Fix error FillNulls crashes with NotImplemented exception on DataFrame with VBufferDataFrameColumn
3) Improve speed and redesign API (legacy API marked as obsolete), internal methods are rewriten to use new API
4) Add extra unit tests

Reasons for refactoring:

Legacy implementation of ApplyElementwise is written not only for applying function on each element in the column, but also to be used for fast columns iteration, that's why it returns rowIndex. This duplication of responsibilities is incorrect and not straightforward. More over it is slow, as instead of only reading values, it writes the same values into memory, also it converts read only columns to editable (that involves memory copy). So in some circumstances memory can be excessively copied even twice.
Legacy method requires to provide function that takes into account null values - this is not userfriendly. For working with Null methods there are already FillNulls and DropNulls method. New method applies function only to valuable values, this also leads to better performance


