### PR TITLE
Fix incorrect IntPtr null check in FftUtils

### DIFF
--- a/src/Microsoft.ML.TimeSeries/FftUtils.cs
+++ b/src/Microsoft.ML.TimeSeries/FftUtils.cs
@@ -248,7 +248,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
             }
             finally
             {
-                if (descriptor != null)
+                if (descriptor != IntPtr.Zero)
                     FreeDescriptor(ref descriptor);
             }
         }
@@ -294,7 +294,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
             }
             finally
             {
-                if (descriptor != null)
+                if (descriptor != IntPtr.Zero)
                     FreeDescriptor(ref descriptor);
             }
 
@@ -350,7 +350,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
             }
             finally
             {
-                if (descriptor != null)
+                if (descriptor != IntPtr.Zero)
                     FreeDescriptor(ref descriptor);
             }
         }
@@ -396,7 +396,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
             }
             finally
             {
-                if (descriptor != null)
+                if (descriptor != IntPtr.Zero)
                     FreeDescriptor(ref descriptor);
             }
 


### PR DESCRIPTION
Caught by prototype CodeQL rule.

We should not compare an IntPtr value to null since it will always result as _not equal_. We should compare to `IntPtr.Zero` instead.