### PR TITLE
Use arcade script for installing MacOS dependencies

### DIFF
--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -68,7 +68,7 @@ jobs:
     # Extra MacOS step required to install OS-specific dependencies
     - ${{ if contains(parameters.pool.vmImage, 'macOS')  }}:
       - script: |
-          brew update
+          $(Build.SourcesDirectory)/eng/common/native/install-dependencies.sh osx
           brew install libomp
           brew link libomp --force
         displayName: Install MacOS build dependencies

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -143,7 +143,7 @@ extends:
             ArtifactName: pkgassets
         steps:
         - script: |
-            brew update
+            $(Build.SourcesDirectory)/eng/common/native/install-dependencies.sh osx
             brew install libomp
             brew link libomp --force
           displayName: Install build dependencies
@@ -165,7 +165,7 @@ extends:
             ArtifactName: pkgassets
         steps:
         - script:  |
-            brew update
+            $(Build.SourcesDirectory)/eng/common/native/install-dependencies.sh osx
             brew install libomp
             brew link libomp --force
           displayName: Install build dependencies


### PR DESCRIPTION
Building on MacOS was taking an additional 30+ minutes as it built dependencies like CMake, OpenSSL, etc from source.

Leverage the common script for installing dependencies used by runtime and other dotnet repos.