### PR TITLE
Update macOS Helix queues from decommissioned OSX.13 to osx.15

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -124,7 +124,7 @@ jobs:
     innerLoop: true
     pool:
       vmImage: macOS-15
-    helixQueue: OSX.13.Amd64.Open
+    helixQueue: osx.15.amd64.open
 
 - template: /build/ci/job-template.yml
   parameters:
@@ -145,7 +145,7 @@ jobs:
     innerLoop: true
     pool:
       vmImage: macOS-15
-    helixQueue: OSX.13.Arm64.Open
+    helixQueue: osx.15.arm64.open
 
 - template: /build/ci/job-template.yml
   parameters:


### PR DESCRIPTION
## Summary

The `OSX.13.Amd64.Open` and `OSX.13.Arm64.Open` Helix queues have been decommissioned and are no longer available in the Helix API. This causes **all macOS CI jobs** to fail with:

```
Helix API does not contain an entry for OSX.13.Arm64.Open
```

This failure affects both `main` and all open PRs (e.g., #7582).

## Changes

Updated `.vsts-dotnet-ci.yml`:
- `OSX.13.Amd64.Open` → `osx.15.amd64.open` (MacOS_x64 job)
- `OSX.13.Arm64.Open` → `osx.15.arm64.open` (MacOS_cross_arm64 job)

## Why osx.15?

- The build agents already use `vmImage: macOS-15`, so testing on macOS 15 is consistent
- `osx.15.amd64.open` and `osx.15.arm64.open` are confirmed available on [helix.dot.net](https://helix.dot.net/#Test-External-macOS)
- `osx.14` would also work but there's no benefit to testing on an older OS than the build agent
