### PR TITLE
Add a stub packageSourceMapping

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -15,6 +15,35 @@
     <add key="mlnet-assets" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/machinelearning-assets/nuget/v3/index.json" />
     <add key="dotnet8" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
   </packageSources>
+  <packageSourceMapping>
+    <packageSource key="dotnet-public">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="dotnet-tools">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="dotnet-libraries">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="dotnet-eng">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="vs-buildservices">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="dotnet5-roslyn">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="mlnet-daily">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="mlnet-assets">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="dotnet8">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
   <disabledPackageSources>
     <clear />
   </disabledPackageSources>


### PR DESCRIPTION
Without packageSourceMapping, you may receive NuGet warning NU1507. Building with WarnAsError will elevate this to a fatal error.

```
C:\d\source-indexer\bin\repo\machinelearning\test\Microsoft.ML.CpuMath.UnitTests\Microsoft.ML.CpuMath.UnitTests.csproj : error NU1507: Warning As Error: There are 9 package sources defined in your configuration. When using central package management, please map your package sources with package source mapping (https://aka.ms/nuget-package-source-mapping) or specify a single package source. The following sources are defined: dotnet-public, dotnet-tools, dotnet-libraries, dotnet-eng, vs-buildservices, dotnet5-roslyn, mlnet-daily, mlnet-assets, dotnet8 [C:\d\source-indexer\bin\repo\machinelearning\Microsoft.ML.sln]
```

Using * as a pattern means any repo can supply any package, the pattern can be further refined later.