### PR TITLE
Enable dependabot.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Configure regular dependency updates
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Configure dependabot for public dependency updates.  This will help this repo stay up to date with public dependencies.

We'll still need to review dependency PRs, and mirror packages to our feeds, but this will help ensure we stay up to date.