### PR TITLE
Support ByteLevel encoding in Bpe tokenizer to support DeepSeek model

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -100,7 +100,7 @@
     <MicrosoftMLTensorFlowTestModelsVersion>0.0.13-test</MicrosoftMLTensorFlowTestModelsVersion>
     <MicrosoftMLTestDatabasesVersion>0.0.6-test</MicrosoftMLTestDatabasesVersion>
     <MicrosoftMLTestModelsVersion>0.0.7-test</MicrosoftMLTestModelsVersion>
-    <MicrosoftMLTestTokenizersVersion>2.0.0-beta.25126.1</MicrosoftMLTestTokenizersVersion>
+    <MicrosoftMLTestTokenizersVersion>2.0.0-beta.25161.1</MicrosoftMLTestTokenizersVersion>
     <SystemDataSqlClientVersion>4.9.0</SystemDataSqlClientVersion>
     <SystemDataSQLiteCoreVersion>1.0.118</SystemDataSQLiteCoreVersion>
     <XunitCombinatorialVersion>1.6.24</XunitCombinatorialVersion>

--- a/src/Microsoft.ML.Tokenizers/Model/BPETokenizer.cs
+++ b/src/Microsoft.ML.Tokenizers/Model/BPETokenizer.cs
@@ -979,7 +979,7 @@ namespace Microsoft.ML.Tokenizers
             charsWritten = 0;
 
             // Enough buffer to carry one converted vocabulary to UTF-16 form
-            Span<char> vocabBuffer = stackalloc char[256];
+            Span<char> vocabBuffer = stackalloc char[128];
 
             // Enough buffer to carry one UTF-8 vocabulary
             Span<byte> utf8bytes = stackalloc byte[256];
@@ -1309,9 +1309,8 @@ namespace Microsoft.ML.Tokenizers
             }
 
             scoped ReadOnlySpan<char> textSpan = text;
-
-            Span<char> token = stackalloc char[BufferLength];
-            Span<int> mapping = stackalloc int[BufferLength];
+            scoped Span<char> token;
+            scoped Span<int> mapping = Span<int>.Empty;
             char[]? tokenBuffer = null;
             int[]? mappingBuffer = null;
 
@@ -1326,14 +1325,15 @@ namespace Microsoft.ML.Tokenizers
                     mappingBuffer = ArrayPool<int>.Shared.Rent(destinationMaxSize);
                     mapping = mappingBuffer;
                 }
+                else
+                {
+                    token = stackalloc char[destinationMaxSize];
+                    mapping = stackalloc int[destinationMaxSize];
+                }
 
                 int encodedLength = Helpers.EncodeToUtf8AndTransform(text, token, mapping);
                 textSpan = token.Slice(0, encodedLength);
                 mapping = mapping.Slice(0, encodedLength);
-            }
-            else
-            {
-                mapping = Span<int>.Empty;
             }
 
             Word word;
@@ -1422,8 +1422,8 @@ namespace Microsoft.ML.Tokenizers
 
             scoped ReadOnlySpan<char> textSpan = text;
 
-            Span<char> token = stackalloc char[BufferLength];
-            Span<int> mapping = stackalloc int[BufferLength];
+            scoped Span<char> token;
+            scoped Span<int> mapping = Span<int>.Empty;
             char[]? tokenBuffer = null;
             int[]? mappingBuffer = null;
 
@@ -1437,6 +1437,11 @@ namespace Microsoft.ML.Tokenizers
 
                     mappingBuffer = ArrayPool<int>.Shared.Rent(destinationMaxSize);
                     mapping = mappingBuffer;
+                }
+                else
+                {
+                    token = stackalloc char[destinationMaxSize];
+                    mapping = stackalloc int[destinationMaxSize];
                 }
 
                 int encodedLength = Helpers.EncodeToUtf8AndTransform(text, token, mapping);
@@ -1497,8 +1502,8 @@ namespace Microsoft.ML.Tokenizers
 
             scoped ReadOnlySpan<char> textSpan = text;
 
-            Span<char> token = stackalloc char[BufferLength];
-            Span<int> mapping = stackalloc int[BufferLength];
+            scoped Span<char> token;
+            scoped Span<int> mapping = Span<int>.Empty;
             char[]? tokenBuffer = null;
             int[]? mappingBuffer = null;
 
@@ -1512,6 +1517,11 @@ namespace Microsoft.ML.Tokenizers
 
                     mappingBuffer = ArrayPool<int>.Shared.Rent(destinationMaxSize);
                     mapping = mappingBuffer;
+                }
+                else
+                {
+                    token = stackalloc char[destinationMaxSize];
+                    mapping = stackalloc int[destinationMaxSize];
                 }
 
                 int encodedLength = Helpers.EncodeToUtf8AndTransform(text, token, mapping);

--- a/src/Microsoft.ML.Tokenizers/Model/BPETokenizer.cs
+++ b/src/Microsoft.ML.Tokenizers/Model/BPETokenizer.cs
@@ -31,6 +31,7 @@ namespace Microsoft.ML.Tokenizers
         private readonly Normalizer? _normalizer;
         private readonly Dictionary<StringSpanOrdinalKey, (int, string)>? _specialTokens;
         private readonly Dictionary<int, string>? _specialTokensReverse;
+        private const int BufferLength = 128;
 
         /// <summary>
         /// Gets the special tokens.
@@ -72,12 +73,12 @@ namespace Microsoft.ML.Tokenizers
         public string? ContinuingSubwordPrefix { get; }
 
         /// <summary>
-        /// An optional suffix to characterize and end-of-word sub-word
+        /// An optional suffix to characterize the end-of-word and sub-word
         /// </summary>
         public string? EndOfWordSuffix { get; }
 
         /// <summary>
-        /// Gets or sets whether allowing multiple unknown tokens get fused
+        /// Gets a value indicating whether to merge the sequence of the unknown tokens together.
         /// </summary>
         public bool FuseUnknownTokens { get; }
 
@@ -129,6 +130,66 @@ namespace Microsoft.ML.Tokenizers
             (Dictionary<StringSpanOrdinalKey, int>? vocab, Vec<(string, string)> merges) result = ReadModelDataAsync(vocabStream, mergesStream, useAsync: false).GetAwaiter().GetResult();
 
             return new BpeTokenizer(result.vocab, result.merges, preTokenizer, normalizer, specialTokens, unknownToken, continuingSubwordPrefix, endOfWordSuffix, fuseUnknownTokens);
+        }
+
+        public static BpeTokenizer Create(BpeOptions options)
+        {
+            if (options is null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            if (options.Vocabulary is null)
+            {
+                throw new ArgumentNullException(nameof(options.Vocabulary), "The vocabulary cannot be null.");
+            }
+
+            Dictionary<StringSpanOrdinalKey, int> vocab = new Dictionary<StringSpanOrdinalKey, int>(1000);
+
+            foreach ((string token, int id) in options.Vocabulary)
+            {
+                vocab.Add(new StringSpanOrdinalKey(token), id);
+            }
+
+            if (vocab.Count == 0)
+            {
+                throw new InvalidOperationException("The vocabulary cannot be empty.");
+            }
+
+            Vec<(string, string)> merges = default;
+            if (options.Merges is not null)
+            {
+                merges = new Vec<(string, string)>(1000);
+
+                foreach (string merge in options.Merges)
+                {
+                    if (merge is null)
+                    {
+                        throw new InvalidOperationException("The merge entries cannot be null.");
+                    }
+
+                    int index = merge.IndexOf(' ');
+                    if (index < 0 || index == merge.Length - 1 || merge.IndexOf(' ', index + 1) >= 0)
+                    {
+                        throw new InvalidOperationException($"Invalid merger file format");
+                    }
+
+                    merges.Push((merge.Substring(0, index), merge.Substring(index + 1)));
+                }
+            }
+
+            return new BpeTokenizer(
+                            vocab, merges,
+                            options.PreTokenizer,
+                            options.Normalizer,
+                            options.SpecialTokens,
+                            options.UnknownToken,
+                            options.ContinuingSubwordPrefix,
+                            options.EndOfWordSuffix,
+                            options.FuseUnknownTokens,
+                            options.ByteLevel,
+                            options.BeginningOfSentenceToken,
+                            options.EndOfSentenceToken);
         }
 
         /// <summary>
@@ -226,6 +287,9 @@ namespace Microsoft.ML.Tokenizers
         /// <param name="continuingSubwordPrefix">The prefix to attach to sub-word units that don’t represent a beginning of word.</param>
         /// <param name="endOfWordSuffix">The suffix to attach to sub-word units that represent an end of word.</param>
         /// <param name="fuseUnknownTokens">Indicate whether allowing multiple unknown tokens get fused.</param>
+        /// <param name="byteLevel">Indicate whether to handle the input text in byte level.</param>
+        /// <param name="beginningOfSentenceToken">The beginning of sentence token.</param>
+        /// <param name="endOfSentenceToken">The end of sentence token.</param>
         private BpeTokenizer(
                     Dictionary<StringSpanOrdinalKey, int>? vocab,
                     Vec<(string, string)> merges,
@@ -235,15 +299,42 @@ namespace Microsoft.ML.Tokenizers
                     string? unknownToken,
                     string? continuingSubwordPrefix,
                     string? endOfWordSuffix,
-                    bool fuseUnknownTokens)
+                    bool fuseUnknownTokens,
+                    bool byteLevel = false,
+                    string? beginningOfSentenceToken = null,
+                    string? endOfSentenceToken = null)
         {
             FuseUnknownTokens = fuseUnknownTokens;
             ContinuingSubwordPrefix = continuingSubwordPrefix;
             EndOfWordSuffix = endOfWordSuffix;
+            ByteLevel = byteLevel;
             _preTokenizer = preTokenizer ?? PreTokenizer.CreateWordOrNonWord(); // Default to WordOrNonWord pre-tokenizer
             _normalizer = normalizer;
 
             _vocab = vocab ?? new Dictionary<StringSpanOrdinalKey, int>();
+
+            if (beginningOfSentenceToken is not null)
+            {
+                if (!_vocab.TryGetValue(beginningOfSentenceToken, out int aId))
+                {
+                    throw new InvalidOperationException($"The beginning of sentence token '{beginningOfSentenceToken}' was not present in the vocabulary.");
+                }
+
+                BeginningOfSentenceId = aId;
+                BeginningOfSentenceToken = beginningOfSentenceToken;
+            }
+
+            if (endOfSentenceToken is not null)
+            {
+                if (!_vocab.TryGetValue(endOfSentenceToken, out int aId))
+                {
+                    throw new InvalidOperationException($"The end of sentence token '{endOfSentenceToken}' was not present in the vocabulary.");
+                }
+
+                EndOfSentenceId = aId;
+                EndOfSentenceToken = endOfSentenceToken;
+            }
+
             Cache = new StringSpanOrdinalKeyCache<Word>();
 
             VocabReverse = new();
@@ -295,6 +386,33 @@ namespace Microsoft.ML.Tokenizers
         }
 
         /// <summary>
+        /// Gets a value indicating whether to handle the input text in byte level.
+        /// if true, the input text will be converted to UTF-8 bytes before encoding it.
+        /// Additionally, some ASCII characters will be transformed to another characters (e.g Space character will be transformed to 'Ġ' character).
+        /// </summary>
+        public bool ByteLevel { get; }
+
+        /// <summary>
+        /// Gets the optional beginning of sentence token.
+        /// </summary>
+        internal string? BeginningOfSentenceToken { get; }
+
+        /// <summary>
+        /// The id of the beginning of sentence token.
+        /// </summary>
+        internal int BeginningOfSentenceId { get; }
+
+        /// <summary>
+        /// Gets the optional end of sentence token.
+        /// </summary>
+        internal string? EndOfSentenceToken { get; }
+
+        /// <summary>
+        /// The id of the end of sentence token.
+        /// </summary>
+        internal int EndOfSentenceId { get; }
+
+        /// <summary>
         /// Gets the PreTokenizer used by the Tokenizer.
         /// </summary>
         public override PreTokenizer? PreTokenizer => _preTokenizer;
@@ -329,6 +447,11 @@ namespace Microsoft.ML.Tokenizers
                                                                 out int charsConsumed);
 
             List<EncodedToken> tokens = new();
+            if (BeginningOfSentenceToken is not null)
+            {
+                tokens.Add(new EncodedToken(BeginningOfSentenceId, BeginningOfSentenceToken, new Range(0, 0)));
+            }
+
             PriorityQueue<Merge>? priorityQueue = null;
 
             if (splits is not null)
@@ -341,6 +464,11 @@ namespace Microsoft.ML.Tokenizers
             else
             {
                 EncodeWithCache(textSpanToEncode, tokens, 0, ref priorityQueue);
+            }
+
+            if (EndOfSentenceToken is not null)
+            {
+                tokens.Add(new EncodedToken(EndOfSentenceId, EndOfSentenceToken, new Range(charsConsumed, charsConsumed)));
             }
 
             return new EncodeResults<EncodedToken> { Tokens = tokens, NormalizedText = normalizedText, CharsConsumed = charsConsumed };
@@ -378,6 +506,12 @@ namespace Microsoft.ML.Tokenizers
                                                                 out _);
 
             List<int> ids = new();
