### PR TITLE
Bump versions of maintenance-packages dependencies consumed in machin…

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -21,17 +21,17 @@
     <MicrosoftExtensionsOptionsVersion>8.0.2</MicrosoftExtensionsOptionsVersion>
     <NuGetVersion>6.9.1</NuGetVersion>
     <SkiaSharpVersion>2.88.8</SkiaSharpVersion>
-    <SystemBuffersVersion>4.6.0-preview.1.24517.1</SystemBuffersVersion>
+    <SystemBuffersVersion>4.6.0-preview.1.24529.4</SystemBuffersVersion>
     <SystemCodeDomVersion>8.0.0</SystemCodeDomVersion>
     <SystemCollectionsImmutableVersion>8.0.0</SystemCollectionsImmutableVersion>
     <SystemConfigurationConfigurationManagerVersion>6.0.1</SystemConfigurationConfigurationManagerVersion>
     <SystemFormatsAsn1Version>8.0.1</SystemFormatsAsn1Version>
     <SystemIOFileSystemAccessControl>5.0.0</SystemIOFileSystemAccessControl>
-    <SystemMemoryVersion>4.6.0-preview.1.24517.1</SystemMemoryVersion>
+    <SystemMemoryVersion>4.6.0-preview.1.24529.4</SystemMemoryVersion>
     <SystemNumericsTensorsVersion>8.0.0</SystemNumericsTensorsVersion>
     <SystemReflectionEmitLightweightVersion>4.7.0</SystemReflectionEmitLightweightVersion>
     <SystemReflectionEmitVersion>4.3.0</SystemReflectionEmitVersion>
-    <SystemRuntimeCompilerServicesUnsafeVersion>6.1.0-preview.1.24517.1</SystemRuntimeCompilerServicesUnsafeVersion>
+    <SystemRuntimeCompilerServicesUnsafeVersion>6.1.0-preview.1.24529.4</SystemRuntimeCompilerServicesUnsafeVersion>
     <SystemSecurityPrincipalWindows>5.0.0</SystemSecurityPrincipalWindows>
     <SystemTextEncodingsWebVersion>8.0.0</SystemTextEncodingsWebVersion>
     <SystemTextJsonVersion>8.0.4</SystemTextJsonVersion>
@@ -40,7 +40,7 @@
     <ApacheArrowVersion>14.0.2</ApacheArrowVersion>
     <GoogleProtobufVersion>3.27.1</GoogleProtobufVersion>
     <LightGBMVersion>3.3.5</LightGBMVersion>
-    <MicrosoftBclHashCodeVersion>6.0.0-preview.1.24517.1</MicrosoftBclHashCodeVersion>
+    <MicrosoftBclHashCodeVersion>6.0.0-preview.1.24529.4</MicrosoftBclHashCodeVersion>
     <MicrosoftBclMemoryVersion>9.0.0-rc.1.24431.7</MicrosoftBclMemoryVersion>
     <MicrosoftCodeAnalysisAnalyzersVersion>3.3.4</MicrosoftCodeAnalysisAnalyzersVersion>
     <MicrosoftCodeAnalysisCSharpVersion>4.9.2</MicrosoftCodeAnalysisCSharpVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -21,17 +21,17 @@
     <MicrosoftExtensionsOptionsVersion>8.0.2</MicrosoftExtensionsOptionsVersion>
     <NuGetVersion>6.9.1</NuGetVersion>
     <SkiaSharpVersion>2.88.8</SkiaSharpVersion>
-    <SystemBuffersVersion>4.5.1</SystemBuffersVersion>
+    <SystemBuffersVersion>4.6.0-preview.1.24517.1</SystemBuffersVersion>
     <SystemCodeDomVersion>8.0.0</SystemCodeDomVersion>
     <SystemCollectionsImmutableVersion>8.0.0</SystemCollectionsImmutableVersion>
     <SystemConfigurationConfigurationManagerVersion>6.0.1</SystemConfigurationConfigurationManagerVersion>
     <SystemFormatsAsn1Version>8.0.1</SystemFormatsAsn1Version>
     <SystemIOFileSystemAccessControl>5.0.0</SystemIOFileSystemAccessControl>
