### PR TITLE
Add documentation comment warning to only load trusted models

### DIFF
--- a/src/Microsoft.Extensions.ML/Builder/BuilderExtensions.cs
+++ b/src/Microsoft.Extensions.ML/Builder/BuilderExtensions.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Extensions.ML
         /// <returns>
         /// The updated <see cref="PredictionEnginePoolBuilder{TData, TPrediction}"/>.
         /// </returns>
+        /// <remarks>Only add models from trusted sources. Adding models from untrusted sources is a security risk.</remarks>
         public static PredictionEnginePoolBuilder<TData, TPrediction> FromUri<TData, TPrediction>(
             this PredictionEnginePoolBuilder<TData, TPrediction> builder, string uri)
             where TData : class
@@ -41,6 +42,7 @@ namespace Microsoft.Extensions.ML
         /// <returns>
         /// The updated <see cref="PredictionEnginePoolBuilder{TData, TPrediction}"/>.
         /// </returns>
+        /// <remarks>Only add models from trusted sources. Adding models from untrusted sources is a security risk.</remarks>
         public static PredictionEnginePoolBuilder<TData, TPrediction> FromUri<TData, TPrediction>(
             this PredictionEnginePoolBuilder<TData, TPrediction> builder, string modelName, string uri)
             where TData : class
@@ -62,6 +64,7 @@ namespace Microsoft.Extensions.ML
         /// <returns>
         /// The updated <see cref="PredictionEnginePoolBuilder{TData, TPrediction}"/>.
         /// </returns>
+        /// <remarks>Only add models from trusted sources. Adding models from untrusted sources is a security risk.</remarks>
         public static PredictionEnginePoolBuilder<TData, TPrediction> FromUri<TData, TPrediction>(
             this PredictionEnginePoolBuilder<TData, TPrediction> builder, string modelName, Uri uri)
             where TData : class where TPrediction : class, new()
@@ -80,6 +83,7 @@ namespace Microsoft.Extensions.ML
         /// <returns>
         /// The updated <see cref="PredictionEnginePoolBuilder{TData, TPrediction}"/>.
         /// </returns>
+        /// <remarks>Only add models from trusted sources. Adding models from untrusted sources is a security risk.</remarks>
         public static PredictionEnginePoolBuilder<TData, TPrediction> FromUri<TData, TPrediction>(
             this PredictionEnginePoolBuilder<TData, TPrediction> builder, string uri, TimeSpan period)
             where TData : class where TPrediction : class, new()
@@ -103,6 +107,7 @@ namespace Microsoft.Extensions.ML
         /// <returns>
         /// The updated <see cref="PredictionEnginePoolBuilder{TData, TPrediction}"/>.
         /// </returns>
+        /// <remarks>Only add models from trusted sources. Adding models from untrusted sources is a security risk.</remarks>
         public static PredictionEnginePoolBuilder<TData, TPrediction> FromUri<TData, TPrediction>(
             this PredictionEnginePoolBuilder<TData, TPrediction> builder, string modelName, string uri, TimeSpan period)
             where TData : class
@@ -127,6 +132,7 @@ namespace Microsoft.Extensions.ML
         /// <returns>
         /// The updated <see cref="PredictionEnginePoolBuilder{TData, TPrediction}"/>.
         /// </returns>
+        /// <remarks>Only add models from trusted sources. Adding models from untrusted sources is a security risk.</remarks>
         public static PredictionEnginePoolBuilder<TData, TPrediction> FromUri<TData, TPrediction>(
             this PredictionEnginePoolBuilder<TData, TPrediction> builder, string modelName, Uri uri, TimeSpan period)
             where TData : class
@@ -150,6 +156,7 @@ namespace Microsoft.Extensions.ML
         /// <returns>
         /// The updated <see cref="PredictionEnginePoolBuilder{TData, TPrediction}"/>.
         /// </returns>
+        /// <remarks>Only add models from trusted sources. Adding models from untrusted sources is a security risk.</remarks>
         public static PredictionEnginePoolBuilder<TData, TPrediction> FromFile<TData, TPrediction>(
             this PredictionEnginePoolBuilder<TData, TPrediction> builder, string filePath)
             where TData : class
@@ -169,6 +176,7 @@ namespace Microsoft.Extensions.ML
         /// <returns>
         /// The updated <see cref="PredictionEnginePoolBuilder{TData, TPrediction}"/>.
         /// </returns>
+        /// <remarks>Only add models from trusted sources. Adding models from untrusted sources is a security risk.</remarks>
         public static PredictionEnginePoolBuilder<TData, TPrediction> FromFile<TData, TPrediction>(
             this PredictionEnginePoolBuilder<TData, TPrediction> builder, string filePath, bool watchForChanges)
             where TData : class
@@ -190,6 +198,7 @@ namespace Microsoft.Extensions.ML
         /// <returns>
         /// The updated <see cref="PredictionEnginePoolBuilder{TData, TPrediction}"/>.
         /// </returns>
