### PR TITLE
Enable SymSgdNative on arm64 via system BLAS

### DIFF
--- a/src/Native/CMakeLists.txt
+++ b/src/Native/CMakeLists.txt
@@ -265,9 +265,11 @@ if(NOT ${ARCHITECTURE} MATCHES "arm.*")
     add_subdirectory(CpuMathNative)
     add_subdirectory(FastTreeNative)
     add_subdirectory(MklProxyNative)
-    # TODO: once we fix the 4 intel MKL methods, SymSgdNative will need to go back in.
     add_subdirectory(SymSgdNative)
-  endif()
+else()
+    add_subdirectory(MklImportsArm)
+    add_subdirectory(SymSgdNative)
+endif()
 
 if(${ARCHITECTURE} MATCHES "[xX].*64")
   add_subdirectory(OneDalNative)

--- a/src/Native/MklImportsArm/CMakeLists.txt
+++ b/src/Native/MklImportsArm/CMakeLists.txt
@@ -1,0 +1,24 @@
+project(MklImportsArm)
+
+# On ARM platforms, Intel MKL is not available. This target provides
+# a compatible libMklImports.so backed by the system BLAS (typically
+# OpenBLAS) with stubs for MKL-specific sparse BLAS and FFT functions.
+
+find_package(BLAS REQUIRED)
+
+set(SOURCES
+    MklImportsArm.c
+)
+
+if(NOT WIN32)
+    list(APPEND SOURCES ${VERSION_FILE_PATH})
+    SET(CMAKE_SKIP_BUILD_RPATH  FALSE)
+    SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+    SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+    SET(CMAKE_INSTALL_RPATH "$ORIGIN/")
+endif()
+
+add_library(MklImports SHARED ${SOURCES} ${RESOURCES})
+target_link_libraries(MklImports PUBLIC ${BLAS_LIBRARIES})
+
+install_library_and_symbols(MklImports)

--- a/src/Native/MklImportsArm/MklImportsArm.c
+++ b/src/Native/MklImportsArm/MklImportsArm.c
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// ARM replacement for Intel MKL (libMklImports.so).
+//
+// Standard CBLAS functions (sgemm, sgemv, saxpy, sdot, etc.) are
+// forwarded to OpenBLAS, which exports them with identical signatures.
+//
+// Sparse CBLAS extensions (saxpyi, sdoti) are provided here since
+// OpenBLAS does not include them.
+//
+// MKL DFTI (FFT) functions are stubbed — they are referenced by the
+// managed MKL Components initializer but not used by SymSGD. The stubs
+// return error codes so any actual FFT call fails cleanly rather than
+// crashing.
+
+// --- Sparse BLAS (MKL extensions, not in OpenBLAS) ---
+
+void cblas_saxpyi(const int nz, const float a,
+                  const float *x, const int *indx, float *y)
+{
+    for (int i = 0; i < nz; i++)
+        y[indx[i]] += a * x[i];
+}
+
+float cblas_sdoti(const int nz, const float *x,
+                  const int *indx, const float *y)
+{
+    float result = 0.0f;
+    for (int i = 0; i < nz; i++)
+        result += x[i] * y[indx[i]];
+    return result;
+}
+
+// --- DFTI (FFT) stubs ---
+
+const char* DftiErrorMessage(long status)
+{
+    return "DFTI not available (OpenBLAS arm64 build)";
+}
+
+long DftiCreateDescriptor(void **h, int precision, int domain, int dim, ...)
+{
+    *h = (void*)0;
+    return -1;
+}
+
+long DftiSetValue(void *h, int param, ...)
+{
+    return -1;
+}
+
+long DftiCommitDescriptor(void *h) { return -1; }
+long DftiComputeForward(void *h, ...) { return -1; }
+long DftiComputeBackward(void *h, ...) { return -1; }
+long DftiFreeDescriptor(void **h) { return 0; }

--- a/src/Native/SymSgdNative/CMakeLists.txt
+++ b/src/Native/SymSgdNative/CMakeLists.txt
@@ -33,7 +33,11 @@ else()
     endif()
 endif()
 
-if(NOT ${ARCHITECTURE} MATCHES "arm.*")
+if(${ARCHITECTURE} MATCHES "arm.*")
+    # On ARM, MklImports is built from MklImportsArm (OpenBLAS-backed).
+    # Link against the CMake target directly.
+    set(MKL_LIBRARY MklImports)
+else()
     find_library(MKL_LIBRARY MklImports HINTS ${MKL_LIB_PATH})
 endif()
 

