### PR TITLE
Improve native build and mark our official build as CFS Clean

### DIFF
--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -56,6 +56,8 @@ extends:
         enabled: true
       tsa:
         enabled: true
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean
     pool:
       name: $(DncEngInternalBuildPool)
       image: $(WindowsImage)

--- a/src/Native/CMakeLists.txt
+++ b/src/Native/CMakeLists.txt
@@ -13,6 +13,9 @@ set(RESOURCES)
 # Include 'bin/obj' dir since it contains _version.h
 include_directories("$ENV{__IntermediatesDir}")
 
+# Define path to native source link file
+set(NATIVE_SOURCELINK_FILE_PATH "$ENV{__IntermediatesDir}/native.sourcelink.json")
+
 if(WIN32)
     add_definitions(-DWIN32)
     add_definitions(-D_WIN32=1)
@@ -22,11 +25,9 @@ if(WIN32)
     endif()
     add_compile_options($<$<CONFIG:Debug>:-DDEBUG>)
     add_compile_options($<$<CONFIG:Release>:-DNDEBUG>)
-    add_compile_options($<$<CONFIG:RelWithDebInfo>:-DNDEBUG>)
     add_compile_options($<$<CONFIG:Debug>:/Od>)
     add_compile_options($<$<CONFIG:Debug>:/MTd>) # /MT will static link the VC runtime library, so it doesn't need to be installed on the target machine
     add_compile_options($<$<CONFIG:Release>:/MT>)
-    add_compile_options($<$<CONFIG:RelWithDebInfo>:/MT>)
     add_compile_options(/guard:cf)
     add_compile_options(/Zo) # make optimized builds debugging easier. /Zo is the newer documented flag.
     add_compile_options(/nologo) # Suppress Startup Banner
@@ -41,6 +42,11 @@ if(WIN32)
     add_compile_options(/Zc:inline)
     add_compile_options(/fp:precise)
     add_compile_options(/EHsc)
+    add_compile_options(/Brepro)
+    add_compile_options(/d1nodatetime)
+    add_compile_options(/experimental:deterministic)
+    add_compile_options(/GL)
+    add_compile_options(/d2CastGuardFailureMode:fastfail)
 
     # From here below are warnings required to be explicitly enabled.
     add_compile_options(/w34242)
@@ -62,8 +68,14 @@ if(WIN32)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /DEBUG /PDBCOMPRESS")
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /STACK:1572864")
 
-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /guard:cf")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /guard:cf")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /guard:cf /Brepro")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /guard:cf /Brepro")
+
+    # Enable native source link if the source link file exists
+    if(EXISTS ${NATIVE_SOURCELINK_FILE_PATH})
+        set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /sourcelink:${NATIVE_SOURCELINK_FILE_PATH}")
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /sourcelink:${NATIVE_SOURCELINK_FILE_PATH}")
+    endif(EXISTS ${NATIVE_SOURCELINK_FILE_PATH})
 
     # Debug build specific flags
     set(CMAKE_SHARED_LINKER_FLAGS_DEBUG "/NOVCFEATURE")
@@ -71,18 +83,12 @@ if(WIN32)
     set(CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG} /NODEFAULTLIB:vcompd.lib /DEFAULTLIB:vcomp.lib")
 
     # Release build specific flags
-    set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} /DEBUG /OPT:REF /OPT:ICF")
-    set(CMAKE_STATIC_LINKER_FLAGS_RELEASE "${CMAKE_STATIC_LINKER_FLAGS_RELEASE} /DEBUG /OPT:REF /OPT:ICF")
-    set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /DEBUG /OPT:REF /OPT:ICF")
+    set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} /DEBUG /OPT:REF /OPT:ICF /LTCG")
+    set(CMAKE_STATIC_LINKER_FLAGS_RELEASE "${CMAKE_STATIC_LINKER_FLAGS_RELEASE} /DEBUG /OPT:REF /OPT:ICF /LTCG")
+    set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /DEBUG /OPT:REF /OPT:ICF /LTCG")
     set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} /NODEFAULTLIB:libucrt.lib /DEFAULTLIB:ucrt.lib")
     set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /NODEFAULTLIB:libucrt.lib /DEFAULTLIB:ucrt.lib")
 
-    # RelWithDebInfo specific flags
-    set(CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO} /DEBUG /OPT:REF /OPT:ICF")
-    set(CMAKE_STATIC_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_STATIC_LINKER_FLAGS_RELWITHDEBINFO} /DEBUG /OPT:REF /OPT:ICF")
-    set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO} /DEBUG /OPT:REF /OPT:ICF")
-    set(CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO} /NODEFAULTLIB:libucrt.lib /DEFAULTLIB:ucrt.lib")
-    set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO} /NODEFAULTLIB:libucrt.lib /DEFAULTLIB:ucrt.lib")
     list(APPEND RESOURCES $ENV{__IntermediatesDir}/NativeVersion.rc)
 else()
     add_compile_options(-Wno-unused-local-typedef)

--- a/src/Native/Native.proj
+++ b/src/Native/Native.proj
@@ -48,6 +48,7 @@
   <PropertyGroup  Condition="'$(OS)' == 'Windows_NT'">
     <GenerateNativeVersionInfo>true</GenerateNativeVersionInfo>
     <NativeVersionFile>$(IntermediateOutputPath)_version.h</NativeVersionFile>