-    <SystemMemoryVersion>4.5.5</SystemMemoryVersion>
+    <SystemMemoryVersion>4.6.0-preview.1.24517.1</SystemMemoryVersion>
     <SystemNumericsTensorsVersion>8.0.0</SystemNumericsTensorsVersion>
     <SystemReflectionEmitLightweightVersion>4.7.0</SystemReflectionEmitLightweightVersion>
     <SystemReflectionEmitVersion>4.3.0</SystemReflectionEmitVersion>
-    <SystemRuntimeCompilerServicesUnsafeVersion>6.0.0</SystemRuntimeCompilerServicesUnsafeVersion>
+    <SystemRuntimeCompilerServicesUnsafeVersion>6.1.0-preview.1.24517.1</SystemRuntimeCompilerServicesUnsafeVersion>
     <SystemSecurityPrincipalWindows>5.0.0</SystemSecurityPrincipalWindows>
     <SystemTextEncodingsWebVersion>8.0.0</SystemTextEncodingsWebVersion>
     <SystemTextJsonVersion>8.0.4</SystemTextJsonVersion>
@@ -40,7 +40,7 @@
     <ApacheArrowVersion>14.0.2</ApacheArrowVersion>
     <GoogleProtobufVersion>3.27.1</GoogleProtobufVersion>
     <LightGBMVersion>3.3.5</LightGBMVersion>
-    <MicrosoftBclHashCodeVersion>1.1.1</MicrosoftBclHashCodeVersion>
+    <MicrosoftBclHashCodeVersion>6.0.0-preview.1.24517.1</MicrosoftBclHashCodeVersion>
     <MicrosoftBclMemoryVersion>9.0.0-rc.1.24431.7</MicrosoftBclMemoryVersion>
     <MicrosoftCodeAnalysisAnalyzersVersion>3.3.4</MicrosoftCodeAnalysisAnalyzersVersion>
     <MicrosoftCodeAnalysisCSharpVersion>4.9.2</MicrosoftCodeAnalysisCSharpVersion>

--- a/test/Microsoft.ML.CodeAnalyzer.Tests/Helpers/AdditionalMetadataReferences.cs
+++ b/test/Microsoft.ML.CodeAnalyzer.Tests/Helpers/AdditionalMetadataReferences.cs
@@ -16,10 +16,10 @@ namespace Microsoft.ML.CodeAnalyzer.Tests.Helpers
     {
 #if NETCOREAPP
         internal static readonly ReferenceAssemblies DefaultReferenceAssemblies = ReferenceAssemblies.Default
-            .AddPackages(ImmutableArray.Create(new PackageIdentity("System.Memory", "4.5.1")));
+            .AddPackages(ImmutableArray.Create(new PackageIdentity("System.Memory", "4.6.0")));
 #else
         internal static readonly ReferenceAssemblies DefaultReferenceAssemblies = ReferenceAssemblies.NetFramework.Net472.Default
-            .AddPackages(ImmutableArray.Create(new PackageIdentity("System.Memory", "4.5.1")));
+            .AddPackages(ImmutableArray.Create(new PackageIdentity("System.Memory", "4.6.0")));
 #endif
 
         internal static readonly MetadataReference MSDataDataViewReference = RefFromType<IDataView>();


### PR DESCRIPTION
dotnet/runtime depends on these packages that we are now publishing from dotnet/maintenance-packages:

- Microsoft.Bcl.HashCode
- System.Buffers
- System.Memory
- System.Runtime.CompilerServices.Unsafe

Bumping their versions to consume the new preview versions, available in the dotnet-libraries feed: https://dnceng.visualstudio.com/public/_artifacts/feed/dotnet-libraries

Related PRs:
- runtime: https://github.com/dotnet/runtime/pull/108806
- winforms: https://github.com/dotnet/winforms/pull/12313