### PR TITLE
Fix decoding special tokens in SentencePiece tokenizer

### DIFF
--- a/test/Microsoft.ML.Tokenizers.Tests/LlamaTests.cs
+++ b/test/Microsoft.ML.Tokenizers.Tests/LlamaTests.cs
@@ -384,6 +384,11 @@ namespace Microsoft.ML.Tokenizers.Tests
         public void TestDecodeSpecialTokenWithSmallId(LlamaTokenizer llamaTokenizer)
         {
             Assert.Equal(llamaTokenizer.EndOfSentenceToken, llamaTokenizer.Decode([llamaTokenizer.EndOfSentenceId], considerSpecialTokens: true));
+            Span<char> destinationBuffer = stackalloc char[llamaTokenizer.EndOfSentenceToken.Length];
+            Assert.Equal(OperationStatus.Done, llamaTokenizer.Decode([llamaTokenizer.EndOfSentenceId], destinationBuffer, considerSpecialTokens: true, out int idsConsumed, out int charactersWritten));
+            Assert.Equal(llamaTokenizer.EndOfSentenceToken.Length, charactersWritten);
+            Assert.Equal(llamaTokenizer.EndOfSentenceToken, destinationBuffer.ToString());
+            Assert.Equal(1, idsConsumed);
         }
 
         [Fact]

--- a/test/Microsoft.ML.Tokenizers.Tests/LlamaTests.cs
+++ b/test/Microsoft.ML.Tokenizers.Tests/LlamaTests.cs
@@ -376,6 +376,16 @@ namespace Microsoft.ML.Tokenizers.Tests
             TokenizerTests.TestTokenLimits(llamaTokenizer);
         }
 
+        /// <summary>
+        /// Test that the special token with a small id is decoded correctly.
+        /// </summary>
+        [Theory]
+        [MemberData(nameof(LlamaTokenizersListData))]
+        public void TestDecodeSpecialTokenWithSmallId(LlamaTokenizer llamaTokenizer)
+        {
+            Assert.Equal(llamaTokenizer.EndOfSentenceToken, llamaTokenizer.Decode([llamaTokenizer.EndOfSentenceId], considerSpecialTokens: true));
+        }
+
         [Fact]
         public void TestSentencePieceNormalizer()
         {


### PR DESCRIPTION
There was corner case while decoding special tokens Ids in Sentence Piece tokenizer and the special tokens ids show up in the beginning of the decoding list. The change here addresses that and ensures the special tokens will get decoded as expected. 