+    <NativeSourceLinkFile>$(IntermediateOutputPath)native.sourcelink.json</NativeSourceLinkFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
@@ -120,7 +121,7 @@
 
   <Target Name="BuildNativeWindows"
           Condition="'$(OS)' == 'Windows_NT'"
-          DependsOnTargets="GenerateNativeVersionFile">
+          DependsOnTargets="GenerateNativeVersionFile;GenerateNativeSourcelinkFile">
 
     <PropertyGroup>
       <BuildArgs>$(Configuration) $(TargetArchitecture) --mkllibpath $(NuGetPackageRoot)mlnetmkldeps\$(MlNetMklDepsVersion)\runtimes\$(PackageRid)\native</BuildArgs>
@@ -246,6 +247,15 @@
     <Copy SourceFiles="@(NativePackageAsset)"
           DestinationFolder="$(PackageAssetsPath)%(NativePackageAsset.RelativePath)" />
 
+  </Target>
+
+  <Target Name="GenerateNativeSourcelinkFile"
+          DependsOnTargets="GenerateSourceLinkFile"
+          Condition="'$(DisableSourceLink)' != 'true' and '$(OS)' == 'Windows_NT'"
+          Inputs="$(SourceLink)"
+          Outputs="$(NativeSourceLinkFile)">
+    <Error Condition="'$(SourceLink)' == ''" Text="Please set SourceLink to forward appropriate information for sourcelink."/>
+    <Copy SourceFiles="$(SourceLink)" DestinationFiles="$(NativeSourceLinkFile)" />
   </Target>
 
   <Target Name="Pack" />

--- a/src/Native/build.cmd
+++ b/src/Native/build.cmd
@@ -3,10 +3,12 @@ setlocal
 
 :: Store current script directory before %~dp0 gets affected by another process later.
 set __currentScriptDir=%~dp0
+set "__currentScriptDir=%__currentScriptDir:~0,-1%"
+
 
 :SetupArgs
 :: Initialize the args that will be passed to cmake
-set __rootDir=%__currentScriptDir%..\..
+set __rootDir=%__currentScriptDir%\..\..
 set __artifactsDir=%__rootDir%\artifacts
 set __binDir=%__artifactsDir%\bin
 set __objDir=%__artifactsDir%\obj
@@ -51,7 +53,9 @@ set "VSCMD_START_DIR=%__currentScriptDir%"
 call "%_VSCOMNTOOLS%\VsDevCmd.bat"
 
 :RunVCVars
-if "%VisualStudioVersion%"=="17.0" (
+if "%VisualStudioVersion%"=="18.0" (
+    goto :VS2026
+) else if "%VisualStudioVersion%"=="17.0" (
     goto :VS2022
 ) else if "%VisualStudioVersion%"=="16.0" (
     goto :VS2019
@@ -66,6 +70,14 @@ if "%VisualStudioVersion%"=="17.0" (
 echo Error: Visual Studio 2015, 2017, 2019, or 2022 required
 echo        Please see https://github.com/dotnet/machinelearning/tree/main/Documentation for build instructions.
 exit /b 1
+
+:VS2026
+:: Setup vars for VS2026
+set __PlatformToolset=v145
+set __VSVersion=18 2026
+:: Set the environment for the native build
+call "%VS180COMNTOOLS%..\..\VC\Auxiliary\Build\vcvarsall.bat" %__VCBuildArch%
+goto :SetupDirs
 
 :VS2022
 :: Setup vars for VS2022

--- a/src/Native/gen-buildsys-win.bat
+++ b/src/Native/gen-buildsys-win.bat
@@ -30,6 +30,7 @@ if /i "%3" == "x64"     (set __ExtraCmakeParams=%__ExtraCmakeParams% -A x64)
 if /i "%3" == "x86"     (set __ExtraCmakeParams=%__ExtraCmakeParams% -A Win32)
 if /i "%3" == "arm64"     (set __ExtraCmakeParams=%__ExtraCmakeParams% -A arm64)
 if /i "%3" == "arm"     (set __ExtraCmakeParams=%__ExtraCmakeParams% -A arm)
+echo "%CMakePath%" "-DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE%" "-DCMAKE_INSTALL_PREFIX=%__CMakeBinDir%" "-DMKL_LIB_PATH=%MKL_LIB_PATH%" "-DONEDAL_DEVEL_PATH=%ONEDAL_DEVEL_PATH%" "-DONETBB_DEVEL_PATH=%ONETBB_DEVEL_PATH%" "-DARCHITECTURE=%3" -G "Visual Studio %__VSString%" %__ExtraCmakeParams% -B. -H%1
 "%CMakePath%" "-DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE%" "-DCMAKE_INSTALL_PREFIX=%__CMakeBinDir%" "-DMKL_LIB_PATH=%MKL_LIB_PATH%" "-DONEDAL_DEVEL_PATH=%ONEDAL_DEVEL_PATH%" "-DONETBB_DEVEL_PATH=%ONETBB_DEVEL_PATH%" "-DARCHITECTURE=%3" -G "Visual Studio %__VSString%" %__ExtraCmakeParams% -B. -H%1
 endlocal
 GOTO :DONE


### PR DESCRIPTION
The CFS Clean marking will prevent our build from accessing public packaging endpoints (like NuGet.org, myget.org, etc).
See https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-build/cloudbuild/resolving-cfs-s360-items

The other settings are just various native toolchain improvements like deterministic build, source linking, etc.  I also enabled the repo to build with Dev18 while I was at it.