+
+            if (BeginningOfSentenceToken is not null)
+            {
+                ids.Add(BeginningOfSentenceId);
+            }
+
             PriorityQueue<Merge>? priorityQueue = null;
 
             int charsConsumed = 0;
@@ -397,6 +531,11 @@ namespace Microsoft.ML.Tokenizers
             else
             {
                 EncodeToIdsWithCache(textSpanToEncode, ids, maxTokenCount, out charsConsumed, ref priorityQueue);
+            }
+
+            if (EndOfSentenceToken is not null && ids.Count < maxTokenCount)
+            {
+                ids.Add(EndOfSentenceId);
             }
 
             return new EncodeResults<int> { Tokens = ids, NormalizedText = normalizedText, CharsConsumed = charsConsumed };
@@ -434,7 +573,7 @@ namespace Microsoft.ML.Tokenizers
                                                                 out _);
 
             PriorityQueue<Merge>? priorityQueue = null;
-            int count = 0;
+            int count = BeginningOfSentenceToken is null ? 0 : 1;
             int textLength = 0;
 
             if (splits is not null)
@@ -453,6 +592,11 @@ namespace Microsoft.ML.Tokenizers
             else
             {
                 count = EncodeToIdsWithCache(textSpanToEncode, null, maxTokenCount, out textLength, ref priorityQueue);
+            }
+
+            if (EndOfSentenceToken is not null && count < maxTokenCount)
+            {
+                count++;
             }
 
             return count;
@@ -511,7 +655,7 @@ namespace Microsoft.ML.Tokenizers
                                                                 out _);
 
             PriorityQueue<Merge>? priorityQueue = null;
-            int count = 0;
+            int count = BeginningOfSentenceToken is null ? 0 : 1;
             if (splits is not null)
             {
                 foreach ((int Offset, int Length) split in splits)
@@ -528,6 +672,11 @@ namespace Microsoft.ML.Tokenizers
             else
             {
                 count = EncodeToIdsWithCache(textSpanToEncode, null, maxTokenCount, out charsConsumed, ref priorityQueue);
+            }
+
+            if (EndOfSentenceToken is not null && count < maxTokenCount)
+            {
+                count++;
             }
 
             return count;
@@ -562,7 +711,7 @@ namespace Microsoft.ML.Tokenizers
 
             if (splits is not null)
             {
-                tokenCount = 0;
+                tokenCount = EndOfSentenceToken is null ? 0 : 1;
                 foreach ((int Offset, int Length) split in splits.Reverse())
                 {
                     tokenCount += EncodeToIdsFromEndWithCache(textSpanToEncode.Slice(split.Offset, split.Length), null, maxTokenCount - tokenCount, out int textIndex, ref priorityQueue);
@@ -571,10 +720,13 @@ namespace Microsoft.ML.Tokenizers
                         return split.Offset + textIndex;
                     }
                 }
+
+                tokenCount += tokenCount < maxTokenCount && BeginningOfSentenceToken is not null ? 1 : 0;
             }
             else
             {
-                tokenCount = EncodeToIdsFromEndWithCache(textSpanToEncode, null, maxTokenCount, out int charsConsumed, ref priorityQueue);
+                tokenCount = EncodeToIdsFromEndWithCache(textSpanToEncode, null, maxTokenCount - (EndOfSentenceToken is null ? 0 : 1), out int charsConsumed, ref priorityQueue);
+                tokenCount += tokenCount < maxTokenCount && BeginningOfSentenceToken is not null ? 1 : 0;
                 return charsConsumed;
             }
 
@@ -628,6 +780,11 @@ namespace Microsoft.ML.Tokenizers
                 throw new ArgumentNullException(nameof(ids));
             }
 
+            if (ByteLevel)
+            {
+                return DecodeByteLevel(ids, considerSpecialTokens);
+            }
+
             ValueStringBuilder sb = new ValueStringBuilder();
 
             bool decodeUnknownToken = _unknownTokenId.HasValue && considerSpecialTokens;
@@ -673,6 +830,48 @@ namespace Microsoft.ML.Tokenizers
             return sb.ToString();
         }
 
+        private string DecodeByteLevel(IEnumerable<int> ids, bool considerSpecialTokens)
+        {
+            int bytesIndex = 0;
+            byte[] bytes = ArrayPool<byte>.Shared.Rent(BufferLength << 1);
+
+            foreach (int id in ids)
+            {
+                if (_specialTokensReverse?.TryGetValue(id, out string? token) is true)
+                {
+                    if (!considerSpecialTokens)
+                    {
+                        continue;
+                    }
+
+                    Helpers.AppendToBytesArray(token.AsSpan(), ref bytes, ref bytesIndex);
+                    continue;
+                }
+
+                if (MapIdToToken(id) is string s)
+                {
+                    ReadOnlySpan<char> span = s.AsSpan();
+                    if (EndOfWordSuffix is not null && span.EndsWith(EndOfWordSuffix.AsSpan(), StringComparison.Ordinal))
+                    {
+                        span = span.Slice(0, span.Length - EndOfWordSuffix.Length);
+                    }
+
+                    if (ContinuingSubwordPrefix is not null && span.StartsWith(ContinuingSubwordPrefix.AsSpan(), StringComparison.Ordinal))
+                    {
+                        span = span.Slice(ContinuingSubwordPrefix.Length);
+                    }
+
+                    Helpers.AppendToBytesArray(span, ref bytes, ref bytesIndex);
+                }
+            }
+
+            string decodedString = Helpers.GetString(bytes.AsSpan(0, bytesIndex));
+
+            ArrayPool<byte>.Shared.Return(bytes);
+
+            return decodedString;
+        }
+
         /// <summary>
         /// Decode the given ids back to text and store the result in the <paramref name="destination"/> span.
         /// </summary>
@@ -698,6 +897,11 @@ namespace Microsoft.ML.Tokenizers
             if (ids is null)
             {
                 throw new ArgumentNullException(nameof(ids));
+            }
+
+            if (ByteLevel)
+            {
+                return DecodeByteLevel(ids, destination, considerSpecialTokens, out idsConsumed, out charsWritten);
             }
 
             idsConsumed = 0;
@@ -764,6 +968,124 @@ namespace Microsoft.ML.Tokenizers
                     buffer = buffer.Slice(sSpan.Length);
                 }
                 idsConsumed++;
+            }
+
+            return OperationStatus.Done;
+        }
+
+        private OperationStatus DecodeByteLevel(IEnumerable<int> ids, Span<char> destination, bool considerSpecialTokens, out int idsConsumed, out int charsWritten)
+        {
+            idsConsumed = 0;
+            charsWritten = 0;
+
+            // Enough buffer to carry one converted vocabulary to UTF-16 form
+            Span<char> vocabBuffer = stackalloc char[256];
+
+            // Enough buffer to carry one UTF-8 vocabulary
+            Span<byte> utf8bytes = stackalloc byte[256];
+
+            int incompleteUtf8BytesInBuffer = 0;
+            int incompleteUtf8BytesInBufferIndex = 0;
+            int utf16CharsInBuffer = 0;
+            int idsHangingCount = 0;
+
+            ByteToUnicodeEncoding byteToUnicodeEncoding = ByteToUnicodeEncoding.Instance;
+
+            Span<char> buffer = destination;
+
+            foreach (int id in ids)
+            {
+                if (_specialTokensReverse?.TryGetValue(id, out string? specialToken) is true)
+                {
+                    if (!considerSpecialTokens)
+                    {
+                        idsConsumed++;
+                        continue;
+                    }
+
+                    if (incompleteUtf8BytesInBuffer > 0)
+                    {
+                        return OperationStatus.InvalidData; // unexpected case
+                    }
+
+                    ReadOnlySpan<char> specialTokenSpan = specialToken.AsSpan();
+
+                    if (specialTokenSpan.Length > buffer.Length)
+                    {
+                        return OperationStatus.DestinationTooSmall;
+                    }
+
+                    specialTokenSpan.CopyTo(buffer);
+                    buffer = buffer.Slice(specialTokenSpan.Length);
+                    charsWritten += specialTokenSpan.Length;
+                    idsConsumed++;
+                    continue;
+                }
+
+                // vocabularies are stored in UTF-8 form with escaping the control characters.
+                // Need to convert the vocabulary to the original UTF-16 form.
+                if (MapIdToToken(id) is string s)
+                {
+                    ReadOnlySpan<char> span = s.AsSpan();
+                    if (EndOfWordSuffix is not null && span.EndsWith(EndOfWordSuffix.AsSpan(), StringComparison.Ordinal))
+                    {
+                        span = span.Slice(0, span.Length - EndOfWordSuffix.Length);
+                    }
+
+                    if (ContinuingSubwordPrefix is not null && span.StartsWith(ContinuingSubwordPrefix.AsSpan(), StringComparison.Ordinal))
+                    {
+                        span = span.Slice(ContinuingSubwordPrefix.Length);
+                    }
+
+                    Span<byte> current = utf8bytes.Slice(incompleteUtf8BytesInBufferIndex + incompleteUtf8BytesInBuffer);
+
+                    if (current.Length < span.Length)
+                    {
+                        return OperationStatus.InvalidData; // unexpected case
+                    }
+
+                    for (int i = 0; i < span.Length; i++)
+                    {
+                        current[i] = (byte)byteToUnicodeEncoding.UnicodeToByte[span[i]];
+                    }
+
+                    current = utf8bytes.Slice(incompleteUtf8BytesInBufferIndex, incompleteUtf8BytesInBuffer + span.Length);
+                    if (!Helpers.ConvertUtf8ToUtf16(current, vocabBuffer.Slice(utf16CharsInBuffer), out int utf8BytesConsumed, out int utf16CharsWritten))
+                    {
+                        return OperationStatus.InvalidData; // unexpected case of malformed utf8 sequence
+                    }
+
+                    if (current.Length == utf8BytesConsumed) // encoding is complete
+                    {
+                        int completeCharsWritten = utf16CharsInBuffer + utf16CharsWritten;
+                        if (completeCharsWritten > buffer.Length)
+                        {
+                            return OperationStatus.DestinationTooSmall;
+                        }
+
+                        vocabBuffer.Slice(0, completeCharsWritten).CopyTo(buffer);
+                        buffer = buffer.Slice(completeCharsWritten);
+                        charsWritten += completeCharsWritten;
+
+                        incompleteUtf8BytesInBuffer = 0;
+                        incompleteUtf8BytesInBufferIndex = 0;
+                        utf16CharsInBuffer = 0;
+                        idsConsumed += idsHangingCount + 1;
+                        idsHangingCount = 0;
+                    }
+                    else
+                    {
+                        // Incomplete utf8 sequence, complete it in the next iteration
+                        incompleteUtf8BytesInBuffer = current.Length - utf8BytesConsumed;
+                        incompleteUtf8BytesInBufferIndex += utf8BytesConsumed;
+                        utf16CharsInBuffer += utf16CharsWritten;
+                        idsHangingCount++;
+                    }
+
+                    continue;
+                }
+
+                return OperationStatus.InvalidData; // encountered unknown id
             }
 
             return OperationStatus.Done;
@@ -976,7 +1298,7 @@ namespace Microsoft.ML.Tokenizers
             return word;
         }
 
-        internal void WordToTokens(ref Word word, List<EncodedToken> tokens, int offset) => word.ToTokens(VocabReverse, tokens, offset);
+        internal void WordToTokens(ref Word word, List<EncodedToken> tokens, int offset, ReadOnlySpan<int> mapping) => word.ToTokens(VocabReverse, tokens, offset, mapping);
 
         internal void EncodeWithCache(ReadOnlySpan<char> text, List<EncodedToken> tokens, int offset, ref PriorityQueue<Merge>? priorityQueue)
         {
@@ -986,20 +1308,48 @@ namespace Microsoft.ML.Tokenizers
                 return;
             }
 
+            scoped ReadOnlySpan<char> textSpan = text;
+
+            Span<char> token = stackalloc char[BufferLength];
+            Span<int> mapping = stackalloc int[BufferLength];
+            char[]? tokenBuffer = null;
+            int[]? mappingBuffer = null;
+
+            if (ByteLevel)
+            {
+                int destinationMaxSize = Encoding.UTF8.GetMaxByteCount(text.Length);
+                if (destinationMaxSize > BufferLength)
+                {
+                    tokenBuffer = ArrayPool<char>.Shared.Rent(destinationMaxSize);
+                    token = tokenBuffer;
+
+                    mappingBuffer = ArrayPool<int>.Shared.Rent(destinationMaxSize);
+                    mapping = mappingBuffer;
+                }
+
+                int encodedLength = Helpers.EncodeToUtf8AndTransform(text, token, mapping);
+                textSpan = token.Slice(0, encodedLength);
+                mapping = mapping.Slice(0, encodedLength);
+            }
+            else
+            {
+                mapping = Span<int>.Empty;
+            }
+
             Word word;
             if (Cache is not null)
             {
-                if (Cache.TryGetValue(text, out word))
+                if (Cache.TryGetValue(textSpan, out word))
                 {
-                    WordToTokens(ref word, tokens, offset);
+                    WordToTokens(ref word, tokens, offset, mapping);
                     return;
                 }
 
-                word = MergeWord(text, ref priorityQueue);
+                word = MergeWord(textSpan, ref priorityQueue);
 
-                if (text.Length <= MaxWordLengthToCache)
+                if (textSpan.Length <= MaxWordLengthToCache)
                 {
-                    Cache.Set(text.ToString(), word);
+                    Cache.Set(textSpan.ToString(), word);
                 }
             }
             else
