### PR TITLE
Fix local build on linux that was omiting arch argument

### DIFF
--- a/src/Native/build.sh
+++ b/src/Native/build.sh
@@ -23,7 +23,7 @@ done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 RootRepo="$DIR/../.."
 
-__build_arch=
+__build_arch=x64
 __strip_argument=
 __configuration=Debug
 __rootBinPath="$RootRepo/artifacts/bin"


### PR DESCRIPTION
For comparison see Windows build defaults:
https://github.com/dotnet/machinelearning/blob/0a7a0291fc04e4356dab25c614c43fad524b8e9f/src/Native/build.cmd#L17
