### PR TITLE
Update dependencies from maintenance-packages to latest versions

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,6 +48,8 @@
     <MicrosoftMLOnnxRuntimeVersion>1.18.1</MicrosoftMLOnnxRuntimeVersion>
     <MlNetMklDepsVersion>0.0.0.12</MlNetMklDepsVersion>
     <MicrosoftExtensionsAIVersion>9.0.0-preview.9.24507.7</MicrosoftExtensionsAIVersion>
+    <!-- runtime.native.System.Data.SqlClient.sni is not updated by dependency flow as it is not produced live anymore. -->
+    <RuntimeNativeSystemDataSqlClientSniVersion>4.4.0</RuntimeNativeSystemDataSqlClientSniVersion>
     <!--
 @("inteltbb.devel", "win", "2021.7.1.15305")
     -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -21,17 +21,17 @@
     <MicrosoftExtensionsOptionsVersion>8.0.2</MicrosoftExtensionsOptionsVersion>
     <NuGetVersion>6.9.1</NuGetVersion>
     <SkiaSharpVersion>2.88.8</SkiaSharpVersion>
-    <SystemBuffersVersion>4.6.0-preview.1.24529.4</SystemBuffersVersion>
+    <SystemBuffersVersion>4.6.0-rtm.24561.10</SystemBuffersVersion>
     <SystemCodeDomVersion>8.0.0</SystemCodeDomVersion>
     <SystemCollectionsImmutableVersion>8.0.0</SystemCollectionsImmutableVersion>
     <SystemConfigurationConfigurationManagerVersion>6.0.1</SystemConfigurationConfigurationManagerVersion>
     <SystemFormatsAsn1Version>8.0.1</SystemFormatsAsn1Version>
     <SystemIOFileSystemAccessControl>5.0.0</SystemIOFileSystemAccessControl>
-    <SystemMemoryVersion>4.6.0-preview.1.24529.4</SystemMemoryVersion>
+    <SystemMemoryVersion>4.6.0-rtm.24561.10</SystemMemoryVersion>
     <SystemNumericsTensorsVersion>8.0.0</SystemNumericsTensorsVersion>
     <SystemReflectionEmitLightweightVersion>4.7.0</SystemReflectionEmitLightweightVersion>
     <SystemReflectionEmitVersion>4.3.0</SystemReflectionEmitVersion>
-    <SystemRuntimeCompilerServicesUnsafeVersion>6.1.0-preview.1.24529.4</SystemRuntimeCompilerServicesUnsafeVersion>
+    <SystemRuntimeCompilerServicesUnsafeVersion>6.1.0-rtm.24561.10</SystemRuntimeCompilerServicesUnsafeVersion>
     <SystemSecurityPrincipalWindows>5.0.0</SystemSecurityPrincipalWindows>
     <SystemTextEncodingsWebVersion>8.0.0</SystemTextEncodingsWebVersion>
     <SystemTextJsonVersion>8.0.5</SystemTextJsonVersion>
@@ -40,7 +40,7 @@
     <ApacheArrowVersion>14.0.2</ApacheArrowVersion>
     <GoogleProtobufVersion>3.27.1</GoogleProtobufVersion>
     <LightGBMVersion>3.3.5</LightGBMVersion>
-    <MicrosoftBclHashCodeVersion>6.0.0-preview.1.24529.4</MicrosoftBclHashCodeVersion>
+    <MicrosoftBclHashCodeVersion>6.0.0-rtm.24561.10</MicrosoftBclHashCodeVersion>
     <MicrosoftBclMemoryVersion>9.0.0-rc.1.24431.7</MicrosoftBclMemoryVersion>
     <MicrosoftCodeAnalysisAnalyzersVersion>3.3.4</MicrosoftCodeAnalysisAnalyzersVersion>
     <MicrosoftCodeAnalysisCSharpVersion>4.9.2</MicrosoftCodeAnalysisCSharpVersion>
@@ -99,7 +99,7 @@
     <MicrosoftMLTestDatabasesVersion>0.0.6-test</MicrosoftMLTestDatabasesVersion>
     <MicrosoftMLTestModelsVersion>0.0.7-test</MicrosoftMLTestModelsVersion>
     <MicrosoftMLTestTokenizersVersion>2.0.0-beta.24455.2</MicrosoftMLTestTokenizersVersion>
-    <SystemDataSqlClientVersion>4.8.6</SystemDataSqlClientVersion>
+    <SystemDataSqlClientVersion>4.9.0-rtm.24561.10</SystemDataSqlClientVersion>
     <SystemDataSQLiteCoreVersion>1.0.118</SystemDataSQLiteCoreVersion>
     <XunitCombinatorialVersion>1.6.24</XunitCombinatorialVersion>
     <!-- Opt-out repo features -->

--- a/test/Microsoft.ML.Tests/DatabaseLoaderTests.cs
+++ b/test/Microsoft.ML.Tests/DatabaseLoaderTests.cs
@@ -275,6 +275,7 @@ namespace Microsoft.ML.Tests
         private DatabaseSource GetIrisDatabaseSource(string command, int commandTimeoutInSeconds = 30)
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+#pragma warning disable CS0618 // 'SqlClientFactory' is obsolete: 'Use the Microsoft.Data.SqlClient package instead.'
                 return new DatabaseSource(
                     SqlClientFactory.Instance,
                     GetMSSQLConnectionString(TestDatasets.irisDb.name),
@@ -286,6 +287,7 @@ namespace Microsoft.ML.Tests
                     GetSQLiteConnectionString(TestDatasets.irisDbSQLite.name),
                     String.Format(command, TestDatasets.irisDbSQLite.trainFilename),
                     commandTimeoutInSeconds);
+#pragma warning restore CS0618 // 'SqlClientFactory' is obsolete: 'Use the Microsoft.Data.SqlClient package instead.'
         }
 
         private string GetMSSQLConnectionString(string databaseName)

--- a/test/Microsoft.ML.Tests/Microsoft.ML.Tests.csproj
+++ b/test/Microsoft.ML.Tests/Microsoft.ML.Tests.csproj
@@ -54,6 +54,7 @@
     <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="$(MicrosoftMLOnnxRuntimeVersion)" />
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionVersion)" />
     <PackageReference Include="System.Data.SQLite.Core" Version="$(SystemDataSQLiteCoreVersion)" />
+    <PackageReference Include="runtime.native.System.Data.SqlClient.sni" Version="$(RuntimeNativeSystemDataSqlClientSniVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The latest prerelease versions can be found here: https://dnceng.visualstudio.com/public/_artifacts/feed/dotnet-libraries

Tomorrow we can update to the stable versions after they get published to nuget.