### PR TITLE
Consolidate System.Numerics.Tensors dependency

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -27,7 +27,7 @@
     <SystemFormatsAsn1Version>8.0.1</SystemFormatsAsn1Version>
     <SystemIOFileSystemAccessControl>5.0.0</SystemIOFileSystemAccessControl>
     <SystemMemoryVersion>4.6.0</SystemMemoryVersion>
-    <SystemNumericsTensorsVersion>8.0.0</SystemNumericsTensorsVersion>
+    <SystemNumericsTensorsVersion>9.0.0</SystemNumericsTensorsVersion>
     <SystemReflectionEmitLightweightVersion>4.7.0</SystemReflectionEmitLightweightVersion>
     <SystemReflectionEmitVersion>4.3.0</SystemReflectionEmitVersion>
     <SystemRuntimeCompilerServicesUnsafeVersion>6.1.0</SystemRuntimeCompilerServicesUnsafeVersion>

--- a/src/Microsoft.Data.Analysis/Microsoft.Data.Analysis.csproj
+++ b/src/Microsoft.Data.Analysis/Microsoft.Data.Analysis.csproj
@@ -46,7 +46,7 @@
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="System.Numerics.Tensors" Version="9.0.0" />
+    <PackageReference Include="System.Numerics.Tensors" Version="$(SystemNumericsTensorsVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'">


### PR DESCRIPTION
After #7319 is done, System.Numerics.Tensors library dependency can be consolidated to 9.0