+        /// <remarks>Only add models from trusted sources. Adding models from untrusted sources is a security risk.</remarks>
         public static PredictionEnginePoolBuilder<TData, TPrediction> FromFile<TData, TPrediction>(
             this PredictionEnginePoolBuilder<TData, TPrediction> builder, string modelName, string filePath)
             where TData : class
@@ -214,6 +223,7 @@ namespace Microsoft.Extensions.ML
         /// <returns>
         /// The updated <see cref="PredictionEnginePoolBuilder{TData, TPrediction}"/>.
         /// </returns>
+        /// <remarks>Only add models from trusted sources. Adding models from untrusted sources is a security risk.</remarks>
         public static PredictionEnginePoolBuilder<TData, TPrediction> FromFile<TData, TPrediction>(
             this PredictionEnginePoolBuilder<TData, TPrediction> builder, string modelName, string filePath, bool watchForChanges)
             where TData : class

--- a/src/Microsoft.ML.Data/Model/ModelOperationsCatalog.cs
+++ b/src/Microsoft.ML.Data/Model/ModelOperationsCatalog.cs
@@ -142,6 +142,7 @@ namespace Microsoft.ML
         /// <param name="inputSchema">Will contain the input schema for the model. If the model was saved without
         /// any description of the input, there will be no input schema. In this case this can be <see langword="null"/>.</param>
         /// <returns>The loaded model.</returns>
+        /// <remarks>Only load models from trusted sources. Loading models from untrusted sources is a security risk.</remarks>
         /// <example>
         /// <format type="text/markdown">
         /// <![CDATA[
@@ -201,6 +202,7 @@ namespace Microsoft.ML
         /// <param name="inputSchema">Will contain the input schema for the model. If the model was saved without
         /// any description of the input, there will be no input schema. In this case this can be <see langword="null"/>.</param>
         /// <returns>The loaded model.</returns>
+        /// <remarks>Only load models from trusted sources. Loading models from untrusted sources is a security risk.</remarks>
         /// <example>
         /// <format type="text/markdown">
         /// <![CDATA[
@@ -255,6 +257,7 @@ namespace Microsoft.ML
         /// this method will throw an exception. The scenario where no loader is stored in the stream should
         /// be handled instead using the <see cref="Load(Stream, out DataViewSchema)"/> method.</param>
         /// <returns>The transformer model from the model stream.</returns>
