### PR TITLE
Accessing data by column after adding columns to a DataFrame returns error data

### DIFF
--- a/src/Microsoft.Data.Analysis/DataFrameColumnCollection.cs
+++ b/src/Microsoft.Data.Analysis/DataFrameColumnCollection.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Data.Analysis
             RowCount = column.Length;
 
             _columnNameToIndexDictionary[column.Name] = columnIndex;
-            for (int i = columnIndex + 1; i < Count; i++)
+            for (int i = columnIndex; i < Count; i++)
             {
                 _columnNameToIndexDictionary[this[i].Name]++;
             }

--- a/test/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
+++ b/test/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
@@ -44,6 +44,17 @@ namespace Microsoft.Data.Analysis.Tests
         }
 
         [Fact]
+        public void ColumnInsertTest()
+        {
+            var df = DataFrame.LoadCsvFromString("a1,a2\n1,2\n3,4");
+
+            var dc0 = DataFrameColumn.Create("a0", new int[] { 0, 0 });
+            df.Columns.Insert(0, dc0);
+            var dc = df.Columns["a1"];
+            Assert.Equal("a1", dc.Name);
+        }
+
+        [Fact]
         public void ColumnAndTableCreationTest()
         {
             const int rowCount = 10;


### PR DESCRIPTION
fix #7135 

Describe the bug
Accessing data by column after adding columns to a DataFrame returns error data

````
var df = DataFrame.LoadCsvFromString("a1,a2\n1,2\n3,4");
var dc0 = DataFrameColumn.Create("a0", new int[] { 0, 0 });
df.Columns.Insert(0, dc0);
var dc1 = df["a1"];
Console.WriteLine(dc1.ToString());
````


This code expected print: a1: 1 3
But it print: a0: 0 0