@@ -1007,7 +1357,14 @@ namespace Microsoft.ML.Tokenizers
                 word = MergeWord(text, ref priorityQueue);
             }
 
-            WordToTokens(ref word, tokens, offset);
+            WordToTokens(ref word, tokens, offset, mapping);
+
+            if (tokenBuffer is not null)
+            {
+                ArrayPool<char>.Shared.Return(tokenBuffer);
+                Debug.Assert(mappingBuffer is not null);
+                ArrayPool<int>.Shared.Return(mappingBuffer);
+            }
         }
 
         internal int WordToIds(ref Word word, IList<int>? accumulatedIds, out int charsConsumed, int fullTextLength, int maxTokens)
@@ -1063,26 +1420,68 @@ namespace Microsoft.ML.Tokenizers
 
             Word word;
 
-            if (Cache is not null)
+            scoped ReadOnlySpan<char> textSpan = text;
+
+            Span<char> token = stackalloc char[BufferLength];
+            Span<int> mapping = stackalloc int[BufferLength];
+            char[]? tokenBuffer = null;
+            int[]? mappingBuffer = null;
+
+            if (ByteLevel)
             {
-                if (Cache.TryGetValue(text, out Word hit))
+                int destinationMaxSize = Encoding.UTF8.GetMaxByteCount(text.Length);
+                if (destinationMaxSize > BufferLength)
                 {
-                    return WordToIds(ref hit, accumulatedIds, out charsConsumed, text.Length, maxTokens);
+                    tokenBuffer = ArrayPool<char>.Shared.Rent(destinationMaxSize);
+                    token = tokenBuffer;
+
+                    mappingBuffer = ArrayPool<int>.Shared.Rent(destinationMaxSize);
+                    mapping = mappingBuffer;
                 }
 
-                word = MergeWord(text, ref priorityQueue);
+                int encodedLength = Helpers.EncodeToUtf8AndTransform(text, token, mapping);
+                textSpan = token.Slice(0, encodedLength);
+            }
 
-                if (text.Length <= MaxWordLengthToCache)
+            if (Cache is not null)
+            {
+                if (Cache.TryGetValue(textSpan, out Word hit))
                 {
-                    Cache.Set(text.ToString(), word);
+                    int res = WordToIds(ref hit, accumulatedIds, out charsConsumed, textSpan.Length, maxTokens);
+                    if (ByteLevel)
+                    {
+                        charsConsumed = charsConsumed >= textSpan.Length ? text.Length : mapping[charsConsumed];
+                    }
+
+                    return res;
+                }
+
+                word = MergeWord(textSpan, ref priorityQueue);
+
+                if (textSpan.Length <= MaxWordLengthToCache)
+                {
+                    Cache.Set(textSpan.ToString(), word);
                 }
             }
             else
             {
-                word = MergeWord(text, ref priorityQueue);
+                word = MergeWord(textSpan, ref priorityQueue);
             }
 
-            return WordToIds(ref word, accumulatedIds, out charsConsumed, text.Length, maxTokens);
+            int result = WordToIds(ref word, accumulatedIds, out charsConsumed, textSpan.Length, maxTokens);
+            if (ByteLevel)
+            {
+                charsConsumed = charsConsumed >= textSpan.Length ? text.Length : mapping[charsConsumed];
+            }
+
+            if (tokenBuffer is not null)
+            {
+                ArrayPool<char>.Shared.Return(tokenBuffer);
+                Debug.Assert(mappingBuffer is not null);
+                ArrayPool<int>.Shared.Return(mappingBuffer);
+            }
+
+            return result;
         }
 
         internal int EncodeToIdsFromEndWithCache(ReadOnlySpan<char> text, IList<int>? accumulatedIds, int maxTokens, out int textIndex, ref PriorityQueue<Merge>? priorityQueue)
@@ -1096,26 +1495,70 @@ namespace Microsoft.ML.Tokenizers
                 return 1;
             }
 
-            if (Cache is not null)
+            scoped ReadOnlySpan<char> textSpan = text;
+
+            Span<char> token = stackalloc char[BufferLength];
+            Span<int> mapping = stackalloc int[BufferLength];
+            char[]? tokenBuffer = null;
+            int[]? mappingBuffer = null;
+
+            if (ByteLevel)
             {
-                if (Cache.TryGetValue(text, out Word hit))
+                int destinationMaxSize = Encoding.UTF8.GetMaxByteCount(text.Length);
+                if (destinationMaxSize > BufferLength)
                 {
-                    return WordToIdsFromEnd(ref hit, accumulatedIds, out textIndex, text.Length, maxTokens);
+                    tokenBuffer = ArrayPool<char>.Shared.Rent(destinationMaxSize);
+                    token = tokenBuffer;
+
+                    mappingBuffer = ArrayPool<int>.Shared.Rent(destinationMaxSize);
+                    mapping = mappingBuffer;
                 }
 
-                word = MergeWord(text, ref priorityQueue);
+                int encodedLength = Helpers.EncodeToUtf8AndTransform(text, token, mapping);
+                textSpan = token.Slice(0, encodedLength);
+            }
 
-                if (text.Length <= MaxWordLengthToCache)
+            if (Cache is not null)
+            {
+                if (Cache.TryGetValue(textSpan, out Word hit))
                 {
-                    Cache.Set(text.ToString(), word);
+                    int res = WordToIdsFromEnd(ref hit, accumulatedIds, out textIndex, textSpan.Length, maxTokens);
+
+                    if (ByteLevel)
+                    {
+                        textIndex = textIndex >= textSpan.Length ? text.Length : mapping[textIndex];
+                    }
+
+                    return res;
+                }
+
+                word = MergeWord(textSpan, ref priorityQueue);
+
+                if (textSpan.Length <= MaxWordLengthToCache)
+                {
+                    Cache.Set(textSpan.ToString(), word);
                 }
             }
             else
             {
-                word = MergeWord(text, ref priorityQueue);
+                word = MergeWord(textSpan, ref priorityQueue);
             }
 
-            return WordToIdsFromEnd(ref word, accumulatedIds, out textIndex, text.Length, maxTokens);
+            int result = WordToIdsFromEnd(ref word, accumulatedIds, out textIndex, textSpan.Length, maxTokens);
+
+            if (ByteLevel)
+            {
+                textIndex = textIndex >= textSpan.Length ? text.Length : mapping[textIndex];
+            }
+
+            if (tokenBuffer is not null)
+            {
+                ArrayPool<char>.Shared.Return(tokenBuffer);
+                Debug.Assert(mappingBuffer is not null);
+                ArrayPool<int>.Shared.Return(mappingBuffer);
+            }
+
+            return result;
         }
     }
 }

--- a/src/Microsoft.ML.Tokenizers/Model/BpeOptions.cs
+++ b/src/Microsoft.ML.Tokenizers/Model/BpeOptions.cs
@@ -73,7 +73,7 @@ namespace Microsoft.ML.Tokenizers
         /// <summary>
         /// Gets or sets a value indicating whether to handle the input text in byte level.
         /// if true, the input text will be converted to UTF-8 bytes before encoding it.
-        /// Additionally, some ASCII characters will be transformed to another characters (e.g Space character will be transformed to 'Ġ' character).
+        /// Additionally, some ASCII characters will be transformed to different characters (e.g Space character will be transformed to 'Ġ' character).
         /// </summary>
         public bool ByteLevel { get; set; }
 

--- a/src/Microsoft.ML.Tokenizers/Model/BpeOptions.cs
+++ b/src/Microsoft.ML.Tokenizers/Model/BpeOptions.cs
@@ -28,7 +28,7 @@ namespace Microsoft.ML.Tokenizers
         /// <summary>
         /// Gets or sets the vocabulary to use.
         /// </summary>
-        public IEnumerable<(string Token, int Id)> Vocabulary { get; set; }
+        public IEnumerable<(string Token, int Id)> Vocabulary { get; }
 
         /// <summary>
         /// Gets or sets the list of the merge strings used to merge tokens during encoding.

