### PR TITLE
Suppress nuget preview warning

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,7 +25,7 @@
     <StrongNameKeyId>Open</StrongNameKeyId>
 
     <!-- temporarily suppress NETSDK 1206 until we can update OnnxRuntime to fix https://github.com/dotnet/machinelearning/issues/6916 -->
-    <NoWarn>$(NoWarn);NETSDK1206</NoWarn>
+    <NoWarn>$(NoWarn);NETSDK1206;NU5104</NoWarn>
   </PropertyGroup>
 
     <PropertyGroup>


### PR DESCRIPTION
Temporarily suppressing the nuget warning since we need to have a dependency on the preview package.