### PR TITLE
BpeTokenizer Cleanup

### DIFF
--- a/src/Microsoft.ML.Tokenizers/Model/BPETokenizer.cs
+++ b/src/Microsoft.ML.Tokenizers/Model/BPETokenizer.cs
@@ -320,7 +320,7 @@ namespace Microsoft.ML.Tokenizers
 
             if (beginningOfSentenceToken is not null)
             {
-                if (!_vocab.TryGetValue(beginningOfSentenceToken, out int aId) && (specialTokens is null || !specialTokens.TryGetValue(beginningOfSentenceToken, out aId)))
+                if (_vocab.TryGetValue(beginningOfSentenceToken, out int aId) is false && specialTokens?.TryGetValue(beginningOfSentenceToken, out aId) is false)
                 {
                     throw new InvalidOperationException($"The beginning of sentence token '{beginningOfSentenceToken}' was not present in the vocabulary.");
                 }
@@ -331,7 +331,7 @@ namespace Microsoft.ML.Tokenizers
 
             if (endOfSentenceToken is not null)
             {
-                if (!_vocab.TryGetValue(endOfSentenceToken, out int aId) && (specialTokens is null || !specialTokens.TryGetValue(endOfSentenceToken, out aId)))
+                if (_vocab.TryGetValue(endOfSentenceToken, out int aId) is false && specialTokens?.TryGetValue(endOfSentenceToken, out aId) is false)
                 {
                     throw new InvalidOperationException($"The end of sentence token '{endOfSentenceToken}' was not present in the vocabulary.");
                 }

--- a/test/Microsoft.ML.Tokenizers.Tests/BpeTests.cs
+++ b/test/Microsoft.ML.Tokenizers.Tests/BpeTests.cs
@@ -885,6 +885,66 @@ namespace Microsoft.ML.Tokenizers.Tests
             Assert.Equal(text, tokenizer.Decode(ids, considerSpecialTokens: false));
         }
 
+        [Fact]
+        public void TestTokenizerWithSpecialTokens()
+        {
+            // "https://huggingface.co/openai-community/gpt2/raw/main/vocab.json";
+            // "https://huggingface.co/openai-community/gpt2/raw/main/merges.txt";
+
+            BpeOptions options = new BpeOptions(Path.Combine(@"Gpt-2", "vocab.json"), Path.Combine(@"Gpt-2", "merges.txt"))
+            {
+                UnknownToken = "unk",
+
+                SpecialTokens = new Dictionary<string, int> // SpecialTokens not part of the original vocab.json
+                {
+                    { "<|sos|>", 50257 },
+                    { "<|eos|>", 50258 }
+                },
+                BeginningOfSentenceToken = "<|sos|>",
+                EndOfSentenceToken = "<|eos|>"
+            };
+
+            BpeTokenizer bpeTokenizer = BpeTokenizer.Create(options);
+            Assert.True(bpeTokenizer.Vocabulary.TryGetValue(options.UnknownToken, out int unkId));
+
+            string text = "Hello world!\uD800";
+
+            var ids = bpeTokenizer.EncodeToIds(text, considerPreTokenization: false);
+            Assert.Equal([50257, 15496, 2954, 6894, 0, 2954, 50258], ids); // space and u+D800 couldn't be encoded and produced unk tokens
+            Assert.Equal(unkId, ids[ids.Count - 2]);
+            Assert.Equal(options.SpecialTokens["<|sos|>"], ids[0]);
+            Assert.Equal(options.SpecialTokens["<|eos|>"], ids[^1]);
+
+            var tokens = bpeTokenizer.EncodeToTokens(text, out _, considerPreTokenization: false).Select(t => t.Value).ToArray();
+            Assert.Equal(["<|sos|>", "Hello", "unk", "world", "!", "unk", "<|eos|>"], tokens);
+
+            Assert.Equal("<|sos|>Hellounkworld!unk<|eos|>", bpeTokenizer.Decode(ids));
+            Assert.Equal("Helloworld!", bpeTokenizer.Decode(ids, considerSpecialTokens: false));
+
+            BpeOptions options1 = new BpeOptions(options.Vocabulary)
+            {
+                // Null UnknownToken means no unknown token support
+                Merges = options.Merges,
+                SpecialTokens = options.SpecialTokens,
+                BeginningOfSentenceToken = options.BeginningOfSentenceToken,
+                EndOfSentenceToken = options.EndOfSentenceToken
+            };
+
+            bpeTokenizer = BpeTokenizer.Create(options1);
+            ids = bpeTokenizer.EncodeToIds(text, considerPreTokenization: false);
+
+            // Because Unknown is not supported in this encoding, the encoding will produce different encoding results
+            Assert.Equal([50257, 39, 5037, 1764, 0, 50258], ids);
+            Assert.Equal(options.SpecialTokens["<|sos|>"], ids[0]);
+            Assert.Equal(options.SpecialTokens["<|eos|>"], ids[^1]);
+
+            tokens = bpeTokenizer.EncodeToTokens(text, out _, considerPreTokenization: false).Select(t => t.Value).ToArray();
+            Assert.Equal(["<|sos|>", "H", "ellow", "orld", "!", "<|eos|>"], tokens);
+
+            Assert.Equal("<|sos|>Helloworld!<|eos|>", bpeTokenizer.Decode(ids));
+            Assert.Equal("Helloworld!", bpeTokenizer.Decode(ids, considerSpecialTokens: false));
+        }
+
         private static BpeTokenizer CreateBpeTokenizerFromJson()
         {
             // @"https://huggingface.co/deepseek-ai/DeepSeek-R1/resolve/main/tokenizer.json?download=true"


### PR DESCRIPTION
This change is a simple clean-up for the BPE tokenizer:

* Adds support for `BeginningOfSentenceToken` and `EndOfSentenceToken` when these tokens are not present in the vocabulary but are instead provided as special tokens by the tokenizer.
* Simplifies the implementation of the `Decode` method.