--- a/src/Microsoft.ML.Tokenizers/Model/BpeOptions.cs
+++ b/src/Microsoft.ML.Tokenizers/Model/BpeOptions.cs
@@ -1,0 +1,100 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.ML.Tokenizers
+{
+    /// <summary>
+    /// Options for the BPE tokenizer.
+    /// </summary>
+    public sealed class BpeOptions
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BpeOptions"/> class.
+        /// </summary>
+        public BpeOptions(IEnumerable<(string Token, int Id)> vocabulary)
+        {
+            if (vocabulary == null)
+            {
+                throw new ArgumentNullException(nameof(vocabulary));
+            }
+
+            Vocabulary = vocabulary;
+        }
+
+        /// <summary>
+        /// Gets or sets the vocabulary to use.
+        /// </summary>
+        public IEnumerable<(string Token, int Id)> Vocabulary { get; set; }
+
+        /// <summary>
+        /// Gets or sets the list of the merge strings used to merge tokens during encoding.
+        /// </summary>
+        public IEnumerable<string>? Merges { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional special tokens to use.
+        /// </summary>
+        public Dictionary<string, int>? SpecialTokens { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional normalizer to normalize the input text before encoding it.
+        /// </summary>
+        public Normalizer? Normalizer { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional pre-tokenizer to split the input text into tokens before encoding it.
+        /// </summary>
+        public PreTokenizer? PreTokenizer { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Unknown token.
+        /// </summary>
+        public string? UnknownToken { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to merge the sequence of the unknown tokens together.
+        /// </summary>
+        public bool FuseUnknownTokens { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional prefix to be used for every subword that is not a beginning-of-word token
+        /// </summary>
+        public string? ContinuingSubwordPrefix { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional suffix to characterize the end-of-word and sub-word
+        /// </summary>
+        public string? EndOfWordSuffix { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to handle the input text in byte level.
+        /// if true, the input text will be converted to UTF-8 bytes before encoding it.
+        /// Additionally, some ASCII characters will be transformed to another characters (e.g Space character will be transformed to 'Ġ' character).
+        /// </summary>
+        public bool ByteLevel { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional beginning of sentence token to be used when encoding the input text.
+        /// </summary>
+        /// <remarks>
+        /// When specified, this token will be added to the beginning of the input text before encoding it.
+        /// This is useful for models that require a specific token to indicate the start of a sentence.
+        /// This token should be present in the vocabulary.
+        /// </remarks>
+        public string? BeginningOfSentenceToken { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional end of sentence token to be used when encoding the input text.
+        /// </summary>
+        /// <remarks>
+        /// When specified, this token will be added to the end of the input text before encoding it.
+        /// This is useful for models that require a specific token to indicate the end of a sentence.
+        /// This token should be present in the vocabulary.
+        /// </remarks>
+        public string? EndOfSentenceToken { get; set; }
+    }
+}

--- a/src/Microsoft.ML.Tokenizers/Model/CodeGenTokenizer.cs
+++ b/src/Microsoft.ML.Tokenizers/Model/CodeGenTokenizer.cs
@@ -1263,7 +1263,7 @@ namespace Microsoft.ML.Tokenizers
                     {
                         if (considerSpecialTokens)
                         {
-                            AppendToBytesArray(BeginningOfSentenceToken!.AsSpan(), ref bytes, ref bytesIndex);
+                            Helpers.AppendToBytesArray(BeginningOfSentenceToken!.AsSpan(), ref bytes, ref bytesIndex);
                         }
                         continue;
                     }
@@ -1272,7 +1272,7 @@ namespace Microsoft.ML.Tokenizers
                     {
                         if (considerSpecialTokens)
                         {
-                            AppendToBytesArray(EndOfSentenceToken!.AsSpan(), ref bytes, ref bytesIndex);
+                            Helpers.AppendToBytesArray(EndOfSentenceToken!.AsSpan(), ref bytes, ref bytesIndex);
                         }
                         continue;
                     }
@@ -1281,7 +1281,7 @@ namespace Microsoft.ML.Tokenizers
                     {
                         if (considerSpecialTokens)
                         {
-                            AppendToBytesArray(UnknownToken!.AsSpan(), ref bytes, ref bytesIndex);
+                            Helpers.AppendToBytesArray(UnknownToken!.AsSpan(), ref bytes, ref bytesIndex);
                         }
                         continue;
                     }
@@ -1306,7 +1306,7 @@ namespace Microsoft.ML.Tokenizers
                     {
                         ReadOnlySpan<char> span = firstToken && hasPrefixSpace && s.Length > 0 && s[0] == _transformedSpace ? s.AsSpan(1) : s.AsSpan();
                         firstToken = false;
-                        AppendToBytesArray(span, ref bytes, ref bytesIndex);
+                        Helpers.AppendToBytesArray(span, ref bytes, ref bytesIndex);
                     }
                 }
 
@@ -1562,27 +1562,6 @@ namespace Microsoft.ML.Tokenizers
             }
 
             return null;
-        }
-
-        private void AppendToBytesArray(ReadOnlySpan<char> text, ref byte[] bytes, ref int bytesIndex)
-        {
-            IReadOnlyDictionary<char, char> unicodeToByte = ByteToUnicodeEncoding.Instance.UnicodeToByte;
-            for (int i = 0; i < text.Length; i++)
-            {
-                if (unicodeToByte.TryGetValue(text[i], out char c))
-                {
-                    if (bytesIndex >= bytes.Length)
-                    {
-                        Helpers.ArrayPoolGrow<byte>(ref bytes, bytes.Length * 2);
-                    }
-
-                    bytes[bytesIndex++] = (byte)c;
-                    continue;
-                }
-
-                // rare cases
-                i += Helpers.EncodeCodePointToUtf8(text, i, ref bytes, ref bytesIndex) - 1;
-            }
         }
 
         //

--- a/src/Microsoft.ML.Tokenizers/Model/Word.cs
+++ b/src/Microsoft.ML.Tokenizers/Model/Word.cs
@@ -289,15 +289,31 @@ namespace Microsoft.ML.Tokenizers
             return sb.ToString();
         }
 
-        public void ToTokens(SortedDictionary<int, string> vocabReverse, List<EncodedToken> tokens, int offset)
+        public void ToTokens(SortedDictionary<int, string> vocabReverse, List<EncodedToken> tokens, int offset, ReadOnlySpan<int> mapping)
         {
             int index = 0;
 
-            for (int i = 0; i < SymbolsCount; i++)
+            if (mapping.IsEmpty)
             {
-                int endIndex = index + _symbols[i].Len;
-                tokens.Add(new EncodedToken(_symbols[i].C, vocabReverse[_symbols[i].C], new Range(index + offset, index + offset + _symbols[i].Len)));
-                index += _symbols[i].Len;
+                for (int i = 0; i < SymbolsCount; i++)
+                {
+                    int endIndex = index + _symbols[i].Len;
+                    tokens.Add(new EncodedToken(_symbols[i].C, vocabReverse[_symbols[i].C], new Range(index + offset, index + offset + _symbols[i].Len)));
+                    index += _symbols[i].Len;
+                }
+            }
+            else
+            {
+                for (int i = 0; i < SymbolsCount; i++)
+                {
+                    int endIndex = index + _symbols[i].Len;
+
+                    int mappedIndex = mapping[index];
+                    int mappedEndIndex = mapping[endIndex - 1] + 1;
+
+                    tokens.Add(new EncodedToken(_symbols[i].C, vocabReverse[_symbols[i].C], new Range(mappedIndex + offset, mappedEndIndex + offset)));
+                    index += _symbols[i].Len;
+                }
             }
         }
     }

--- a/src/Microsoft.ML.Tokenizers/PreTokenizer/CompositePreTokenizer.cs
+++ b/src/Microsoft.ML.Tokenizers/PreTokenizer/CompositePreTokenizer.cs
@@ -1,0 +1,214 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.ML.Tokenizers;
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+/// <summary>
+/// CompositePreTokenizer is a pre-tokenizer that applies multiple pre-tokenizers in sequence.
+/// </summary>
+public class CompositePreTokenizer : PreTokenizer
+{
+    private const int MaxPreTokenizersCount = 10;
+    private readonly IReadOnlyList<PreTokenizer> _preTokenizers;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CompositePreTokenizer"/> class.
+    /// </summary>
+    /// <param name="preTokenizers">The list of pre-tokenizers to apply.</param>
+    /// <param name="specialTokens">The special tokens to apply.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="preTokenizers"/> is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="preTokenizers"/> contains null elements.</exception>
+    /// <remarks>
+    /// The <see cref="CompositePreTokenizer"/> can accept a list of pre-tokenizers with a maximum of 10 items.
+    /// </remarks>
+    public CompositePreTokenizer(IReadOnlyList<PreTokenizer> preTokenizers, IReadOnlyDictionary<string, int>? specialTokens = null)
+    {
+        if (preTokenizers is null)
+        {
+            throw new ArgumentNullException(nameof(preTokenizers));
+        }
+
+        // Limit the number of pre-tokenizers to a reasonable amount as we do a recursive calls depending on the number of pre-tokenizers
+        if (preTokenizers.Count > MaxPreTokenizersCount)
+        {
+            throw new ArgumentException($"Too many pre-tokenizers provided. Maximum is {MaxPreTokenizersCount}.", nameof(preTokenizers));
+        }
+
+        foreach (var preTokenizer in preTokenizers)
+        {
+            if (preTokenizer is null)
+            {
+                throw new ArgumentException("Pre-tokenizer cannot be null.", nameof(preTokenizers));
+            }
+        }
+
+        if (specialTokens is { Count: > 0 })
+        {
+            var list = new List<PreTokenizer>(specialTokens.Count + 1);
+
+            list.Add(new RegexPreTokenizer(new Regex(string.Join("|", specialTokens.Keys.Select(s => Regex.Escape(s))), RegexOptions.Compiled), null));
+
+            foreach (var preTokenizer in preTokenizers)
+            {
+                list.Add(preTokenizer);
+            }
+
+            _preTokenizers = list.AsReadOnly();
+        }
+        else
+        {
+            _preTokenizers = preTokenizers;
+        }
+    }
+
+    /// <summary>
+    /// Gets the list of pre-tokenizers.
+    /// </summary>
+    public IReadOnlyList<PreTokenizer> PreTokenizers => _preTokenizers;
+
+    /// <summary>
+    /// Pre-tokenizes the input text using the specified pre-tokenizers.
+    /// </summary>
+    /// <param name="text">The input text to pre-tokenize.</param>
+    /// <returns>The list of pre-tokenized ranges.</returns>
+    public override IEnumerable<(int Offset, int Length)> PreTokenize(string text)
+    {
+        int beginning = 0;
+        foreach ((int Offset, int Length) range in SplitText(text, _preTokenizers, preTokenizerIndex: 0, beginning, text.Length - beginning))
+        {
+            yield return (range.Offset, range.Length);
+            beginning += range.Length;
+        }
+
+        static IEnumerable<(int Offset, int Length)> SplitText(string text, IReadOnlyList<PreTokenizer> preTokenizers, int preTokenizerIndex, int offset, int length)
+        {
+            Debug.Assert(preTokenizerIndex < preTokenizers.Count, "Index out of range for pre-tokenizers.");
+            var preTokenizer = preTokenizers[preTokenizerIndex];
+
+            int beginning = 0; // relative to the offset
+            foreach ((int Offset, int Length) range in preTokenizer.PreTokenize(text.AsSpan(offset, length)))
+            {
+                if (range.Offset > beginning)
+                {
+                    // Recurse for subsequent tokenizers
+                    if (preTokenizerIndex + 1 < preTokenizers.Count)
+                    {
+                        foreach ((int Offset, int Length) subRange in SplitText(text, preTokenizers, preTokenizerIndex + 1, offset + beginning, range.Offset - beginning))
+                        {
+                            yield return subRange;
+                        }
+                    }
+                    else
+                    {
+                        yield return (offset + beginning, range.Offset);
+                    }
+                }
+
+                beginning = range.Offset + range.Length;
+
+                yield return (offset + range.Offset, range.Length);
+            }
+
+            if (beginning < length)
+            {
+                // Handle the remaining of the text
+                if (preTokenizerIndex + 1 < preTokenizers.Count)
+                {
+                    foreach ((int Offset, int Length) subRange in SplitText(text, preTokenizers, preTokenizerIndex + 1, offset + beginning, length - beginning))
+                    {
+                        yield return subRange;
+                    }
+                }
+                else
+                {
+                    yield return (offset + beginning, length);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Pre-tokenizes the input text span using the specified pre-tokenizers.
+    /// </summary>
+    /// <param name="text">The input text span to pre-tokenize.</param>
+    /// <returns>The list of pre-tokenized ranges.</returns>
+    public override IEnumerable<(int Offset, int Length)> PreTokenize(ReadOnlySpan<char> text)
+    {
+        if (text.IsEmpty)
+        {
+            return [];
+        }
+
+        char[] buffer = ArrayPool<char>.Shared.Rent(text.Length);
+        text.CopyTo(buffer);
+
+        IEnumerable<(int Offset, int Length)> result = PreTokenize(buffer, text.Length);
+
+        ArrayPool<char>.Shared.Return(buffer);
+        return result;
+    }
+
+    private IEnumerable<(int Offset, int Length)> PreTokenize(char[] text, int length)
+    {
+        int beginning = 0;
+
+        foreach ((int Offset, int Length) range in SplitText(text, _preTokenizers, preTokenizerIndex: 0, beginning, length - beginning))
+        {
+            yield return (range.Offset, range.Length);
+            beginning += range.Length;
+        }
+
+        static IEnumerable<(int Offset, int Length)> SplitText(char[] text, IReadOnlyList<PreTokenizer> preTokenizers, int preTokenizerIndex, int offset, int length)
+        {
+            Debug.Assert(preTokenizerIndex < preTokenizers.Count, "Index out of range for pre-tokenizers.");
+            var preTokenizer = preTokenizers[preTokenizerIndex];
+
+            int beginning = 0; // relative to the offset
+            foreach ((int Offset, int Length) range in preTokenizer.PreTokenize(text.AsSpan(offset, length)))
+            {
+                if (range.Offset > beginning)
+                {
+                    // Recurse for subsequent tokenizers
+                    if (preTokenizerIndex + 1 < preTokenizers.Count)
+                    {
+                        foreach ((int Offset, int Length) subRange in SplitText(text, preTokenizers, preTokenizerIndex + 1, offset + beginning, range.Offset - beginning))
+                        {
+                            yield return subRange;
+                        }
+                    }
+                    else
+                    {
+                        yield return (offset + beginning, range.Offset);
+                    }
+                }
+
+                beginning = range.Offset + range.Length;
+
+                yield return (offset + range.Offset, range.Length);
+            }
+
+            if (beginning < length)
+            {
+                // Handle the remaining of the text
+                if (preTokenizerIndex + 1 < preTokenizers.Count)
+                {
+                    foreach ((int Offset, int Length) subRange in SplitText(text, preTokenizers, preTokenizerIndex + 1, offset + beginning, length - beginning))
+                    {
+                        yield return subRange;
+                    }
+                }
+                else
+                {
+                    yield return (offset + beginning, length);
+                }
+            }
+        }
+    }
+}

--- a/test/Microsoft.ML.Tokenizers.Tests/BpeTests.cs
+++ b/test/Microsoft.ML.Tokenizers.Tests/BpeTests.cs
@@ -12,8 +12,10 @@ using System.Linq;
 using System.Net;
 using System.Text;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Xunit;
+using static System.Net.Mime.MediaTypeNames;
 
 namespace Microsoft.ML.Tokenizers.Tests
 {
@@ -253,33 +255,8 @@ namespace Microsoft.ML.Tokenizers.Tests
             {
                 BpeTokenizer bpe = BpeTokenizer.Create(vocabFile: vocabFile, mergesFile: mergesFile, preTokenizer: PreTokenizer.CreateWordOrNonWord(), normalizer: null, unknownToken: unknownToken,
                                     continuingSubwordPrefix: continuingSubwordPrefix, endOfWordSuffix: endOfWordSuffix, fuseUnknownTokens: fuseUnknownToken);
-                Tokenizer tokenizer = bpe;
-                IReadOnlyList<EncodedToken> encoding = tokenizer.EncodeToTokens(sentence, out _);
-                int[] encodingIds = encoding.Select(t => t.Id).ToArray();
-                IReadOnlyList<int> idsList = tokenizer.EncodeToIds(sentence);
 
-                Assert.Equal(expectedTokens.Length, encoding.Count);
-                Assert.Equal(offsets.Length, encoding.Count);
-                Assert.Equal(ids.Length, encoding.Count);
-                Assert.Equal(ids.Length, idsList.Count);
-                Assert.Equal(ids.Length, tokenizer.CountTokens(sentence));
-                Assert.Equal(decodedTokens, tokenizer.Decode(encodingIds));
-                Assert.Equal(decodedTokensWithoutUnknownToken, bpe.Decode(encodingIds, considerSpecialTokens: false));
-
-                TestDecodingWithSpan(bpe, encodingIds, considerSpecialTokens: true, decodedTokens);
-                TestDecodingWithSpan(bpe, encodingIds, considerSpecialTokens: false, decodedTokensWithoutUnknownToken);
-
-                var reverseVocabulary = bpe.Vocabulary.ToDictionary(kvp => kvp.Value, kvp => kvp.Key);
-
-                for (int i = 0; i < encoding.Count; i++)
-                {
-                    Assert.Equal(expectedTokens[i], encoding[i].Value);
-                    Assert.Equal(offsets[i], (encoding[i].Offset.Start.Value, encoding[i].Offset.End.Value - encoding[i].Offset.Start.Value));
-                    Assert.Equal(ids[i], encoding[i].Id);
-                    Assert.Equal(ids[i], idsList[i]);
-                    Assert.Equal(encoding[i].Value, reverseVocabulary[encodingIds[i]]);
-                    Assert.Equal(encodingIds[i], bpe.Vocabulary[encoding[i].Value]);
-                }
+                SimpleWithUnknownTokenTest(bpe, sentence, offsets, ids, expectedTokens, decodedTokens, decodedTokensWithoutUnknownToken);
             }
             finally
             {
@@ -288,6 +265,51 @@ namespace Microsoft.ML.Tokenizers.Tests
                 {
                     Utils.DeleteFile(mergesFile);
                 }
+            }
+
+            BpeOptions bpeOptions = new BpeOptions(vocab.Select(kvp => (kvp.Key, kvp.Value)))
+            {
+                Merges = merges?.Select(kvp => $"{kvp.Item1} {kvp.Item2}"),
+                PreTokenizer = PreTokenizer.CreateWordOrNonWord(),
+                Normalizer = null,
+                UnknownToken = unknownToken,
+                ContinuingSubwordPrefix = continuingSubwordPrefix,
+                EndOfWordSuffix = endOfWordSuffix,
+                FuseUnknownTokens = fuseUnknownToken
+            };
+
+            BpeTokenizer bpe1 = BpeTokenizer.Create(bpeOptions);
+            SimpleWithUnknownTokenTest(bpe1, sentence, offsets, ids, expectedTokens, decodedTokens, decodedTokensWithoutUnknownToken);
+        }
+
+        private void SimpleWithUnknownTokenTest(BpeTokenizer bpe, string sentence, (int, int)[] offsets, int[] ids, string[] expectedTokens, string decodedTokens, string decodedTokensWithoutUnknownToken)
+        {
+            Tokenizer tokenizer = bpe;
+            IReadOnlyList<EncodedToken> encoding = tokenizer.EncodeToTokens(sentence, out _);
+            int[] encodingIds = encoding.Select(t => t.Id).ToArray();
+            IReadOnlyList<int> idsList = tokenizer.EncodeToIds(sentence);
+
+            Assert.Equal(expectedTokens.Length, encoding.Count);
+            Assert.Equal(offsets.Length, encoding.Count);
+            Assert.Equal(ids.Length, encoding.Count);
+            Assert.Equal(ids.Length, idsList.Count);
+            Assert.Equal(ids.Length, tokenizer.CountTokens(sentence));
+            Assert.Equal(decodedTokens, tokenizer.Decode(encodingIds));
+            Assert.Equal(decodedTokensWithoutUnknownToken, bpe.Decode(encodingIds, considerSpecialTokens: false));
+
+            TestDecodingWithSpan(bpe, encodingIds, considerSpecialTokens: true, decodedTokens);
+            TestDecodingWithSpan(bpe, encodingIds, considerSpecialTokens: false, decodedTokensWithoutUnknownToken);
+
+            var reverseVocabulary = bpe.Vocabulary.ToDictionary(kvp => kvp.Value, kvp => kvp.Key);
+
+            for (int i = 0; i < encoding.Count; i++)
+            {
+                Assert.Equal(expectedTokens[i], encoding[i].Value);
+                Assert.Equal(offsets[i], (encoding[i].Offset.Start.Value, encoding[i].Offset.End.Value - encoding[i].Offset.Start.Value));
+                Assert.Equal(ids[i], encoding[i].Id);
+                Assert.Equal(ids[i], idsList[i]);
+                Assert.Equal(encoding[i].Value, reverseVocabulary[encodingIds[i]]);
+                Assert.Equal(encodingIds[i], bpe.Vocabulary[encoding[i].Value]);
             }
         }
 
@@ -359,6 +381,17 @@ namespace Microsoft.ML.Tokenizers.Tests
             mergesStream.Position = 0;
 
             bpe = await BpeTokenizer.CreateAsync(vocabStream, mergesStream);
+            ValidateTokenizer(bpe);
+
+            string jsonString = File.ReadAllText(vocabFile);
+            Dictionary<string, int>? dictionary = JsonSerializer.Deserialize<Dictionary<string, int>>(jsonString);
+
+            bpe = BpeTokenizer.Create(
+                new BpeOptions(dictionary!.Select(kvp => (kvp.Key, kvp.Value)))
+                {
+                    Merges = File.ReadAllLines(mergesFile).Skip(1).ToArray() // Skip the first line which is the header "#version".
+                });
+
             ValidateTokenizer(bpe);
         }
 
@@ -557,6 +590,436 @@ namespace Microsoft.ML.Tokenizers.Tests
 
             return BpeTokenizer.Create(
                         vocabStream: emptyVocabStream, mergesStream: null, preTokenizer: preTokenizer ?? PreTokenizer.CreateWordOrNonWord(), normalizer: normalizer, unknownToken: "Ukn");
+        }
+
+        //
+        // DeepSeek tests
+        //
+
+        private static string DumpEncodingTokens(IReadOnlyList<EncodedToken> encoding)
+        {
+            string result = $"[{string.Join(", ", encoding.Select(t => $"{t.Id}"))} ] {Environment.NewLine}";
+            result += $"[{string.Join(", ", encoding.Select(t => $"\"{t.Value}\""))} ] {Environment.NewLine}";
+            result += $"[{string.Join(", ", encoding.Select(t => $"({t.Offset.Start}, {t.Offset.End.Value})"))} ]";
+            return result;
+        }
+
+        public static IEnumerable<object?[]> DeepSeekData
+        {
+            get
+            {
+                // text, ids, tokens, offsets
+                yield return new object?[]
+                {
+                    @"\sqrt{3x-1}+(1+x)^2", // Math expression
+                    new int[] { 0, 52765, 93, 21, 90, 15, 19, 14419, 10, 19, 34705, 21590, 20 },
+                    new string[] { "<｜begin▁of▁sentence｜>", "\\sqrt", "{", "3", "x", "-", "1", "}+", "(", "1", "+x", ")^", "2" },
+                    new (int, int)[] { (0, 0), (0, 5), (5, 6), (6, 7), (7, 8), (8, 9), (9, 10), (10, 12), (12, 13), (13, 14), (14, 16), (16, 18), (18, 19) },
+                };
+
+                yield return new object?[]
+                {
+                    "def add(a, b):\n    return a + b", // Python function
+                    new int[] { 0, 3465, 1258, 6036, 14, 291, 3395, 361, 1354, 260, 940, 291 },
+                    new string[] { "<｜begin▁of▁sentence｜>", "def", "Ġadd", "(a", ",", "Ġb", "):Ċ", "ĠĠĠ", "Ġreturn", "Ġa", "Ġ+", "Ġb" },
+                    new (int, int)[] { (0, 0), (0, 3), (3, 7), (7, 9), (9, 10), (10, 12), (12, 15), (15, 18), (18, 25), (25, 27), (27, 29), (29, 31) },
+                };
+
+                yield return new object?[]
+                {
+                    "function greet(name) {\n    return a + b", // JavaScript function
+                    new int[] { 0, 8701, 49166, 17984, 11, 875, 361, 1354, 260, 940, 291 },
+                    new string[] { "<｜begin▁of▁sentence｜>", "function", "Ġgreet", "(name", ")", "Ġ{Ċ", "ĠĠĠ", "Ġreturn", "Ġa", "Ġ+", "Ġb" },
+                    new (int, int)[] { (0, 0), (0, 8), (8, 14), (14, 19), (19, 20), (20, 23), (23, 26), (26, 33), (33, 35), (35, 37), (37, 39) },
+                };
+
+                yield return new object?[]
+                {
+                    "Hello, how are you?\nBonjour, comment ça va?\n你好，你怎么样？\n", // Multilingual text
+                    new int[] { 0, 19923, 14, 1192, 477, 440, 2755, 52015, 46703, 14, 7006, 65750, 10879, 2755, 30594, 303, 804, 19602, 6692 },
+                    new string[] { "<｜begin▁of▁sentence｜>", "Hello", ",", "Ġhow", "Ġare", "Ġyou", "?Ċ", "Bon", "jour", ",", "Ġcomment", "ĠÃ§a", "Ġva", "?Ċ", "ä½łå¥½", "ï¼Į", "ä½ł", "æĢİä¹Īæł·", "ï¼ŁĊ" },
+                    new (int, int)[] { (0, 0), (0, 5), (5, 6), (6, 10), (10, 14), (14, 18), (18, 20), (20, 23), (23, 27), (27, 28), (28, 36), (36, 39), (39, 42), (42, 44), (44, 46), (46, 47), (47, 48), (48, 51), (51, 53) },
+                };
+
+                yield return new object?[]
+                {
+                    "カタカナ", // Japanese text
+                    new int[] { 0, 15961, 11767, 15961, 27071 },
+                    new string[] { "<｜begin▁of▁sentence｜>", "ãĤ«", "ãĤ¿", "ãĤ«", "ãĥĬ" },
+                    new (int, int)[] { (0, 0), (0, 1), (1, 2), (2, 3), (3, 4) },
+                };
+
+                yield return new object?[]
+                {
+                    "1234567890", // numbers to ensure splitting on 3-digits boundary
+                    new int[] { 0, 6895, 18009, 25744, 18 },
+                    new string[] { "<｜begin▁of▁sentence｜>", "123", "456", "789", "0" },
+                    new (int, int)[] { (0, 0), (0, 3), (3, 6), (6, 9), (9, 10) },
+                };
+
+                yield return new object?[]
+                {
+                    "This is a test 1234567890カタカナ日本語 for us.", // multilingual text with numbers
+                    new int[] { 0, 2337, 344, 260, 1950, 223, 6895, 18009, 25744, 18, 15961, 11767, 15961, 27071, 88768, 362, 550, 16 },
+                    new string[] { "<｜begin▁of▁sentence｜>", "This", "Ġis", "Ġa", "Ġtest", "Ġ", "123", "456", "789", "0", "ãĤ«", "ãĤ¿", "ãĤ«", "ãĥĬ", "æĹ¥æľ¬èªŀ", "Ġfor", "Ġus", "." },
+                    new (int, int)[] { (0, 0), (0, 4), (4, 7), (7, 9), (9, 14), (14, 15), (15, 18), (18, 21), (21, 24), (24, 25), (25, 26), (26, 27), (27, 28), (28, 29), (29, 32), (32, 36), (36, 39), (39, 40) },
+                };
+
+                yield return new object?[]
+                {
+                    // DeepSeek-R1 tutorial example long text
+                    "In modern software development, comprehensive testing remains a critical challenge. This tutorial demonstrates how to combine DeepSeek's intelligence with pytest's testing " +
+                    "framework to generate robust unit tests automatically. Automated Unit Test Generation with DeepSeek-R1 and pytest Environment Configuration Set up your testing environment with " +
+                    "these essential packages: # Install core dependencies !pip install pytest deepseek-ai transformers pytest-cov mock # Verify installation import pytest print(f\"pytest version: " +
+                    "{pytest.version}\") Pro Tip: Create a dedicated virtual environment for testing: python -m venv testenv && source testenv/bin/activate Basic Test Generation Workflow Create a " +
+                    "test generator module: # test_generator.py from transformers import AutoTokenizer, AutoModelForCausalLM class TestGenerator: def init(self): self.tokenizer = " +
+                    "AutoTokenizer.from_pretrained(\"deepseek-ai/deepseek-r1\") self.model = AutoModelForCausalLM.from_pretrained(\"deepseek-ai/deepseek-r1\") " +
+                    "def generate_test(self, function_code: str) -> str: prompt = f \"\"\"Generate pytest unit tests for this Python function: {function_code} \\nFollow these requirements: 1. " +
+                    "Use parameterized testing 2. Include edge cases 3. Add type annotations 4. Include descriptive docstrings\"\"\" inputs = self.tokenizer(prompt, return_tensors= \"pt\") " +
+                    "outputs = self.model.generate(**inputs, max_length= 1024) return self.tokenizer.decode(outputs, skip_special_tokens=True) Testing Sample Application Code Create a simple " +
+                    "calculator module to test: # calculator.py def add(a: float, b: float) -> float: return a + b def subtract(a: float, b: float) -> float: return a - b Generating and Executing " +
+                    "Tests Automate the test lifecycle: # Generate tests generator = TestGenerator() with open (\"calculator.py\") as f: tests = generator.generate_test(f.read()) # Save generated " +
+                    "tests with open (\"test_calculator.py\", \"w\") as f: f.write(tests) # Run tests with pytest !pytest test_calculator.py -v --cov=calculator Advanced Test Patterns Implement " +
+                    "mock testing with AI-generated scenarios: # test_database.py from unittest.mock import Mock import pytest def test_db_connection(): # AI-generated test scenario " +
+                    "mock_db = Mock() mock_db.connect.return_value = True assert mock_db.connect(\"localhost:5432\") is True mock_db.connect.assert_called_once_with(\"localhost:5432\") " +
+                    "CI/CD Integration Add automated testing to GitHub Actions: # .github/workflows/tests.yml name: AI-Powered Tests on: [push] jobs: test: runs-on: ubuntu-latest steps: - " +
+                    "uses: actions/checkout@v3 - name: Set up Python uses: actions/setup-python@v4 with: python-version: '3.10' - name: Install dependencies run: | pip install -r requirements.txt - " +
+                    "name: Generate tests run: python generate_tests.py - name: Run tests run: pytest --cov=src/ --cov-report=xml",
+                    new int[]
+                    {
+                        0, 1124, 5970, 6460, 2934, 14, 10501, 8273, 7926, 260, 6490, 8851, 16, 1162, 24038, 23723, 1192, 304, 20036, 22651, 4374, 1465, 734, 12967, 418, 105659, 734, 8273, 10303, 304,
+                        10559, 16064, 4761, 8499, 15400, 16, 79763, 14749, 6205, 32036, 418, 22651, 4374, 1465, 8555, 19, 305, 105659, 10651, 44894, 8269, 890, 782, 8273, 3431, 418, 1305, 4930, 26607,
+                        28, 1823, 31788, 8668, 38937, 4050, 92530, 6564, 105659, 5212, 121559, 15, 2238, 98918, 105659, 2846, 757, 25330, 1823, 78419, 19544, 1662, 105659, 2777, 5123, 4, 82, 99297,
+                        6013, 28, 680, 82, 99297, 121719, 95, 5925, 1317, 42542, 28, 12722, 260, 14381, 10814, 3431, 362, 8273, 28, 24847, 565, 79, 12487, 88, 1950, 17821, 6546, 4688, 1950, 17821,
+                        32702, 17, 76117, 15824, 6205, 32036, 7194, 10107, 12722, 260, 1950, 23794, 12124, 28, 1823, 1950, 15810, 95223, 23042, 538, 98918, 1662, 22416, 63241, 14, 22416, 8449, 3870,
+                        37, 51935, 39851, 1312, 6205, 46223, 28, 1351, 3447, 6666, 2605, 2280, 99885, 9160, 438, 22416, 63241, 38425, 5224, 2101, 17021, 1698, 60861, 121559, 15, 2238, 41545, 755,
+                        121559, 9954, 19, 5925, 2280, 25824, 438, 22416, 8449, 3870, 37, 51935, 39851, 38425, 5224, 2101, 17021, 1698, 60861, 121559, 15, 2238, 41545, 755, 121559, 9954, 19, 5925,
+                        1351, 10559, 21525, 6666, 14, 2019, 17636, 28, 1691, 11, 6248, 1691, 28, 12275, 438, 285, 26495, 99732, 105659, 4761, 8499, 362, 566, 15255, 2019, 28, 680, 8701, 17636, 95,
+                        874, 80, 20676, 1305, 7172, 28, 223, 19, 16, 6948, 10767, 1766, 8273, 223, 20, 16, 52480, 9449, 4599, 223, 21, 16, 7043, 2613, 71134, 223, 22, 16, 52480, 35984, 3696, 56638, 63356,
+                        21102, 438, 2280, 99885, 9160, 7093, 79078, 14, 1354, 3682, 63248, 31, 582, 529, 5925, 25798, 438, 2280, 25824, 119629, 109464, 111082, 14, 3979, 29079, 31, 223, 5769, 22, 11, 1354,
+                        2280, 99885, 9160, 104065, 61327, 85, 14, 21429, 4731, 43549, 3682, 58878, 19552, 11, 27445, 28454, 13591, 9909, 12722, 260, 4654, 17612, 12124, 304, 1950, 28, 1823, 17612, 23042,
+                        1351, 1258, 6036, 28, 12249, 14, 291, 28, 12249, 11, 6248, 12249, 28, 1354, 260, 940, 291, 1351, 24522, 6036, 28, 12249, 14, 291, 28, 12249, 11, 6248, 12249, 28, 1354, 260, 565,
+                        291, 115825, 305, 14136, 10063, 34291, 23284, 434, 270, 1950, 72487, 28, 1823, 62754, 8499, 23794, 438, 6205, 46223, 1393, 418, 2526, 12951, 77401, 23042, 5925, 412, 285, 28, 8499,
+                        438, 23794, 119629, 21525, 5123, 17627, 14042, 1823, 27473, 9846, 8499, 418, 2526, 12951, 7958, 4941, 50452, 1741, 23042, 1760, 582, 89, 5925, 412, 285, 28, 285, 26214, 4665, 7333,
+                        11, 1823, 19633, 8499, 418, 105659, 4050, 82, 99297, 1950, 4941, 50452, 1741, 23042, 565, 88, 3820, 83671, 31, 77401, 21555, 6205, 49885, 23639, 25330, 8273, 418, 7703, 38762, 21805,
+                        28, 1823, 1950, 4084, 11444, 23042, 538, 82332, 100170, 1662, 51705, 1662, 105659, 1351, 1950, 77563, 65, 30000, 24590, 1823, 7703, 38762, 1950, 18553, 25330, 77563, 438, 51705, 1393,
+                        25330, 77563, 80383, 16, 3916, 23028, 438, 11485, 8719, 25330, 77563, 80383, 1698, 38017, 28, 25498, 20, 5925, 344, 11485, 25330, 77563, 80383, 21498, 4941, 10546, 72710, 29784, 1698,
+                        38017, 28, 25498, 20, 5925, 19415, 100949, 36845, 7043, 27818, 8273, 304, 56720, 31817, 28, 1823, 1204, 14765, 124907, 44672, 9543, 7333, 105169, 2329, 28, 7703, 6351, 99434, 34291,
+                        377, 28, 764, 38312, 63, 11193, 28, 1950, 28, 12122, 8909, 28, 21342, 37094, 2800, 66469, 6531, 28, 565, 6623, 28, 8102, 17, 9547, 606, 34, 88, 21, 565, 2329, 28, 8269, 890, 15255, 6623,
+                        28, 8102, 2283, 319, 1425, 3095, 8150, 34, 88, 22, 418, 28, 24847, 15, 9713, 28, 905, 21, 16, 553, 9, 565, 2329, 28, 31788, 38937, 2632, 28, 369, 14220, 6564, 565, 84, 7172, 16415, 565,
+                        2329, 28, 62754, 8499, 2632, 28, 24847, 10559, 3682, 7333, 23042, 565, 2329, 28, 19633, 8499, 2632, 28, 105659, 3820, 83671, 31, 24483, 17, 3820, 83671, 77002, 33577, 3957
+                    },
+                    new string[]
+                    {
+                        "<｜begin▁of▁sentence｜>", "In", "Ġmodern", "Ġsoftware", "Ġdevelopment", ",", "Ġcomprehensive", "Ġtesting", "Ġremains", "Ġa", "Ġcritical", "Ġchallenge", ".", "ĠThis",
+                        "Ġtutorial", "Ġdemonstrates", "Ġhow", "Ġto", "Ġcombine", "ĠDeep", "Se", "ek", "'s", "Ġintelligence", "Ġwith", "Ġpytest", "'s", "Ġtesting", "Ġframework", "Ġto",
+                        "Ġgenerate", "Ġrobust", "Ġunit", "Ġtests", "Ġautomatically", ".", "ĠAutomated", "ĠUnit", "ĠTest", "ĠGeneration", "Ġwith", "ĠDeep", "Se", "ek", "-R", "1", "Ġand",
+                        "Ġpytest", "ĠEnvironment", "ĠConfiguration", "ĠSet", "Ġup", "Ġyour", "Ġtesting", "Ġenvironment", "Ġwith", "Ġthese", "Ġessential", "Ġpackages", ":", "Ġ#", "ĠInstall",
+                        "Ġcore", "Ġdependencies", "Ġ!", "pip", "Ġinstall", "Ġpytest", "Ġdeep", "seek", "-", "ai", "Ġtransformers", "Ġpytest", "-c", "ov", "Ġmock", "Ġ#", "ĠVerify", "Ġinstallation",
+                        "Ġimport", "Ġpytest", "Ġprint", "(f", "\"", "p", "ytest", "Ġversion", ":", "Ġ{", "p", "ytest", ".version", "}", "\")", "ĠPro", "ĠTip", ":", "ĠCreate", "Ġa", "Ġdedicated",
+                        "Ġvirtual", "Ġenvironment", "Ġfor", "Ġtesting", ":", "Ġpython", "Ġ-", "m", "Ġven", "v", "Ġtest", "env", "Ġ&&", "Ġsource", "Ġtest", "env", "/bin", "/", "activate", "ĠBasic",
+                        "ĠTest", "ĠGeneration", "ĠWork", "flow", "ĠCreate", "Ġa", "Ġtest", "Ġgenerator", "Ġmodule", ":", "Ġ#", "Ġtest", "_g", "enerator", ".py", "Ġfrom", "Ġtransformers", "Ġimport",
+                        "ĠAuto", "Tokenizer", ",", "ĠAuto", "Model", "For", "C", "ausal", "LM", "Ġclass", "ĠTest", "Generator", ":", "Ġdef", "Ġinit", "(self", "):", "Ġself", ".token", "izer", "Ġ=",
+                        "ĠAuto", "Tokenizer", ".from", "_p", "ret", "rained", "(\"", "deep", "seek", "-", "ai", "/de", "ep", "seek", "-r", "1", "\")", "Ġself", ".model", "Ġ=", "ĠAuto", "Model", "For",
+                        "C", "ausal", "LM", ".from", "_p", "ret", "rained", "(\"", "deep", "seek", "-", "ai", "/de", "ep", "seek", "-r", "1", "\")", "Ġdef", "Ġgenerate", "_test", "(self", ",",
+                        "Ġfunction", "_code", ":", "Ġstr", ")", "Ġ->", "Ġstr", ":", "Ġprompt", "Ġ=", "Ġf", "Ġ\"\"\"", "Generate", "Ġpytest", "Ġunit", "Ġtests", "Ġfor", "Ġthis", "ĠPython", "Ġfunction",
+                        ":", "Ġ{", "function", "_code", "}", "Ġ\\", "n", "Follow", "Ġthese", "Ġrequirements", ":", "Ġ", "1", ".", "ĠUse", "Ġparameter", "ized", "Ġtesting", "Ġ", "2", ".", "ĠInclude",
+                        "Ġedge", "Ġcases", "Ġ", "3", ".", "ĠAdd", "Ġtype", "Ġannotations", "Ġ", "4", ".", "ĠInclude", "Ġdescriptive", "Ġdoc", "strings", "\"\"\"", "Ġinputs", "Ġ=", "Ġself", ".token",
+                        "izer", "(p", "rompt", ",", "Ġreturn", "_t", "ensors", "=", "Ġ\"", "pt", "\")", "Ġoutputs", "Ġ=", "Ġself", ".model", ".generate", "(**", "inputs", ",", "Ġmax", "_length",
+                        "=", "Ġ", "102", "4", ")", "Ġreturn", "Ġself", ".token", "izer", ".decode", "(output", "s", ",", "Ġskip", "_s", "pecial", "_t", "okens", "=True", ")", "ĠTesting", "ĠSample",
+                        "ĠApplication", "ĠCode", "ĠCreate", "Ġa", "Ġsimple", "Ġcalculator", "Ġmodule", "Ġto", "Ġtest", ":", "Ġ#", "Ġcalculator", ".py", "Ġdef", "Ġadd", "(a", ":", "Ġfloat", ",",
+                        "Ġb", ":", "Ġfloat", ")", "Ġ->", "Ġfloat", ":", "Ġreturn", "Ġa", "Ġ+", "Ġb", "Ġdef", "Ġsubtract", "(a", ":", "Ġfloat", ",", "Ġb", ":", "Ġfloat", ")", "Ġ->", "Ġfloat", ":",
+                        "Ġreturn", "Ġa", "Ġ-", "Ġb", "ĠGenerating", "Ġand", "ĠExec", "uting", "ĠTests", "ĠAutom", "ate", "Ġthe", "Ġtest", "Ġlifecycle", ":", "Ġ#", "ĠGenerate", "Ġtests", "Ġgenerator",
+                        "Ġ=", "ĠTest", "Generator", "()", "Ġwith", "Ġopen", "Ġ(\"", "calculator", ".py", "\")", "Ġas", "Ġf", ":", "Ġtests", "Ġ=", "Ġgenerator", ".generate", "_test", "(f", ".read", "())",
+                        "Ġ#", "ĠSave", "Ġgenerated", "Ġtests", "Ġwith", "Ġopen", "Ġ(\"", "test", "_c", "alcul", "ator", ".py", "\",", "Ġ\"", "w", "\")", "Ġas", "Ġf", ":", "Ġf", ".write", "(t", "ests", ")",
+                        "Ġ#", "ĠRun", "Ġtests", "Ġwith", "Ġpytest", "Ġ!", "p", "ytest", "Ġtest", "_c", "alcul", "ator", ".py", "Ġ-", "v", "Ġ--", "cov", "=", "calculator", "ĠAdvanced", "ĠTest", "ĠPatterns",
+                        "ĠImplement", "Ġmock", "Ġtesting", "Ġwith", "ĠAI", "-generated", "Ġscenarios", ":", "Ġ#", "Ġtest", "_d", "atabase", ".py", "Ġfrom", "Ġunittest", ".mock", "Ġimport", "ĠMock",
+                        "Ġimport", "Ġpytest", "Ġdef", "Ġtest", "_db", "_", "connection", "():", "Ġ#", "ĠAI", "-generated", "Ġtest", "Ġscenario", "Ġmock", "_db", "Ġ=", "ĠMock", "()", "Ġmock", "_db",
+                        ".connect", ".", "return", "_value", "Ġ=", "ĠTrue", "Ġassert", "Ġmock", "_db", ".connect", "(\"", "localhost", ":", "543", "2", "\")", "Ġis", "ĠTrue", "Ġmock", "_db", ".connect",
+                        ".assert", "_c", "alled", "_once", "_with", "(\"", "localhost", ":", "543", "2", "\")", "ĠCI", "/CD", "ĠIntegration", "ĠAdd", "Ġautomated", "Ġtesting", "Ġto", "ĠGitHub", "ĠActions",
+                        ":", "Ġ#", "Ġ.", "github", "/work", "flows", "/t", "ests", ".yml", "Ġname", ":", "ĠAI", "-P", "owered", "ĠTests", "Ġon", ":", "Ġ[", "push", "]", "Ġjobs", ":", "Ġtest", ":", "Ġruns",
+                        "-on", ":", "Ġub", "untu", "-l", "atest", "Ġsteps", ":", "Ġ-", "Ġuses", ":", "Ġactions", "/", "check", "out", "@", "v", "3", "Ġ-", "Ġname", ":", "ĠSet", "Ġup", "ĠPython", "Ġuses",
+                        ":", "Ġactions", "/s", "et", "up", "-p", "ython", "@", "v", "4", "Ġwith", ":", "Ġpython", "-", "version", ":", "Ġ'", "3", ".", "10", "'", "Ġ-", "Ġname", ":", "ĠInstall",
+                        "Ġdependencies", "Ġrun", ":", "Ġ|", "Ġpip", "Ġinstall", "Ġ-", "r", "Ġrequirements", ".txt", "Ġ-", "Ġname", ":", "ĠGenerate", "Ġtests", "Ġrun", ":", "Ġpython", "Ġgenerate", "_t",
+                        "ests", ".py", "Ġ-", "Ġname", ":", "ĠRun", "Ġtests", "Ġrun", ":", "Ġpytest", "Ġ--", "cov", "=", "src", "/", "Ġ--", "cov", "-report", "=x", "ml"
+                    },
+                    new (int, int)[]
+                    {
+                        (0, 0), (0, 2), (2, 9), (9, 18), (18, 30), (30, 31), (31, 45), (45, 53), (53, 61), (61, 63), (63, 72), (72, 82), (82, 83), (83, 88), (88, 97), (97, 110), (110, 114), (114, 117),
+                        (117, 125), (125, 130), (130, 132), (132, 134), (134, 136), (136, 149), (149, 154), (154, 161), (161, 163), (163, 171), (171, 181), (181, 184), (184, 193), (193, 200), (200, 205),
+                        (205, 211), (211, 225), (225, 226), (226, 236), (236, 241), (241, 246), (246, 257), (257, 262), (262, 267), (267, 269), (269, 271), (271, 273), (273, 274), (274, 278), (278, 285),
+                        (285, 297), (297, 311), (311, 315), (315, 318), (318, 323), (323, 331), (331, 343), (343, 348), (348, 354), (354, 364), (364, 373), (373, 374), (374, 376), (376, 384), (384, 389),
+                        (389, 402), (402, 404), (404, 407), (407, 415), (415, 422), (422, 427), (427, 431), (431, 432), (432, 434), (434, 447), (447, 454), (454, 456), (456, 458), (458, 463), (463, 465),
+                        (465, 472), (472, 485), (485, 492), (492, 499), (499, 505), (505, 507), (507, 508), (508, 509), (509, 514), (514, 522), (522, 523), (523, 525), (525, 526), (526, 531), (531, 539),
+                        (539, 540), (540, 542), (542, 546), (546, 550), (550, 551), (551, 558), (558, 560), (560, 570), (570, 578), (578, 590), (590, 594), (594, 602), (602, 603), (603, 610), (610, 612),
+                        (612, 613), (613, 617), (617, 618), (618, 623), (623, 626), (626, 629), (629, 636), (636, 641), (641, 644), (644, 648), (648, 649), (649, 657), (657, 663), (663, 668), (668, 679),
+                        (679, 684), (684, 688), (688, 695), (695, 697), (697, 702), (702, 712), (712, 719), (719, 720), (720, 722), (722, 727), (727, 729), (729, 737), (737, 740), (740, 745), (745, 758),
+                        (758, 765), (765, 770), (770, 779), (779, 780), (780, 785), (785, 790), (790, 793), (793, 794), (794, 799), (799, 801), (801, 807), (807, 812), (812, 821), (821, 822), (822, 826),
+                        (826, 831), (831, 836), (836, 838), (838, 843), (843, 849), (849, 853), (853, 855), (855, 860), (860, 869), (869, 874), (874, 876), (876, 879), (879, 885), (885, 887), (887, 891),
+                        (891, 895), (895, 896), (896, 898), (898, 901), (901, 903), (903, 907), (907, 909), (909, 910), (910, 912), (912, 917), (917, 923), (923, 925), (925, 930), (930, 935), (935, 938),
+                        (938, 939), (939, 944), (944, 946), (946, 951), (951, 953), (953, 956), (956, 962), (962, 964), (964, 968), (968, 972), (972, 973), (973, 975), (975, 978), (978, 980), (980, 984),
+                        (984, 986), (986, 987), (987, 989), (989, 993), (993, 1002), (1002, 1007), (1007, 1012), (1012, 1013), (1013, 1022), (1022, 1027), (1027, 1028), (1028, 1032), (1032, 1033),
+                        (1033, 1036), (1036, 1040), (1040, 1041), (1041, 1048), (1048, 1050), (1050, 1052), (1052, 1056), (1056, 1064), (1064, 1071), (1071, 1076), (1076, 1082), (1082, 1086), (1086, 1091),
+                        (1091, 1098), (1098, 1107), (1107, 1108), (1108, 1110), (1110, 1118), (1118, 1123), (1123, 1124), (1124, 1126), (1126, 1127), (1127, 1133), (1133, 1139), (1139, 1152), (1152, 1153),
+                        (1153, 1154), (1154, 1155), (1155, 1156), (1156, 1160), (1160, 1170), (1170, 1174), (1174, 1182), (1182, 1183), (1183, 1184), (1184, 1185), (1185, 1193), (1193, 1198), (1198, 1204),
+                        (1204, 1205), (1205, 1206), (1206, 1207), (1207, 1211), (1211, 1216), (1216, 1228), (1228, 1229), (1229, 1230), (1230, 1231), (1231, 1239), (1239, 1251), (1251, 1255), (1255, 1262),
+                        (1262, 1265), (1265, 1272), (1272, 1274), (1274, 1279), (1279, 1285), (1285, 1289), (1289, 1291), (1291, 1296), (1296, 1297), (1297, 1304), (1304, 1306), (1306, 1312), (1312, 1313),
+                        (1313, 1315), (1315, 1317), (1317, 1319), (1319, 1327), (1327, 1329), (1329, 1334), (1334, 1340), (1340, 1349), (1349, 1352), (1352, 1358), (1358, 1359), (1359, 1363), (1363, 1370),
+                        (1370, 1371), (1371, 1372), (1372, 1375), (1375, 1376), (1376, 1377), (1377, 1384), (1384, 1389), (1389, 1395), (1395, 1399), (1399, 1406), (1406, 1413), (1413, 1414), (1414, 1415),
+                        (1415, 1420), (1420, 1422), (1422, 1428), (1428, 1430), (1430, 1435), (1435, 1440), (1440, 1441), (1441, 1449), (1449, 1456), (1456, 1468), (1468, 1473), (1473, 1480), (1480, 1482),
+                        (1482, 1489), (1489, 1500), (1500, 1507), (1507, 1510), (1510, 1515), (1515, 1516), (1516, 1518), (1518, 1529), (1529, 1532), (1532, 1536), (1536, 1540), (1540, 1542), (1542, 1543),
+                        (1543, 1549), (1549, 1550), (1550, 1552), (1552, 1553), (1553, 1559), (1559, 1560), (1560, 1563), (1563, 1569), (1569, 1570), (1570, 1577), (1577, 1579), (1579, 1581), (1581, 1583),
+                        (1583, 1587), (1587, 1596), (1596, 1598), (1598, 1599), (1599, 1605), (1605, 1606), (1606, 1608), (1608, 1609), (1609, 1615), (1615, 1616), (1616, 1619), (1619, 1625), (1625, 1626),
+                        (1626, 1633), (1633, 1635), (1635, 1637), (1637, 1639), (1639, 1650), (1650, 1654), (1654, 1659), (1659, 1664), (1664, 1670), (1670, 1676), (1676, 1679), (1679, 1683), (1683, 1688),
+                        (1688, 1698), (1698, 1699), (1699, 1701), (1701, 1710), (1710, 1716), (1716, 1726), (1726, 1728), (1728, 1733), (1733, 1742), (1742, 1744), (1744, 1749), (1749, 1754), (1754, 1757),
+                        (1757, 1767), (1767, 1770), (1770, 1772), (1772, 1775), (1775, 1777), (1777, 1778), (1778, 1784), (1784, 1786), (1786, 1796), (1796, 1805), (1805, 1810), (1810, 1812), (1812, 1817),
+                        (1817, 1820), (1820, 1822), (1822, 1827), (1827, 1837), (1837, 1843), (1843, 1848), (1848, 1853), (1853, 1856), (1856, 1860), (1860, 1862), (1862, 1867), (1867, 1871), (1871, 1874),
+                        (1874, 1876), (1876, 1878), (1878, 1879), (1879, 1881), (1881, 1884), (1884, 1886), (1886, 1887), (1887, 1889), (1889, 1895), (1895, 1897), (1897, 1901), (1901, 1902), (1902, 1904),
+                        (1904, 1908), (1908, 1914), (1914, 1919), (1919, 1926), (1926, 1928), (1928, 1929), (1929, 1934), (1934, 1939), (1939, 1941), (1941, 1946), (1946, 1950), (1950, 1953), (1953, 1955),
+                        (1955, 1956), (1956, 1959), (1959, 1962), (1962, 1963), (1963, 1973), (1973, 1982), (1982, 1987), (1987, 1996), (1996, 2006), (2006, 2011), (2011, 2019), (2019, 2024), (2024, 2027),
+                        (2027, 2037), (2037, 2047), (2047, 2048), (2048, 2050), (2050, 2055), (2055, 2057), (2057, 2064), (2064, 2067), (2067, 2072), (2072, 2081), (2081, 2086), (2086, 2093), (2093, 2098),
+                        (2098, 2105), (2105, 2112), (2112, 2116), (2116, 2121), (2121, 2124), (2124, 2125), (2125, 2135), (2135, 2138), (2138, 2140), (2140, 2143), (2143, 2153), (2153, 2158), (2158, 2167),
+                        (2167, 2172), (2172, 2175), (2175, 2177), (2177, 2182), (2182, 2184), (2184, 2189), (2189, 2192), (2192, 2200), (2200, 2201), (2201, 2207), (2207, 2213), (2213, 2215), (2215, 2220),
+                        (2220, 2227), (2227, 2232), (2232, 2235), (2235, 2243), (2243, 2245), (2245, 2254), (2254, 2255), (2255, 2258), (2258, 2259), (2259, 2261), (2261, 2264), (2264, 2269), (2269, 2274),
+                        (2274, 2277), (2277, 2285), (2285, 2292), (2292, 2294), (2294, 2299), (2299, 2304), (2304, 2309), (2309, 2311), (2311, 2320), (2320, 2321), (2321, 2324), (2324, 2325), (2325, 2327),
+                        (2327, 2330), (2330, 2333), (2333, 2345), (2345, 2349), (2349, 2359), (2359, 2367), (2367, 2370), (2370, 2377), (2377, 2385), (2385, 2386), (2386, 2388), (2388, 2390), (2390, 2396),
+                        (2396, 2401), (2401, 2406), (2406, 2408), (2408, 2412), (2412, 2416), (2416, 2421), (2421, 2422), (2422, 2425), (2425, 2427), (2427, 2433), (2433, 2439), (2439, 2442), (2442, 2443),
+                        (2443, 2445), (2445, 2449), (2449, 2450), (2450, 2455), (2455, 2456), (2456, 2461), (2461, 2462), (2462, 2467), (2467, 2470), (2470, 2471), (2471, 2474), (2474, 2478), (2478, 2480),
+                        (2480, 2485), (2485, 2491), (2491, 2492), (2492, 2494), (2494, 2499), (2499, 2500), (2500, 2508), (2508, 2509), (2509, 2514), (2514, 2517), (2517, 2518), (2518, 2519), (2519, 2520),
+                        (2520, 2522), (2522, 2527), (2527, 2528), (2528, 2532), (2532, 2535), (2535, 2542), (2542, 2547), (2547, 2548), (2548, 2556), (2556, 2558), (2558, 2560), (2560, 2562), (2562, 2564),
+                        (2564, 2569), (2569, 2570), (2570, 2571), (2571, 2572), (2572, 2577), (2577, 2578), (2578, 2585), (2585, 2586), (2586, 2593), (2593, 2594), (2594, 2596), (2596, 2597), (2597, 2598),
+                        (2598, 2600), (2600, 2601), (2601, 2603), (2603, 2608), (2608, 2609), (2609, 2617), (2617, 2630), (2630, 2634), (2634, 2635), (2635, 2637), (2637, 2641), (2641, 2649), (2649, 2651),
+                        (2651, 2652), (2652, 2665), (2665, 2669), (2669, 2671), (2671, 2676), (2676, 2677), (2677, 2686), (2686, 2692), (2692, 2696), (2696, 2697), (2697, 2704), (2704, 2713), (2713, 2715),
+                        (2715, 2719), (2719, 2722), (2722, 2724), (2724, 2729), (2729, 2730), (2730, 2734), (2734, 2740), (2740, 2744), (2744, 2745), (2745, 2752), (2752, 2755), (2755, 2758), (2758, 2759),
+                        (2759, 2762), (2762, 2763), (2763, 2766), (2766, 2769), (2769, 2776), (2776, 2778), (2778, 2780)
+                    },
+                };
+            }
+        }
+
+        private static BpeTokenizer _deepSeekR1Tokenizer = CreateBpeTokenizerFromJson();
+        private static IReadOnlyDictionary<int, string> _vocabReverse = _deepSeekR1Tokenizer.Vocabulary.ToDictionary(kvp => kvp.Value, kvp => kvp.Key);
+
+        [Theory]
+        [MemberData(nameof(DeepSeekData))]
+        public void TestDeepSeekR1Tokenizer(string text, int[] ids, string[] tokens, (int, int)[] offsets)
+        {
+            BpeTokenizer tokenizer = _deepSeekR1Tokenizer;
+            IReadOnlyList<EncodedToken> encoding = tokenizer.EncodeToTokens(text, out _);
+
+            Assert.Equal(ids, encoding.Select(t => t.Id).ToArray());
+            Assert.Equal(tokens, encoding.Select(t => t.Value).ToArray());
+            Assert.Equal(offsets, encoding.Select(t => (t.Offset.Start.Value, t.Offset.End.Value)).ToArray());
+            Assert.Equal(ids, tokenizer.EncodeToIds(text));
+            Assert.Equal(ids.Count(), tokenizer.CountTokens(text));
+
+            for (int i = 1; i < encoding.Count; i++)
+            {
+                IReadOnlyList<int> subIds = tokenizer.EncodeToIds(text, maxTokenCount: i, out _, out int charConsumed);
+                Assert.Equal(i, subIds.Count);
+                Assert.Equal(ids.Take(i), subIds);
+
+                int index = tokenizer.GetIndexByTokenCount(text, i, out _, out int tokenCount);
+                Assert.Equal(encoding[i].Offset.Start.Value, index);
+                Assert.Equal(i, tokenCount);
+                index = tokenizer.GetIndexByTokenCountFromEnd(text, i, out _, out tokenCount);
+                Assert.Equal(encoding[encoding.Count - i].Offset.Start.Value, index);
+                Assert.Equal(i, tokenCount);
+            }
+
+            int beginningOfSentenceId = ids[0];
+            Assert.True(_vocabReverse.TryGetValue(beginningOfSentenceId, out string? beginningOfSentenceToken));
+            Assert.Equal(beginningOfSentenceToken + text, tokenizer.Decode(ids));
+            Assert.Equal(text, tokenizer.Decode(ids, considerSpecialTokens: false));
+
+            char[] destinationBuffer = new char[beginningOfSentenceToken.Length + text.Length];
+            Assert.Equal(OperationStatus.Done, tokenizer.Decode(ids, destinationBuffer.AsSpan(), considerSpecialTokens: true, out int idsConsumed, out int charsWritten));
+            Assert.Equal(beginningOfSentenceToken + text, destinationBuffer.AsSpan(0, charsWritten).ToString());
+            Assert.Equal(ids.Length, idsConsumed);
+            Assert.Equal(OperationStatus.Done, tokenizer.Decode(ids, destinationBuffer.AsSpan(), considerSpecialTokens: false, out idsConsumed, out charsWritten));
+            Assert.Equal(text, destinationBuffer.AsSpan(0, charsWritten).ToString());
+            Assert.Equal(ids.Length, idsConsumed);
+            Assert.Equal(OperationStatus.DestinationTooSmall, tokenizer.Decode(ids, destinationBuffer.AsSpan(0, text.Length - 1), considerSpecialTokens: false, out idsConsumed, out charsWritten));
+            Assert.True(idsConsumed < ids.Length);
+            Assert.True(charsWritten < text.Length);
+            Assert.Equal(OperationStatus.DestinationTooSmall, tokenizer.Decode(ids, destinationBuffer.AsSpan(0, text.Length), considerSpecialTokens: true, out idsConsumed, out charsWritten));
+            Assert.True(idsConsumed < ids.Length);
+            Assert.True(charsWritten <= text.Length);
+
+            //
+            // Test special tokens
+            //
+
+            string thinkStartSpecialToken = "<think>";
+            string thinkEndSpecialToken = "<think>";
+            Assert.NotNull(tokenizer.SpecialTokens);
+            Assert.True(tokenizer.SpecialTokens.TryGetValue(thinkStartSpecialToken, out int thinkStartId));
+            Assert.True(tokenizer.SpecialTokens.TryGetValue(thinkEndSpecialToken, out int thinkEndId));
+
+            string textWithSpecialTokens = $"{thinkStartSpecialToken}{text}{thinkEndSpecialToken}";
+            encoding = tokenizer.EncodeToTokens(textWithSpecialTokens, out _);
+            ids = encoding.Select(e => e.Id).ToArray();
+            Assert.Equal(ids, tokenizer.EncodeToIds(textWithSpecialTokens));
+
+            Assert.Equal(beginningOfSentenceId, encoding[0].Id);
+            Assert.Equal(thinkStartId, encoding[1].Id);
+            Assert.Equal(thinkEndId, encoding[^1].Id);
+            Assert.Equal(beginningOfSentenceToken, encoding[0].Value);
+            Assert.Equal(thinkStartSpecialToken, encoding[1].Value);
+            Assert.Equal(thinkEndSpecialToken, encoding[^1].Value);
+
+            Assert.Equal(beginningOfSentenceToken + textWithSpecialTokens, tokenizer.Decode(ids));
+            Assert.Equal(text, tokenizer.Decode(ids, considerSpecialTokens: false));
+        }
+
+        private static BpeTokenizer CreateBpeTokenizerFromJson()
+        {
+            // @"https://huggingface.co/deepseek-ai/DeepSeek-R1/resolve/main/tokenizer.json?download=true"
+            using Stream jsonModelStream = File.OpenRead(Path.Combine(@"DeepSeek", "tokenizer-DeepSeek-R1.json"));
+            using var reader = new StreamReader(jsonModelStream, Encoding.UTF8);
+            string json = reader.ReadToEnd();
+
+            using JsonDocument doc = JsonDocument.Parse(json);
+            JsonElement root = doc.RootElement;
+            if (!root.TryGetProperty("model", out JsonElement modelElement) ||
+                modelElement.ValueKind != JsonValueKind.Object ||
+                !modelElement.TryGetProperty("type", out JsonElement typeElement) ||
+                !"BPE".Equals(typeElement.GetString(), StringComparison.OrdinalIgnoreCase) ||
+                !modelElement.TryGetProperty("vocab", out JsonElement vocabElement) ||
+                vocabElement.ValueKind != JsonValueKind.Object)
+            {
+                throw new InvalidOperationException("Invalid model format");
+            }
+
+            BpeOptions bpeOptions = new BpeOptions(GetVocabulary(vocabElement));
+
+            if (modelElement.TryGetProperty("unk_token", out JsonElement unKnownElement))
+            {
+                bpeOptions.UnknownToken = unKnownElement.GetString();
+            }
+
+            if (modelElement.TryGetProperty("continuing_subword_prefix", out JsonElement continuingSubwordPrefixElement))
+            {
+                bpeOptions.ContinuingSubwordPrefix = continuingSubwordPrefixElement.GetString();
+            }
+
+            if (modelElement.TryGetProperty("end_of_word_suffix", out JsonElement endOfWordSuffixElement))
+            {
+                bpeOptions.EndOfWordSuffix = endOfWordSuffixElement.GetString();
+            }
+
+            if (modelElement.TryGetProperty("fuse_unknown_tokens", out JsonElement fuseUnknownTokensElement))
+            {
+                bpeOptions.FuseUnknownTokens = fuseUnknownTokensElement.GetBoolean();
+            }
+
+            bpeOptions.SpecialTokens = GetSpecialTokens(root);
+            bpeOptions.Merges = GetMerges(modelElement);
+            IReadOnlyList<PreTokenizer>? preTokenizers = GetPreTokenizer(root, out bool byteLevel);
+            bpeOptions.ByteLevel = byteLevel;
+
+            if (preTokenizers is not null)
+            {
+                bpeOptions.PreTokenizer = new CompositePreTokenizer(preTokenizers, bpeOptions.SpecialTokens);
+            }
+
+            bpeOptions.BeginningOfSentenceToken = "<｜begin▁of▁sentence｜>";
+
+            return BpeTokenizer.Create(bpeOptions);
+        }
+
+        private static IEnumerable<(string Token, int Id)> GetVocabulary(JsonElement vocabElement)
+        {
+            foreach (JsonProperty token in vocabElement.EnumerateObject())
+            {
+                yield return (token.Name, token.Value.GetInt32());
+            }
+        }
+
+        private static IEnumerable<string> GetMerges(JsonElement modelElement)
+        {
+            if (modelElement.TryGetProperty("merges", out JsonElement mergesElement) && mergesElement.ValueKind == JsonValueKind.Array)
+            {
+                foreach (JsonElement merge in mergesElement.EnumerateArray())
+                {
+                    if (merge.ValueKind == JsonValueKind.String)
+                    {
+                        yield return merge.GetString()!;
+                    }
+                }
+            }
+        }
+
+        internal const int DefaultTimeOutInMilliseconds = 30_000;
+
+        private static IReadOnlyList<PreTokenizer>? GetPreTokenizer(JsonElement root, out bool byteLevel)
+        {
+            byteLevel = false;
+            List<PreTokenizer> preTokenizers = new List<PreTokenizer>();
+
+            if (root.TryGetProperty("pre_tokenizer", out JsonElement preTokenizerElement) &&
+                preTokenizerElement.ValueKind == JsonValueKind.Object &&
+                preTokenizerElement.TryGetProperty("type", out JsonElement typeElement) &&
+                typeElement.ValueKind == JsonValueKind.String &&
+                "Sequence".Equals(typeElement.GetString(), StringComparison.OrdinalIgnoreCase) &&
+                preTokenizerElement.TryGetProperty("pretokenizers", out JsonElement preTokenizersElement) &&
+                preTokenizersElement.ValueKind == JsonValueKind.Array)
+            {
+                foreach (JsonElement preTokenizer in preTokenizersElement.EnumerateArray())
+                {
+                    if (preTokenizer.ValueKind == JsonValueKind.Object &&
+                        preTokenizer.TryGetProperty("type", out JsonElement preTokenizerTypeElement) &&
+                        preTokenizerTypeElement.ValueKind == JsonValueKind.String)
+                    {
+                        string preTokenizerType = preTokenizerTypeElement.GetString()!;
+                        if ("Split".Equals(preTokenizerType, StringComparison.OrdinalIgnoreCase))
+                        {
+                            if (preTokenizer.TryGetProperty("pattern", out JsonElement patternElement) &&
+                                patternElement.ValueKind == JsonValueKind.Object &&
+                                patternElement.TryGetProperty("Regex", out JsonElement regexElement) &&
+                                regexElement.ValueKind == JsonValueKind.String)
+                            {
+                                string pattern = regexElement.GetString()!;
+
+                                preTokenizers.Add(new RegexPreTokenizer(new Regex(pattern, RegexOptions.Compiled, TimeSpan.FromMilliseconds(DefaultTimeOutInMilliseconds)), null));
+                            }
+                        }
+                        else if ("ByteLevel".Equals(preTokenizerType, StringComparison.OrdinalIgnoreCase))
+                        {
+                            byteLevel = true;
+                        }
+                    }
+                }
+
+                return preTokenizers;
+            }
+
+            return null;
+        }
+
+        private static Dictionary<string, int>? GetSpecialTokens(JsonElement root)
+        {
+            if (root.TryGetProperty("added_tokens", out JsonElement modelElement) && modelElement.ValueKind == JsonValueKind.Array)
+            {
+                Dictionary<string, int> specialTokens = new Dictionary<string, int>();
+                foreach (JsonElement token in modelElement.EnumerateArray())
+                {
+                    if (token.TryGetProperty("content", out JsonElement contentElement) &&
+                        contentElement.ValueKind == JsonValueKind.String &&
+                        token.TryGetProperty("id", out JsonElement idElement) && idElement.ValueKind == JsonValueKind.Number)
+                    {
+                        string content = contentElement.GetString()!;
+                        if (content is not null && !content.StartsWith("<｜place▁holder", StringComparison.OrdinalIgnoreCase))
+                        {
+                            specialTokens[content] = idElement.GetInt32();
+                        }
+                    }
+                }
+
+                return specialTokens;
+            }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
This change includes:  

- Adding support for **ByteLevel encoding** in the BPE tokenizer.  
- Introducing a new `BpeTokenizer.Create` method that allows creating a tokenizer using the newly introduced `BpeOptions` type. This enables users to obtain tokenizer data from various sources (e.g., `tokenizer.json` files) and instantiate the tokenizer using this new factory method.  
- Expanding test coverage to validate ByteLevel support.  
- Adding a test that loads the real [tokenizer.json](https://huggingface.co/deepseek-ai/DeepSeek-R1/blob/main/tokenizer.json) for the **DeepSeek R1** model and verifies its functionality. Since the DeepSeek tokenizer utilizes ByteLevel encoding, it serves as an ideal test case for this feature.  
- Providing test code for loading `tokenizer.json`, which can be used as a template for loading other models' tokenizers when needed.
- Introducing the CompositePreTokenizer to support the DeepSeek pre-tokenization scenario.