### PR TITLE
macOS: Only build OneDalNative when oneDAL headers & libs are configured (fixes macOS x64 build)

### DIFF
--- a/src/Native/CMakeLists.txt
+++ b/src/Native/CMakeLists.txt
@@ -262,14 +262,25 @@ if(NOT ${ARCHITECTURE} MATCHES "arm.*")
     add_subdirectory(SymSgdNative)
   endif()
 
+# Build OneDalNative only when explicitly configured with oneDAL headers & libs.
+# This avoids failing builds on platforms (e.g., macOS) where a oneDAL "devel"
+# package is not available via NuGet and no ONEDAL_* paths are provided.
 if(${ARCHITECTURE} MATCHES "[xX].*64")
-  add_subdirectory(OneDalNative)
+  if(DEFINED ONEDAL_DEVEL_PATH AND DEFINED ONEDAL_REDIST_PATH)
+    if(EXISTS "${ONEDAL_DEVEL_PATH}/include/daal.h")
+      add_subdirectory(OneDalNative)
+    else()
+      message(STATUS "Skipping OneDalNative: ${ONEDAL_DEVEL_PATH}/include/daal.h not found")
+    endif()
+  else()
+    message(STATUS "Skipping OneDalNative: ONEDAL_DEVEL_PATH/ONEDAL_REDIST_PATH not set")
+  endif()
 else()
   if (DEFINED ONEDAL_DEVEL_PATH)
-    message("Path to OneDal library defined [${ONEDAL_DEVEL_PATH}] but it is not being built on this arch.")
+    message(STATUS "Path to oneDAL defined [${ONEDAL_DEVEL_PATH}] but not built on this arch.")
   endif()
   if (DEFINED MKL_LIB_PATH)
-    message("Path to Intel MKL library defined [${MKL_LIB_PATH}] but it is not being built on this arch.")
+    message(STATUS "Path to Intel MKL defined [${MKL_LIB_PATH}] but not built on this arch.")
   endif()
 endif()
 


### PR DESCRIPTION
# macOS: Only build OneDalNative when oneDAL headers & libs are configured (fixes macOS x64 build)

**Problem**
On macOS x64, building `src/Native` fails with:
```
fatal error: 'daal.h' file not found
```
The oneDAL “devel” (headers) package is not available via NuGet for `osx-x64`, so locally `ONEDAL_DEVEL_PATH` is not present and `OneDalNative` cannot compile. Today the native CMake unconditionally includes `OneDalNative` on x64, which makes a default macOS developer build fail.

**What this PR changes**
- Gate `add_subdirectory(OneDalNative)` behind explicit configuration:
  - Only include `OneDalNative` when both `ONEDAL_DEVEL_PATH` and `ONEDAL_REDIST_PATH` are defined **and** `${ONEDAL_DEVEL_PATH}/include/daal.h` exists.
  - Otherwise, print an informative `message(STATUS ...)` and skip `OneDalNative`.

**Why this is safe**
- Windows/Linux CI builds that pass `ONEDAL_*` continue to build `OneDalNative` unchanged.
- macOS builds (where oneDAL headers aren’t available via NuGet by default) no longer fail—they build the rest of the native components and skip `OneDalNative`.
- No changes to `build.sh` are required. The script already sets `-DONEDAL_*` only when callers pass the corresponding command-line switches.

**Repro (before)**
```
# macOS x64 without oneDAL headers
cmake ... && make
# -> OneDalNative/OneDalAlgorithms.cpp: fatal error: 'daal.h' file not found
```

**Behavior (after)**
- If `ONEDAL_*` not provided: CMake prints `Skipping OneDalNative: ONEDAL_DEVEL_PATH/ONEDAL_REDIST_PATH not set` and the rest builds fine.
- If `ONEDAL_*` provided and `${ONEDAL_DEVEL_PATH}/include/daal.h` exists: `OneDalNative` builds as before.

**Test matrix**
- ✅ macOS x64 (Intel): builds successfully; `OneDalNative` skipped by default; other native targets build.
- ✅ macOS arm64 (Apple Silicon): previously didn’t include `OneDalNative` (arch guard); behavior unchanged.
- ✅ Linux/Windows (CI): when `ONEDAL_*` are set (as in existing pipelines), behavior unchanged and `OneDalNative` builds.

**Notes**
- This PR intentionally doesn’t alter OpenMP handling or `SymSgdNative`. On macOS x64, developers who need `SymSgdNative` can use Homebrew LLVM (`brew install llvm libomp`) or provide appropriate OpenMP flags; that is orthogonal to oneDAL headers availability.
- We can later add an explicit `-DMLNET_BUILD_ONEDAL=ON/OFF` flag for stricter control if maintainers prefer.