### PR TITLE
Fix PositiveRecall optimization in AutoMLExperiment

### DIFF
--- a/src/Microsoft.ML.AutoML/AutoMLExperiment/IMetricManager.cs
+++ b/src/Microsoft.ML.AutoML/AutoMLExperiment/IMetricManager.cs
@@ -63,7 +63,7 @@ namespace Microsoft.ML.AutoML
                 BinaryClassificationMetric.PositivePrecision => metric.PositivePrecision,
                 BinaryClassificationMetric.NegativePrecision => metric.NegativePrecision,
                 BinaryClassificationMetric.NegativeRecall => metric.NegativeRecall,
-                BinaryClassificationMetric.PositiveRecall => metric.PositivePrecision,
+                BinaryClassificationMetric.PositiveRecall => metric.PositiveRecall,
                 BinaryClassificationMetric.F1Score => metric.F1Score,
                 _ => throw new NotImplementedException(),
             };


### PR DESCRIPTION
BinaryClassificationMetric.PositiveRecall incorrectly returns PositivePrecision.

I noticed this when testing an early stopping pipeline and found that the logged best trial metric did not align with the final model results. This is a self-evident fix (akin to a small typo), so I did not open a new issue for it.

- [x] There's a descriptive title that will make sense to other developers some time from now. 
- [ ] There's associated issues. All PR's should have issue(s) associated - unless a trivial self-evident change such as fixing a typo. You can use the format `Fixes #nnnn` in your description to cause GitHub to automatically close the issue(s) when your PR is merged.
- [x] Your change description explains what the change does, why you chose your approach, and anything else that reviewers should know.
- [ ] You have included any necessary tests in the same PR.