+        /// <remarks>Only load models from trusted sources. Loading models from untrusted sources is a security risk.</remarks>
         public ITransformer LoadWithDataLoader(Stream stream, out IDataLoader<IMultiStreamSource> loader)
         {
             _env.CheckValue(stream, nameof(stream));
@@ -283,6 +286,7 @@ namespace Microsoft.ML
         /// this method will throw an exception. The scenario where no loader is stored in the stream should
         /// be handled instead using the <see cref="Load(Stream, out DataViewSchema)"/> method.</param>
         /// <returns>The transformer model from the model file.</returns>
+        /// <remarks>Only load models from trusted sources. Loading models from untrusted sources is a security risk.</remarks>
         public ITransformer LoadWithDataLoader(string filePath, out IDataLoader<IMultiStreamSource> loader)
         {
             _env.CheckNonEmpty(filePath, nameof(filePath));

--- a/src/Microsoft.ML.OnnxTransformer/OnnxCatalog.cs
+++ b/src/Microsoft.ML.OnnxTransformer/OnnxCatalog.cs
@@ -23,6 +23,8 @@ namespace Microsoft.ML
         /// The name/type of input columns must exactly match name/type of the ONNX model inputs.
         /// The name/type of the produced output columns will match name/type of the ONNX model outputs.
         /// If the gpuDeviceId value is <see langword="null" /> the <see cref="P:MLContext.GpuDeviceId"/> value will be used if it is not <see langword="null" />.
+        /// 
+        /// Only apply models from trusted sources. Applying models from untrusted sources is a security risk.
         /// </remarks>
         /// <param name="catalog">The transform's catalog.</param>
         /// <param name="modelFile">The path of the file containing the ONNX model.</param>
@@ -51,6 +53,8 @@ namespace Microsoft.ML
         /// The name/type of input columns must exactly match name/type of the ONNX model inputs.
         /// The name/type of the produced output columns will match name/type of the ONNX model outputs.
         /// If the gpuDeviceId value is <see langword="null" /> the <see cref="P:MLContext.GpuDeviceId"/> value will be used if it is not <see langword="null" />.
+        /// 
+        /// Only apply models from trusted sources. Applying models from untrusted sources is a security risk.
         /// </remarks>
         /// <param name="catalog">The transform's catalog.</param>
         /// <param name="modelBytes">The <see cref="System.IO.Stream"/> containing the model bytes.</param>
@@ -79,6 +83,8 @@ namespace Microsoft.ML
         /// The name/type of input columns must exactly match name/type of the ONNX model inputs.
         /// The name/type of the produced output columns will match name/type of the ONNX model outputs.
         /// If the gpuDeviceId value is <see langword="null" /> the <see cref="P:MLContext.GpuDeviceId"/> value will be used if it is not <see langword="null" />.
+        /// 
+        /// Only apply models from trusted sources. Applying models from untrusted sources is a security risk.
         /// </remarks>
         /// <param name="catalog">The transform's catalog.</param>
         /// <param name="modelFile">The path of the file containing the ONNX model.</param>
@@ -115,6 +121,8 @@ namespace Microsoft.ML
         /// The name/type of input columns must exactly match name/type of the ONNX model inputs.
         /// The name/type of the produced output columns will match name/type of the ONNX model outputs.
         /// If the gpuDeviceId value is <see langword="null" /> the <see cref="P:MLContext.GpuDeviceId"/> value will be used if it is not <see langword="null" />.
+        /// 
+        /// Only apply models from trusted sources. Applying models from untrusted sources is a security risk.
         /// </remarks>
         /// <param name="catalog">The transform's catalog.</param>
         /// <param name="modelBytes">The <see cref="System.IO.Stream"/> containing the model bytes.</param>
@@ -154,6 +162,8 @@ namespace Microsoft.ML
         /// <param name="fallbackToCpu">If GPU error, raise exception or fallback to CPU.</param>
         /// <remarks>
         /// If the gpuDeviceId value is <see langword="null" /> the <see cref="P:MLContext.GpuDeviceId"/> value will be used if it is not <see langword="null" />.
+        /// 
+        /// Only apply models from trusted sources. Applying models from untrusted sources is a security risk.
         /// </remarks>
         /// <example>
         /// <format type="text/markdown">
@@ -186,6 +196,8 @@ namespace Microsoft.ML
         /// <param name="fallbackToCpu">If GPU error, raise exception or fallback to CPU.</param>
         /// <remarks>
         /// If the gpuDeviceId value is <see langword="null" /> the <see cref="P:MLContext.GpuDeviceId"/> value will be used if it is not <see langword="null" />.
+        /// 
+        /// Only apply models from trusted sources. Applying models from untrusted sources is a security risk.
         /// </remarks>
         /// <example>
         /// <format type="text/markdown">
@@ -212,6 +224,8 @@ namespace Microsoft.ML
         /// </summary>
         /// <remarks>
         /// If the options.GpuDeviceId value is <see langword="null" /> the <see cref="P:MLContext.GpuDeviceId"/> value will be used if it is not <see langword="null" />.
+        /// 
+        /// Only apply models from trusted sources. Applying models from untrusted sources is a security risk.
         /// </remarks>
         /// <param name="catalog">The transform's catalog.</param>
         /// <param name="options">Options for the <see cref="OnnxScoringEstimator"/>.</param>
@@ -239,6 +253,8 @@ namespace Microsoft.ML
         /// <param name="fallbackToCpu">If GPU error, raise exception or fallback to CPU.</param>
         /// <remarks>
         /// If the gpuDeviceId value is <see langword="null" /> the <see cref="P:MLContext.GpuDeviceId"/> value will be used if it is not <see langword="null" />.
+        /// 
+        /// Only apply models from trusted sources. Applying models from untrusted sources is a security risk.
         /// </remarks>
         /// <example>
         /// <format type="text/markdown">
@@ -277,6 +293,8 @@ namespace Microsoft.ML
         /// <param name="fallbackToCpu">If GPU error, raise exception or fallback to CPU.</param>
         /// <remarks>
         /// If the gpuDeviceId value is <see langword="null" /> the <see cref="P:MLContext.GpuDeviceId"/> value will be used if it is not <see langword="null" />.
+        /// 
+        /// Only apply models from trusted sources. Applying models from untrusted sources is a security risk.
         /// </remarks>
         /// <example>
         /// <format type="text/markdown">
@@ -311,6 +329,8 @@ namespace Microsoft.ML
         /// <param name="fallbackToCpu">If GPU error, raise exception or fallback to CPU.</param>
         /// <remarks>
         /// If the gpuDeviceId value is <see langword="null" /> the <see cref="P:MLContext.GpuDeviceId"/> value will be used if it is not <see langword="null" />.
+        /// 
+        /// Only apply models from trusted sources. Applying models from untrusted sources is a security risk.
         /// </remarks>
         public static OnnxScoringEstimator ApplyOnnxModel(this TransformsCatalog catalog,
             string[] outputColumnNames,
@@ -336,6 +356,8 @@ namespace Microsoft.ML
         /// <param name="fallbackToCpu">If GPU error, raise exception or fallback to CPU.</param>
         /// <remarks>
         /// If the gpuDeviceId value is <see langword="null" /> the <see cref="P:MLContext.GpuDeviceId"/> value will be used if it is not <see langword="null" />.
+        /// 
+        /// Only apply models from trusted sources. Applying models from untrusted sources is a security risk.
         /// </remarks>
         public static OnnxScoringEstimator ApplyOnnxModel(this TransformsCatalog catalog,
             string[] outputColumnNames,
@@ -365,6 +387,8 @@ namespace Microsoft.ML
         /// <param name="fallbackToCpu">If GPU error, raise exception or fallback to CPU.</param>
         /// <remarks>
         /// If the gpuDeviceId value is <see langword="null" /> the <see cref="P:MLContext.GpuDeviceId"/> value will be used if it is not <see langword="null" />.
+        /// 
+        /// Only apply models from trusted sources. Applying models from untrusted sources is a security risk.
         /// </remarks>
         public static OnnxScoringEstimator ApplyOnnxModel(this TransformsCatalog catalog,
             string[] outputColumnNames,
@@ -395,6 +419,8 @@ namespace Microsoft.ML
         /// <param name="fallbackToCpu">If GPU error, raise exception or fallback to CPU.</param>
         /// <remarks>
         /// If the gpuDeviceId value is <see langword="null" /> the <see cref="P:MLContext.GpuDeviceId"/> value will be used if it is not <see langword="null" />.
+        /// 
+        /// Only apply models from trusted sources. Applying models from untrusted sources is a security risk.
         /// </remarks>
         public static OnnxScoringEstimator ApplyOnnxModel(this TransformsCatalog catalog,
             string[] outputColumnNames,
@@ -426,6 +452,8 @@ namespace Microsoft.ML
         /// <param name="recursionLimit">Optional, specifies the Protobuf CodedInputStream recursion limit. Default value is 100.</param>
         /// <remarks>
         /// If the gpuDeviceId value is <see langword="null" /> the <see cref="P:MLContext.GpuDeviceId"/> value will be used if it is not <see langword="null" />.
+        /// 
+        /// Only apply models from trusted sources. Applying models from untrusted sources is a security risk.
         /// </remarks>
         public static OnnxScoringEstimator ApplyOnnxModel(this TransformsCatalog catalog,
             string[] outputColumnNames,
@@ -458,6 +486,8 @@ namespace Microsoft.ML
         /// <param name="recursionLimit">Optional, specifies the Protobuf CodedInputStream recursion limit. Default value is 100.</param>
         /// <remarks>
         /// If the gpuDeviceId value is <see langword="null" /> the <see cref="P:MLContext.GpuDeviceId"/> value will be used if it is not <see langword="null" />.
+        /// 
+        /// Only apply models from trusted sources. Applying models from untrusted sources is a security risk.
         /// </remarks>
         public static OnnxScoringEstimator ApplyOnnxModel(this TransformsCatalog catalog,
             string[] outputColumnNames,

--- a/src/Microsoft.ML.OnnxTransformer/OnnxCatalog.cs
+++ b/src/Microsoft.ML.OnnxTransformer/OnnxCatalog.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -23,8 +23,7 @@ namespace Microsoft.ML
         /// The name/type of input columns must exactly match name/type of the ONNX model inputs.
         /// The name/type of the produced output columns will match name/type of the ONNX model outputs.
         /// If the gpuDeviceId value is <see langword="null" /> the <see cref="P:MLContext.GpuDeviceId"/> value will be used if it is not <see langword="null" />.
-        /// 
-        /// Only apply models from trusted sources. Applying models from untrusted sources is a security risk.
+        /// <para>Only apply models from trusted sources. Applying models from untrusted sources is a security risk.</para>
         /// </remarks>
         /// <param name="catalog">The transform's catalog.</param>
         /// <param name="modelFile">The path of the file containing the ONNX model.</param>
@@ -53,8 +52,7 @@ namespace Microsoft.ML
         /// The name/type of input columns must exactly match name/type of the ONNX model inputs.
         /// The name/type of the produced output columns will match name/type of the ONNX model outputs.
         /// If the gpuDeviceId value is <see langword="null" /> the <see cref="P:MLContext.GpuDeviceId"/> value will be used if it is not <see langword="null" />.
-        /// 
-        /// Only apply models from trusted sources. Applying models from untrusted sources is a security risk.
+        /// <para>Only apply models from trusted sources. Applying models from untrusted sources is a security risk.</para>
         /// </remarks>
         /// <param name="catalog">The transform's catalog.</param>
         /// <param name="modelBytes">The <see cref="System.IO.Stream"/> containing the model bytes.</param>
@@ -83,8 +81,7 @@ namespace Microsoft.ML
         /// The name/type of input columns must exactly match name/type of the ONNX model inputs.
         /// The name/type of the produced output columns will match name/type of the ONNX model outputs.
         /// If the gpuDeviceId value is <see langword="null" /> the <see cref="P:MLContext.GpuDeviceId"/> value will be used if it is not <see langword="null" />.
-        /// 
-        /// Only apply models from trusted sources. Applying models from untrusted sources is a security risk.
+        /// <para>Only apply models from trusted sources. Applying models from untrusted sources is a security risk.</para>
         /// </remarks>
         /// <param name="catalog">The transform's catalog.</param>
         /// <param name="modelFile">The path of the file containing the ONNX model.</param>
@@ -121,8 +118,7 @@ namespace Microsoft.ML
         /// The name/type of input columns must exactly match name/type of the ONNX model inputs.
         /// The name/type of the produced output columns will match name/type of the ONNX model outputs.
         /// If the gpuDeviceId value is <see langword="null" /> the <see cref="P:MLContext.GpuDeviceId"/> value will be used if it is not <see langword="null" />.
-        /// 
-        /// Only apply models from trusted sources. Applying models from untrusted sources is a security risk.
+        /// <para>Only apply models from trusted sources. Applying models from untrusted sources is a security risk.</para>
         /// </remarks>
         /// <param name="catalog">The transform's catalog.</param>
         /// <param name="modelBytes">The <see cref="System.IO.Stream"/> containing the model bytes.</param>
@@ -162,8 +158,7 @@ namespace Microsoft.ML
         /// <param name="fallbackToCpu">If GPU error, raise exception or fallback to CPU.</param>
         /// <remarks>
         /// If the gpuDeviceId value is <see langword="null" /> the <see cref="P:MLContext.GpuDeviceId"/> value will be used if it is not <see langword="null" />.
-        /// 
-        /// Only apply models from trusted sources. Applying models from untrusted sources is a security risk.
+        /// <para>Only apply models from trusted sources. Applying models from untrusted sources is a security risk.</para>
         /// </remarks>
         /// <example>
         /// <format type="text/markdown">
@@ -196,8 +191,7 @@ namespace Microsoft.ML
         /// <param name="fallbackToCpu">If GPU error, raise exception or fallback to CPU.</param>
         /// <remarks>
         /// If the gpuDeviceId value is <see langword="null" /> the <see cref="P:MLContext.GpuDeviceId"/> value will be used if it is not <see langword="null" />.
-        /// 
-        /// Only apply models from trusted sources. Applying models from untrusted sources is a security risk.
+        /// <para>Only apply models from trusted sources. Applying models from untrusted sources is a security risk.</para>
         /// </remarks>
         /// <example>
         /// <format type="text/markdown">
@@ -224,8 +218,7 @@ namespace Microsoft.ML
         /// </summary>
         /// <remarks>
         /// If the options.GpuDeviceId value is <see langword="null" /> the <see cref="P:MLContext.GpuDeviceId"/> value will be used if it is not <see langword="null" />.
-        /// 
-        /// Only apply models from trusted sources. Applying models from untrusted sources is a security risk.
+        /// <para>Only apply models from trusted sources. Applying models from untrusted sources is a security risk.</para>
         /// </remarks>
         /// <param name="catalog">The transform's catalog.</param>
         /// <param name="options">Options for the <see cref="OnnxScoringEstimator"/>.</param>
@@ -253,8 +246,7 @@ namespace Microsoft.ML
         /// <param name="fallbackToCpu">If GPU error, raise exception or fallback to CPU.</param>
         /// <remarks>
         /// If the gpuDeviceId value is <see langword="null" /> the <see cref="P:MLContext.GpuDeviceId"/> value will be used if it is not <see langword="null" />.
-        /// 
-        /// Only apply models from trusted sources. Applying models from untrusted sources is a security risk.
+        /// <para>Only apply models from trusted sources. Applying models from untrusted sources is a security risk.</para>
         /// </remarks>
         /// <example>
         /// <format type="text/markdown">
@@ -293,8 +285,7 @@ namespace Microsoft.ML
         /// <param name="fallbackToCpu">If GPU error, raise exception or fallback to CPU.</param>
         /// <remarks>
         /// If the gpuDeviceId value is <see langword="null" /> the <see cref="P:MLContext.GpuDeviceId"/> value will be used if it is not <see langword="null" />.
-        /// 
-        /// Only apply models from trusted sources. Applying models from untrusted sources is a security risk.
+        /// <para>Only apply models from trusted sources. Applying models from untrusted sources is a security risk.</para>
         /// </remarks>
         /// <example>
         /// <format type="text/markdown">
@@ -329,8 +320,7 @@ namespace Microsoft.ML
         /// <param name="fallbackToCpu">If GPU error, raise exception or fallback to CPU.</param>
         /// <remarks>
         /// If the gpuDeviceId value is <see langword="null" /> the <see cref="P:MLContext.GpuDeviceId"/> value will be used if it is not <see langword="null" />.
-        /// 
-        /// Only apply models from trusted sources. Applying models from untrusted sources is a security risk.
+        /// <para>Only apply models from trusted sources. Applying models from untrusted sources is a security risk.</para>
         /// </remarks>
         public static OnnxScoringEstimator ApplyOnnxModel(this TransformsCatalog catalog,
             string[] outputColumnNames,
@@ -356,8 +346,7 @@ namespace Microsoft.ML
         /// <param name="fallbackToCpu">If GPU error, raise exception or fallback to CPU.</param>
         /// <remarks>
         /// If the gpuDeviceId value is <see langword="null" /> the <see cref="P:MLContext.GpuDeviceId"/> value will be used if it is not <see langword="null" />.
-        /// 
-        /// Only apply models from trusted sources. Applying models from untrusted sources is a security risk.
+        /// <para>Only apply models from trusted sources. Applying models from untrusted sources is a security risk.</para>
         /// </remarks>
         public static OnnxScoringEstimator ApplyOnnxModel(this TransformsCatalog catalog,
             string[] outputColumnNames,
@@ -387,8 +376,7 @@ namespace Microsoft.ML
         /// <param name="fallbackToCpu">If GPU error, raise exception or fallback to CPU.</param>
         /// <remarks>
         /// If the gpuDeviceId value is <see langword="null" /> the <see cref="P:MLContext.GpuDeviceId"/> value will be used if it is not <see langword="null" />.
-        /// 
-        /// Only apply models from trusted sources. Applying models from untrusted sources is a security risk.
+        /// <para>Only apply models from trusted sources. Applying models from untrusted sources is a security risk.</para>
         /// </remarks>
         public static OnnxScoringEstimator ApplyOnnxModel(this TransformsCatalog catalog,
             string[] outputColumnNames,
@@ -419,8 +407,7 @@ namespace Microsoft.ML
         /// <param name="fallbackToCpu">If GPU error, raise exception or fallback to CPU.</param>
         /// <remarks>
         /// If the gpuDeviceId value is <see langword="null" /> the <see cref="P:MLContext.GpuDeviceId"/> value will be used if it is not <see langword="null" />.
-        /// 
-        /// Only apply models from trusted sources. Applying models from untrusted sources is a security risk.
+        /// <para>Only apply models from trusted sources. Applying models from untrusted sources is a security risk.</para>
         /// </remarks>
         public static OnnxScoringEstimator ApplyOnnxModel(this TransformsCatalog catalog,
             string[] outputColumnNames,
@@ -452,8 +439,7 @@ namespace Microsoft.ML
         /// <param name="recursionLimit">Optional, specifies the Protobuf CodedInputStream recursion limit. Default value is 100.</param>
         /// <remarks>
         /// If the gpuDeviceId value is <see langword="null" /> the <see cref="P:MLContext.GpuDeviceId"/> value will be used if it is not <see langword="null" />.
-        /// 
-        /// Only apply models from trusted sources. Applying models from untrusted sources is a security risk.
+        /// <para>Only apply models from trusted sources. Applying models from untrusted sources is a security risk.</para>
         /// </remarks>
         public static OnnxScoringEstimator ApplyOnnxModel(this TransformsCatalog catalog,
             string[] outputColumnNames,
@@ -486,8 +472,7 @@ namespace Microsoft.ML
         /// <param name="recursionLimit">Optional, specifies the Protobuf CodedInputStream recursion limit. Default value is 100.</param>
         /// <remarks>
         /// If the gpuDeviceId value is <see langword="null" /> the <see cref="P:MLContext.GpuDeviceId"/> value will be used if it is not <see langword="null" />.
-        /// 
-        /// Only apply models from trusted sources. Applying models from untrusted sources is a security risk.
+        /// <para>Only apply models from trusted sources. Applying models from untrusted sources is a security risk.</para>
         /// </remarks>
         public static OnnxScoringEstimator ApplyOnnxModel(this TransformsCatalog catalog,
             string[] outputColumnNames,

--- a/src/Microsoft.ML.OnnxTransformer/OnnxCatalog.cs
+++ b/src/Microsoft.ML.OnnxTransformer/OnnxCatalog.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -20,9 +20,11 @@ namespace Microsoft.ML
         /// and how to run it on a GPU.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// The name/type of input columns must exactly match name/type of the ONNX model inputs.
         /// The name/type of the produced output columns will match name/type of the ONNX model outputs.
         /// If the gpuDeviceId value is <see langword="null" /> the <see cref="P:MLContext.GpuDeviceId"/> value will be used if it is not <see langword="null" />.
+        /// </para>
         /// <para>Only apply models from trusted sources. Applying models from untrusted sources is a security risk.</para>
         /// </remarks>
         /// <param name="catalog">The transform's catalog.</param>
@@ -49,9 +51,11 @@ namespace Microsoft.ML
         /// and how to run it on a GPU.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// The name/type of input columns must exactly match name/type of the ONNX model inputs.
         /// The name/type of the produced output columns will match name/type of the ONNX model outputs.
         /// If the gpuDeviceId value is <see langword="null" /> the <see cref="P:MLContext.GpuDeviceId"/> value will be used if it is not <see langword="null" />.
+        /// </para>
         /// <para>Only apply models from trusted sources. Applying models from untrusted sources is a security risk.</para>
         /// </remarks>
         /// <param name="catalog">The transform's catalog.</param>
@@ -78,9 +82,11 @@ namespace Microsoft.ML
         /// and how to run it on a GPU.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// The name/type of input columns must exactly match name/type of the ONNX model inputs.
         /// The name/type of the produced output columns will match name/type of the ONNX model outputs.
         /// If the gpuDeviceId value is <see langword="null" /> the <see cref="P:MLContext.GpuDeviceId"/> value will be used if it is not <see langword="null" />.
+        /// </para>
         /// <para>Only apply models from trusted sources. Applying models from untrusted sources is a security risk.</para>
         /// </remarks>
         /// <param name="catalog">The transform's catalog.</param>
@@ -115,9 +121,11 @@ namespace Microsoft.ML
         /// and how to run it on a GPU.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// The name/type of input columns must exactly match name/type of the ONNX model inputs.
         /// The name/type of the produced output columns will match name/type of the ONNX model outputs.
         /// If the gpuDeviceId value is <see langword="null" /> the <see cref="P:MLContext.GpuDeviceId"/> value will be used if it is not <see langword="null" />.
+        /// </para>
         /// <para>Only apply models from trusted sources. Applying models from untrusted sources is a security risk.</para>
         /// </remarks>
         /// <param name="catalog">The transform's catalog.</param>
@@ -157,7 +165,9 @@ namespace Microsoft.ML
         /// <param name="gpuDeviceId">Optional GPU device ID to run execution on, <see langword="null" /> to run on CPU.</param>
         /// <param name="fallbackToCpu">If GPU error, raise exception or fallback to CPU.</param>
         /// <remarks>
+        /// <para>
         /// If the gpuDeviceId value is <see langword="null" /> the <see cref="P:MLContext.GpuDeviceId"/> value will be used if it is not <see langword="null" />.
+        /// </para>
         /// <para>Only apply models from trusted sources. Applying models from untrusted sources is a security risk.</para>
         /// </remarks>
         /// <example>
@@ -190,7 +200,9 @@ namespace Microsoft.ML
         /// <param name="gpuDeviceId">Optional GPU device ID to run execution on, <see langword="null" /> to run on CPU.</param>
         /// <param name="fallbackToCpu">If GPU error, raise exception or fallback to CPU.</param>
         /// <remarks>
+        /// <para>
         /// If the gpuDeviceId value is <see langword="null" /> the <see cref="P:MLContext.GpuDeviceId"/> value will be used if it is not <see langword="null" />.
+        /// </para>
         /// <para>Only apply models from trusted sources. Applying models from untrusted sources is a security risk.</para>
         /// </remarks>
         /// <example>
@@ -217,7 +229,9 @@ namespace Microsoft.ML
         /// and how to run it on a GPU.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// If the options.GpuDeviceId value is <see langword="null" /> the <see cref="P:MLContext.GpuDeviceId"/> value will be used if it is not <see langword="null" />.
+        /// </para>
         /// <para>Only apply models from trusted sources. Applying models from untrusted sources is a security risk.</para>
         /// </remarks>
         /// <param name="catalog">The transform's catalog.</param>
@@ -245,7 +259,9 @@ namespace Microsoft.ML
         /// <param name="gpuDeviceId">Optional GPU device ID to run execution on, <see langword="null" /> to run on CPU.</param>
         /// <param name="fallbackToCpu">If GPU error, raise exception or fallback to CPU.</param>
         /// <remarks>
+        /// <para>
         /// If the gpuDeviceId value is <see langword="null" /> the <see cref="P:MLContext.GpuDeviceId"/> value will be used if it is not <see langword="null" />.
+        /// </para>
         /// <para>Only apply models from trusted sources. Applying models from untrusted sources is a security risk.</para>
         /// </remarks>
         /// <example>
@@ -284,7 +300,9 @@ namespace Microsoft.ML
         /// <param name="gpuDeviceId">Optional GPU device ID to run execution on, <see langword="null" /> to run on CPU.</param>
         /// <param name="fallbackToCpu">If GPU error, raise exception or fallback to CPU.</param>
         /// <remarks>
+        /// <para>
         /// If the gpuDeviceId value is <see langword="null" /> the <see cref="P:MLContext.GpuDeviceId"/> value will be used if it is not <see langword="null" />.
+        /// </para>
         /// <para>Only apply models from trusted sources. Applying models from untrusted sources is a security risk.</para>
         /// </remarks>
         /// <example>
@@ -319,7 +337,9 @@ namespace Microsoft.ML
         /// <param name="gpuDeviceId">Optional GPU device ID to run execution on, <see langword="null" /> to run on CPU.</param>
         /// <param name="fallbackToCpu">If GPU error, raise exception or fallback to CPU.</param>
         /// <remarks>
+        /// <para>
         /// If the gpuDeviceId value is <see langword="null" /> the <see cref="P:MLContext.GpuDeviceId"/> value will be used if it is not <see langword="null" />.
+        /// </para>
         /// <para>Only apply models from trusted sources. Applying models from untrusted sources is a security risk.</para>
         /// </remarks>
         public static OnnxScoringEstimator ApplyOnnxModel(this TransformsCatalog catalog,
@@ -345,7 +365,9 @@ namespace Microsoft.ML
         /// <param name="gpuDeviceId">Optional GPU device ID to run execution on, <see langword="null" /> to run on CPU.</param>
         /// <param name="fallbackToCpu">If GPU error, raise exception or fallback to CPU.</param>
         /// <remarks>
+        /// <para>
         /// If the gpuDeviceId value is <see langword="null" /> the <see cref="P:MLContext.GpuDeviceId"/> value will be used if it is not <see langword="null" />.
+        /// </para>
         /// <para>Only apply models from trusted sources. Applying models from untrusted sources is a security risk.</para>
         /// </remarks>
         public static OnnxScoringEstimator ApplyOnnxModel(this TransformsCatalog catalog,
@@ -375,7 +397,9 @@ namespace Microsoft.ML
         /// <param name="gpuDeviceId">Optional GPU device ID to run execution on, <see langword="null" /> to run on CPU.</param>
         /// <param name="fallbackToCpu">If GPU error, raise exception or fallback to CPU.</param>
         /// <remarks>
+        /// <para>
         /// If the gpuDeviceId value is <see langword="null" /> the <see cref="P:MLContext.GpuDeviceId"/> value will be used if it is not <see langword="null" />.
+        /// </para>
         /// <para>Only apply models from trusted sources. Applying models from untrusted sources is a security risk.</para>
         /// </remarks>
         public static OnnxScoringEstimator ApplyOnnxModel(this TransformsCatalog catalog,
@@ -406,7 +430,9 @@ namespace Microsoft.ML
         /// <param name="gpuDeviceId">Optional GPU device ID to run execution on, <see langword="null" /> to run on CPU.</param>
         /// <param name="fallbackToCpu">If GPU error, raise exception or fallback to CPU.</param>
         /// <remarks>
+        /// <para>
         /// If the gpuDeviceId value is <see langword="null" /> the <see cref="P:MLContext.GpuDeviceId"/> value will be used if it is not <see langword="null" />.
+        /// </para>
         /// <para>Only apply models from trusted sources. Applying models from untrusted sources is a security risk.</para>
         /// </remarks>
         public static OnnxScoringEstimator ApplyOnnxModel(this TransformsCatalog catalog,
@@ -438,7 +464,9 @@ namespace Microsoft.ML
         /// <param name="fallbackToCpu">If GPU error, raise exception or fallback to CPU.</param>
         /// <param name="recursionLimit">Optional, specifies the Protobuf CodedInputStream recursion limit. Default value is 100.</param>
         /// <remarks>
+        /// <para>
         /// If the gpuDeviceId value is <see langword="null" /> the <see cref="P:MLContext.GpuDeviceId"/> value will be used if it is not <see langword="null" />.
+        /// </para>
         /// <para>Only apply models from trusted sources. Applying models from untrusted sources is a security risk.</para>
         /// </remarks>
         public static OnnxScoringEstimator ApplyOnnxModel(this TransformsCatalog catalog,
@@ -471,7 +499,9 @@ namespace Microsoft.ML
         /// <param name="fallbackToCpu">If GPU error, raise exception or fallback to CPU.</param>
         /// <param name="recursionLimit">Optional, specifies the Protobuf CodedInputStream recursion limit. Default value is 100.</param>
         /// <remarks>
+        /// <para>
         /// If the gpuDeviceId value is <see langword="null" /> the <see cref="P:MLContext.GpuDeviceId"/> value will be used if it is not <see langword="null" />.
+        /// </para>
         /// <para>Only apply models from trusted sources. Applying models from untrusted sources is a security risk.</para>
         /// </remarks>
         public static OnnxScoringEstimator ApplyOnnxModel(this TransformsCatalog catalog,

--- a/src/Microsoft.ML.TensorFlow/TensorflowCatalog.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorflowCatalog.cs
@@ -26,6 +26,7 @@ namespace Microsoft.ML
         /// </summary>
         /// <param name="catalog">The transform's catalog.</param>
         /// <param name="modelLocation">Location of the TensorFlow model.</param>
+        /// <remarks>Only load models from trusted sources. Loading models from untrusted sources is a security risk.</remarks>
         /// <example>
         /// <format type="text/markdown">
         /// <![CDATA[
@@ -52,6 +53,7 @@ namespace Microsoft.ML
         /// <param name="catalog">The transform's catalog.</param>
         /// <param name="modelLocation">Location of the TensorFlow model.</param>
         /// <param name="treatOutputAsBatched">If the first dimension of the output is unknown, should it be treated as batched or not.</param>
+        /// <remarks>Only load models from trusted sources. Loading models from untrusted sources is a security risk.</remarks>
         /// <example>
         /// <format type="text/markdown">
         /// <![CDATA[


### PR DESCRIPTION
ML.NET assumes that loaded models are trusted. We should explicitly document this assumption and warn users not to load untrusted models.

Companion PR to change conceptual docs: https://github.com/dotnet/docs/pull/53999