### PR TITLE
Update wording in LDA docs

### DIFF
--- a/src/Microsoft.ML.Transforms/Text/LdaTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/LdaTransform.cs
@@ -1006,7 +1006,7 @@ namespace Microsoft.ML.Transforms.Text
     ///  we would get the results displayed in the table below. Example documents:
     ///  * I like to eat bananas.
     ///  * I eat bananas everyday.
-    ///  * First celebrated in 1970, Earth Day now includes events in more than 193 countries,
+    ///  * First celebrated in 1970, Earth Day now includes events in more than 193 countries/regions,
     ///    which are now coordinated globally by the Earth Day Network.
     ///
     ///  Notice the similarity in values of the first and second row, compared to the third,


### PR DESCRIPTION
Update the wording mentioning countries.  This is actually a quote, but it need not mention `countries`  - the actual source of this quote has since been updated.  
https://en.wikipedia.org/w/index.php?title=Earth_Day&oldid=824511329 (which was pulled from an old version of earthday.org).

I didn't bother updating the values in the comment - I'm not sure if they need to be accurate to get the point across.  @michaelgsharp if you think they should be updated please let me know and help me recompute them.

