### PR TITLE
Added NumberOfLeaves to FastForestRegression and FastForestOva options

### DIFF
--- a/src/Microsoft.ML.AutoML/SweepableEstimator/Estimators/FastForest.cs
+++ b/src/Microsoft.ML.AutoML/SweepableEstimator/Estimators/FastForest.cs
@@ -13,6 +13,7 @@ namespace Microsoft.ML.AutoML.CodeGen
             var option = new FastForestBinaryTrainer.Options()
             {
                 NumberOfTrees = param.NumberOfTrees,
+                NumberOfLeaves = param.NumberOfLeaves,
                 LabelColumnName = param.LabelColumnName,
                 FeatureColumnName = param.FeatureColumnName,
                 ExampleWeightColumnName = param.ExampleWeightColumnName,
@@ -31,6 +32,7 @@ namespace Microsoft.ML.AutoML.CodeGen
             var option = new FastForestRegressionTrainer.Options()
             {
                 NumberOfTrees = param.NumberOfTrees,
+                NumberOfLeaves = param.NumberOfLeaves,
                 FeatureFraction = param.FeatureFraction,
                 LabelColumnName = param.LabelColumnName,
                 FeatureColumnName = param.FeatureColumnName,


### PR DESCRIPTION
`Fixes #7498`

The NumberOfLeaves hyperparameter was not updating in FastForest AutoML experiments for regression and multiclass classification tasks (see regression example in the associated issue, which was trained on the California Housing [dataset](https://www.kaggle.com/datasets/camnugent/california-housing-prices) and optimizing for root mean squared error).

Consequently, the trial parameters reported via an experiment monitor's final ReportBestTrial() method were not aligning with the actual model produced by the experiment. Additionally, model performance was hurt due to the static hyperparameter constraint.

- [x] There's a descriptive title that will make sense to other developers some time from now. 
- [x] There's associated issues. All PR's should have issue(s) associated - unless a trivial self-evident change such as fixing a typo. You can use the format `Fixes #nnnn` in your description to cause GitHub to automatically close the issue(s) when your PR is merged.
- [x] Your change description explains what the change does, why you chose your approach, and anything else that reviewers should know.
- [ ] You have included any necessary tests in the same PR.
