### PR TITLE
create unique temporary directories to prevent permission issues

### DIFF
--- a/src/Microsoft.ML.Core/Data/Repository.cs
+++ b/src/Microsoft.ML.Core/Data/Repository.cs
@@ -123,8 +123,10 @@ internal abstract class Repository : IDisposable
         string tempPath = ectx is IHostEnvironmentInternal iHostInternal ?
             iHostInternal.TempFilePath :
             Path.GetTempPath();
-
-        string path = Path.Combine(Path.GetFullPath(tempPath), "ml_dotnet", Path.GetRandomFileName());
+        int dirNumber = 0;
+        string mlNetTempDir = null!;
+        while (Directory.Exists(mlNetTempDir = Path.Combine(Path.GetFullPath(tempPath), $"ml_dotnet{dirNumber}"))) ;
+        var path = Path.Combine(mlNetTempDir, Path.GetRandomFileName());
         Directory.CreateDirectory(path);
         return path;
     }

--- a/src/Microsoft.ML.Core/Data/Repository.cs
+++ b/src/Microsoft.ML.Core/Data/Repository.cs
@@ -125,7 +125,7 @@ internal abstract class Repository : IDisposable
             Path.GetTempPath();
         int dirNumber = 0;
         string mlNetTempDir = null!;
-        while (Directory.Exists(mlNetTempDir = Path.Combine(Path.GetFullPath(tempPath), $"ml_dotnet{dirNumber}"))) ;
+        while (Directory.Exists(mlNetTempDir = Path.Combine(Path.GetFullPath(tempPath), $"ml_dotnet{dirNumber++}"))) ;
         var path = Path.Combine(mlNetTempDir, Path.GetRandomFileName());
         Directory.CreateDirectory(path);
         return path;


### PR DESCRIPTION
Fixes #7172

This is a tentative fix for #7172 where ml.net fails when multiple users are using same directory. This fix checks if there is already a ml_dotnet<number> if so, it will increase the number until the path is available.


- [X] There's a descriptive title that will make sense to other developers some time from now. 
- [X] There's associated issues. All PR's should have issue(s) associated - unless a trivial self-evident change such as fixing a typo. You can use the format `Fixes #nnnn` in your description to cause GitHub to automatically close the issue(s) when your PR is merged.
- [X] Your change description explains what the change does, why you chose your approach, and anything else that reviewers should know.
- [X] You have included any necessary tests in the same PR.