--- a/src/Native/SymSgdNative/SparseBLAS.h
+++ b/src/Native/SymSgdNative/SparseBLAS.h
@@ -5,10 +5,16 @@
 #pragma once
 #include "../Stdafx.h"
 
-extern "C" float __cdecl cblas_sdot(const int vecSize, const float* denseVecX, const int incX, const float* denseVecY, const int incY);
-extern "C" float __cdecl cblas_sdoti(const int sparseVecSize, const float* sparseVecValues, const int* sparseVecIndices, float* denseVec);
-extern "C" void __cdecl cblas_saxpy(const int vecSize, const float coef, const float* denseVecX, const int incX, float* denseVecY, const int incY);
-extern "C" void __cdecl cblas_saxpyi(const int sparseVecSize, const float coef, const float* sparseVecValues, const int* sparseVecIndices, float* denseVec);
+#ifdef _WIN32
+#define CBLAS_CALLING_CONV __cdecl
+#else
+#define CBLAS_CALLING_CONV
+#endif
+
+extern "C" float CBLAS_CALLING_CONV cblas_sdot(const int vecSize, const float* denseVecX, const int incX, const float* denseVecY, const int incY);
+extern "C" float CBLAS_CALLING_CONV cblas_sdoti(const int sparseVecSize, const float* sparseVecValues, const int* sparseVecIndices, float* denseVec);
+extern "C" void CBLAS_CALLING_CONV cblas_saxpy(const int vecSize, const float coef, const float* denseVecX, const int incX, float* denseVecY, const int incY);
+extern "C" void CBLAS_CALLING_CONV cblas_saxpyi(const int sparseVecSize, const float coef, const float* sparseVecValues, const int* sparseVecIndices, float* denseVec);
 
 float SDOT(const int vecSize, const float* denseVecX, const float* denseVecY) 
 {


### PR DESCRIPTION
## Summary

Resolves the TODO in `src/Native/CMakeLists.txt` and provides the four MKL method substitutes requested in #5798, enabling `SymbolicSgdLogisticRegression` on ARM platforms.

- **New `MklImportsArm` target** — builds a `libMklImports.so` backed by the system BLAS (via `find_package(BLAS)`) for ARM, replacing the Intel MKL redistribution which is x86-only
- **Portable sparse BLAS** — implements `cblas_saxpyi` and `cblas_sdoti` (MKL extensions not in standard CBLAS/OpenBLAS) as straightforward C loops
- **DFTI stubs** — stubs the MKL FFT functions referenced by the managed `Microsoft.ML.Mkl.Components` initializer but unused by SymSGD; stubs return error codes so any actual FFT call fails cleanly
- **`__cdecl` fix** — guards the Windows-only calling convention in `SparseBLAS.h` behind `#ifdef _WIN32`

## Changes

| File | Change |
|---|---|
| `src/Native/CMakeLists.txt` | Build `MklImportsArm` + `SymSgdNative` on ARM (instead of skipping both) |
| `src/Native/MklImportsArm/CMakeLists.txt` | New — builds `libMklImports.so` from system BLAS |
| `src/Native/MklImportsArm/MklImportsArm.c` | New — sparse BLAS implementations + FFT stubs (57 lines) |
| `src/Native/SymSgdNative/CMakeLists.txt` | On ARM: link CMake `MklImports` target instead of `find_library` |
| `src/Native/SymSgdNative/SparseBLAS.h` | Guard `__cdecl` for Windows only |

## Test plan

- [x] CMake build succeeds on aarch64 (Ubuntu 24.04, GCC 13, OpenBLAS 0.3.26)
- [x] `SymbolicSgdLogisticRegression` trains and predicts correctly on arm64
- [x] Binary classification accuracy, AUC, init predictor handoff verified
- [x] `CreatePredictionEngine` works end-to-end
- [x] Existing `[NativeDependencyFact("MklImports")]` tests in `SymSgdClassificationTests.cs` pass on arm64

Tested on NVIDIA DGX Spark (Grace ARM CPU, Ubuntu 24.04, .NET 10.0.107).

## Related issues

- Fixes #5798
- Related to #6588, #7229