### PR TITLE
Publish source index directly from repo

### DIFF
--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -31,6 +31,9 @@ variables:
   value: 1es-windows-2019
 - name: MacImage
   value: macOS-12
+#- ${{ if and(notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
+- name: enableSourceIndex
+  value: true
 - template: /eng/common/templates-official/variables/pool-providers.yml@self
 
 resources:
@@ -295,6 +298,19 @@ extends:
           # Terminate all dotnet build processes.
           - script: $(Build.SourcesDirectory)/.dotnet/dotnet.exe build-server shutdown
             displayName: Dotnet Server Shutdown
+
+      - ${{ if eq(variables.enableSourceIndex, 'true') }}:
+        - template: /eng/common/templates-official/job/source-index-stage1.yml@self
+          parameters:
+            binlogPath: artifacts/log/Release/Build.binlog
+            presteps:
+            - task: NodeTool@0
+              displayName: Install Node 20.x
+              inputs:
+                versionSpec: 20.x
+            pool:
+              name: $(DncEngInternalBuildPool)
+              demands: ImageOverride -equals 1es-windows-2022
 
       - template: /eng/common/templates-official/job/publish-build-assets.yml@self
         parameters:

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -31,7 +31,7 @@ variables:
   value: 1es-windows-2019
 - name: MacImage
   value: macOS-12
-- ${{ if and(notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/publish-source-index-directly-from-repo')) }}:
+- ${{ if and(notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
   - name: enableSourceIndex
     value: true
 - template: /eng/common/templates-official/variables/pool-providers.yml@self

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -302,7 +302,8 @@ extends:
       - ${{ if eq(variables.enableSourceIndex, 'true') }}:
         - template: /eng/common/templates-official/job/source-index-stage1.yml@self
           parameters:
-            binlogPath: artifacts/log/Release/Build.binlog
+            sourceIndexBuildCommand: ./build.cmd -ci -configuration Release /p:TargetArchitecture=x64 /bl
+            binlogPath: msbuild.binlog
             presteps:
             - task: NodeTool@0
               displayName: Install Node 20.x

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -31,7 +31,7 @@ variables:
   value: 1es-windows-2019
 - name: MacImage
   value: macOS-12
-- ${{ if and(notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
+- ${{ if and(notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/publish-source-index-directly-from-repo')) }}:
   - name: enableSourceIndex
     value: true
 - template: /eng/common/templates-official/variables/pool-providers.yml@self

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -31,9 +31,9 @@ variables:
   value: 1es-windows-2019
 - name: MacImage
   value: macOS-12
-#- ${{ if and(notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
-- name: enableSourceIndex
-  value: true
+- ${{ if and(notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
+  - name: enableSourceIndex
+    value: true
 - template: /eng/common/templates-official/variables/pool-providers.yml@self
 
 resources:

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -304,11 +304,6 @@ extends:
           parameters:
             sourceIndexBuildCommand: ./build.cmd -ci -configuration Release /p:TargetArchitecture=x64 /bl
             binlogPath: msbuild.binlog
-            presteps:
-            - task: NodeTool@0
-              displayName: Install Node 20.x
-              inputs:
-                versionSpec: 20.x
             pool:
               name: $(DncEngInternalBuildPool)
               demands: ImageOverride -equals 1es-windows-2022


### PR DESCRIPTION
Building in-repo allows us to improve reliability of source index generation, and increases the likelihood that build issues will be found and fixed by repo owners (who understand their repos better than we do)