### PR TITLE
Update MajorVersion to 6

### DIFF
--- a/eng/BranchInfo.props
+++ b/eng/BranchInfo.props
@@ -28,7 +28,7 @@
     <IsStableProject Condition="'$(StableProjects.IndexOf($(_NormalizedStableProjectName), StringComparison.OrdinalIgnoreCase))' != '-1'">true</IsStableProject>
   </PropertyGroup>
   <PropertyGroup Condition="'$(IsStableProject)' == 'true'">
-    <MajorVersion>5</MajorVersion>
+    <MajorVersion>6</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <!-- Set baseline version for stable packages to check for API Compat -->
@@ -36,7 +36,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(IsStableProject)' != 'true'">
     <MajorVersion>0</MajorVersion>
-    <MinorVersion>23</MinorVersion>
+    <MinorVersion>24</MinorVersion>
     <PatchVersion>0</PatchVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
APICompat will fail until we publish a 5.0.0 build.

For reference see - https://github.com/dotnet/machinelearning/commit/d4bc05db154b1e3c8513e52b9c476f83b49d4048
