### PR TITLE
Fixes #7271 AOT for ML.Tokenizers

### DIFF
--- a/src/Microsoft.ML.Tokenizers/Model/BPETokenizer.cs
+++ b/src/Microsoft.ML.Tokenizers/Model/BPETokenizer.cs
@@ -757,11 +757,10 @@ namespace Microsoft.ML.Tokenizers
         /// Read the given files to extract the vocab and merges
         internal static async ValueTask<(Dictionary<StringSpanOrdinalKey, int>?, Vec<(string, string)>)> ReadModelDataAsync(Stream vocab, Stream? merges, bool useAsync, CancellationToken cancellationToken = default)
         {
-            JsonSerializerOptions options = new() { Converters = { StringSpanOrdinalKeyConverter.Instance } };
+            Dictionary<StringSpanOrdinalKey, int>? dic = useAsync
+                                                         ? await JsonSerializer.DeserializeAsync(vocab, ModelSourceGenerationContext.Default.DictionaryStringSpanOrdinalKeyInt32, cancellationToken).ConfigureAwait(false)
+                                                         : JsonSerializer.Deserialize(vocab, ModelSourceGenerationContext.Default.DictionaryStringSpanOrdinalKeyInt32);
 
-            Dictionary<StringSpanOrdinalKey, int>? dic = useAsync ?
-                                                    await JsonSerializer.DeserializeAsync<Dictionary<StringSpanOrdinalKey, int>>(vocab, options, cancellationToken).ConfigureAwait(false) as Dictionary<StringSpanOrdinalKey, int> :
-                                                    JsonSerializer.Deserialize<Dictionary<StringSpanOrdinalKey, int>>(vocab, options) as Dictionary<StringSpanOrdinalKey, int>;
             var m = useAsync ?
                     await ConvertMergesToHashmapAsync(merges, useAsync, cancellationToken).ConfigureAwait(false) :
                     ConvertMergesToHashmapAsync(merges, useAsync).GetAwaiter().GetResult();

--- a/src/Microsoft.ML.Tokenizers/Model/CodeGenTokenizer.cs
+++ b/src/Microsoft.ML.Tokenizers/Model/CodeGenTokenizer.cs
@@ -1764,11 +1764,10 @@ namespace Microsoft.ML.Tokenizers
 
         private static Dictionary<StringSpanOrdinalKey, (int, string)> GetVocabulary(Stream vocabularyStream)
         {
-            Dictionary<StringSpanOrdinalKey, (int, string)>? vocab;
+            Vocabulary? vocab;
             try
             {
-                JsonSerializerOptions options = new() { Converters = { StringSpanOrdinalKeyCustomConverter.Instance } };
-                vocab = JsonSerializer.Deserialize<Dictionary<StringSpanOrdinalKey, (int, string)>>(vocabularyStream, options) as Dictionary<StringSpanOrdinalKey, (int, string)>;
+                vocab = JsonSerializer.Deserialize(vocabularyStream, ModelSourceGenerationContext.Default.Vocabulary);
             }
             catch (Exception e)
             {

--- a/src/Microsoft.ML.Tokenizers/Model/EnglishRobertaTokenizer.cs
+++ b/src/Microsoft.ML.Tokenizers/Model/EnglishRobertaTokenizer.cs
@@ -169,8 +169,7 @@ namespace Microsoft.ML.Tokenizers
             Dictionary<StringSpanOrdinalKey, int>? vocab;
             try
             {
-                JsonSerializerOptions options = new() { Converters = { StringSpanOrdinalKeyConverter.Instance } };
-                vocab = JsonSerializer.Deserialize<Dictionary<StringSpanOrdinalKey, int>>(vocabularyStream, options) as Dictionary<StringSpanOrdinalKey, int>;
+                vocab = JsonSerializer.Deserialize(vocabularyStream, ModelSourceGenerationContext.Default.DictionaryStringSpanOrdinalKeyInt32);
             }
             catch (Exception e)
             {

--- a/src/Microsoft.ML.Tokenizers/Model/ModelSourceGenerationContext.cs
+++ b/src/Microsoft.ML.Tokenizers/Model/ModelSourceGenerationContext.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.ML.Tokenizers;
+
+[JsonSerializable(typeof(Dictionary<StringSpanOrdinalKey, int>))]
+[JsonSerializable(typeof(Vocabulary))]
+internal partial class ModelSourceGenerationContext : JsonSerializerContext
+{
+}

--- a/src/Microsoft.ML.Tokenizers/Model/ModelSourceGenerationContext.cs
+++ b/src/Microsoft.ML.Tokenizers/Model/ModelSourceGenerationContext.cs
@@ -9,6 +9,4 @@ namespace Microsoft.ML.Tokenizers;
 
 [JsonSerializable(typeof(Dictionary<StringSpanOrdinalKey, int>))]
 [JsonSerializable(typeof(Vocabulary))]
-internal partial class ModelSourceGenerationContext : JsonSerializerContext
-{
-}
+internal partial class ModelSourceGenerationContext : JsonSerializerContext;


### PR DESCRIPTION
Fixes https://github.com/dotnet/machinelearning/issues/7271

This PR makes ML.Tokenizers project [AOT compatible](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/?tabs=windows%2Cnet8). 

ML.Tokenizers is made to use [SourceGenerationContext](https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/source-generation?pivots=dotnet-8-0) for deserializing Json.

I had to create a helper class `Vocabulary` in order to register a `JsonConverter` for it.


**Before** the change, we have following Aot warnings on the calls to Json.Deserialize:
```
  Microsoft.ML.Tokenizers failed with 8 error(s) (2.6s)
    C:\Users\euju\RiderProjects\ml\src\Microsoft.ML.Tokenizers\Model\EnglishRobertaTokenizer.cs(173,25): error IL3050: Using member 'System.Text.Json.JsonSerializer.Deserialize<TValue>(Stream, JsonSerializerOptions)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.
    C:\Users\euju\RiderProjects\ml\src\Microsoft.ML.Tokenizers\Model\EnglishRobertaTokenizer.cs(173,25): error IL2026: Using member 'System.Text.Json.JsonSerializer.Deserialize<TValue>(Stream, JsonSerializerOptions)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.
    C:\Users\euju\RiderProjects\ml\src\Microsoft.ML.Tokenizers\Model\BPETokenizer.cs(763,59): error IL3050: Using member 'System.Text.Json.JsonSerializer.DeserializeAsync<TValue>(Stream, JsonSerializerOptions, CancellationToken)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.
    C:\Users\euju\RiderProjects\ml\src\Microsoft.ML.Tokenizers\Model\BPETokenizer.cs(764,53): error IL3050: Using member 'System.Text.Json.JsonSerializer.Deserialize<TValue>(Stream, JsonSerializerOptions)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.
    C:\Users\euju\RiderProjects\ml\src\Microsoft.ML.Tokenizers\Model\BPETokenizer.cs(763,59): error IL2026: Using member 'System.Text.Json.JsonSerializer.DeserializeAsync<TValue>(Stream, JsonSerializerOptions, CancellationToken)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.
    C:\Users\euju\RiderProjects\ml\src\Microsoft.ML.Tokenizers\Model\BPETokenizer.cs(764,53): error IL2026: Using member 'System.Text.Json.JsonSerializer.Deserialize<TValue>(Stream, JsonSerializerOptions)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.
    C:\Users\euju\RiderProjects\ml\src\Microsoft.ML.Tokenizers\Model\CodeGenTokenizer.cs(1771,25): error IL3050: Using member 'System.Text.Json.JsonSerializer.Deserialize<TValue>(Stream, JsonSerializerOptions)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.
    C:\Users\euju\RiderProjects\ml\src\Microsoft.ML.Tokenizers\Model\CodeGenTokenizer.cs(1771,25): error IL2026: Using member 'System.Text.Json.JsonSerializer.Deserialize<TValue>(Stream, JsonSerializerOptions)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.
```

**After** the change, warnings are no more :)

**Note** that `netstandard2.0` framework is not Aot compatible as trimming is only supported for .NET 6 and later. Therefore, in order to test the compatibility for Microsoft.ML.Tokenizers project, you need to set the TargetFramework to net8.0.

Then you can add `<PublishAot>true</PublishAot>`.

e.g. Microsoft.ML.Tokenizers.csproj
```Xml
  <PropertyGroup>
    <TargetFramework>net8.0</TargetFramework>
    <Nullable>enable</Nullable>
    <IsPackable>true</IsPackable>
    <PackageDescription>Microsoft.ML.Tokenizers contains the implmentation of the tokenization used in the NLP transforms.</PackageDescription>
    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
    <PublishAot>true</PublishAot>
  </PropertyGroup>
```

Then building specifically for `Microsoft.ML.Tokenizers` should result in warnings if the project is not AOT compatible.



We are excited to review your PR.

So we can do the best job, please check:

- [x] There's a descriptive title that will make sense to other developers some time from now. 
- [x] There's associated issues. All PR's should have issue(s) associated - unless a trivial self-evident change such as fixing a typo. You can use the format `Fixes #nnnn` in your description to cause GitHub to automatically close the issue(s) when your PR is merged.
- [x] Your change description explains what the change does, why you chose your approach, and anything else that reviewers should know.
- [ ] You have included any necessary tests in the same PR.

