### PR TITLE
Fix crash in Microsoft.ML.Recommender with validation set

### DIFF
--- a/src/Microsoft.ML.Recommender/SafeTrainingAndModelBuffer.cs
+++ b/src/Microsoft.ML.Recommender/SafeTrainingAndModelBuffer.cs
@@ -368,7 +368,7 @@ namespace Microsoft.ML.Recommender.Internal
                 validProb.R = validNodesPtrs;
                 validProb.M = rowCount;
                 validProb.N = colCount;
-                validProb.Nnz = nodes.Length;
+                validProb.Nnz = validNodes.Length;
 
                 ch.Info("Training {0} by {1} problem on {2} examples with a {3} by {4} validation set including {5} examples",
                     prob.M, prob.N, prob.Nnz, validProb.M, validProb.N, validProb.Nnz);


### PR DESCRIPTION
This PR fixes a crash when calling `Fit` on the `MatrixFactorizationTrainer` class with a validation set. The crash is due to passing an incorrect length to LIBMF (it passes the length from the training set instead of the validation set).