### PR TITLE
Fix memory leak and stale-model results when hot-swapping PredictionEnginePool

### DIFF
--- a/src/Microsoft.Extensions.ML/PoolLoader.cs
+++ b/src/Microsoft.Extensions.ML/PoolLoader.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Extensions.ML
         private readonly IDisposable _changeTokenRegistration;
 
         private readonly ConditionalWeakTable<PredictionEngine<TData, TPrediction>, ObjectPool<PredictionEngine<TData, TPrediction>>> _rentedEngines;
-        private bool _disposed;
+        private int _disposed;
 
         public PoolLoader(IServiceProvider sp, PredictionEnginePoolOptions<TData, TPrediction> poolOptions)
         {
@@ -60,7 +60,7 @@ namespace Microsoft.Extensions.ML
         public PredictionEngine<TData, TPrediction> Get()
         {
             var pool = Volatile.Read(ref _pool);
-            if (_disposed || pool == null)
+            if (Volatile.Read(ref _disposed) != 0 || pool == null)
             {
                 throw new ObjectDisposedException(nameof(PoolLoader<TData, TPrediction>));
             }
@@ -96,7 +96,7 @@ namespace Microsoft.Extensions.ML
 
         private void LoadPool()
         {
-            if (_disposed)
+            if (Volatile.Read(ref _disposed) != 0)
             {
                 return;
             }
@@ -110,7 +110,7 @@ namespace Microsoft.Extensions.ML
 
             DisposeGeneration(oldPool, oldModel, model);
 
-            if (_disposed && Interlocked.CompareExchange(ref _pool, null, newPool) == newPool)
+            if (Volatile.Read(ref _disposed) != 0 && Interlocked.CompareExchange(ref _pool, null, newPool) == newPool)
             {
                 DisposeGeneration(newPool, model, null);
             }
@@ -131,12 +131,11 @@ namespace Microsoft.Extensions.ML
 
         public void Dispose()
         {
-            if (_disposed)
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
             {
                 return;
             }
 
-            _disposed = true;
             _changeTokenRegistration?.Dispose();
 
             var pool = Interlocked.Exchange(ref _pool, null);

--- a/src/Microsoft.Extensions.ML/PoolLoader.cs
+++ b/src/Microsoft.Extensions.ML/PoolLoader.cs
@@ -1,8 +1,9 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.ObjectPool;
@@ -19,14 +20,22 @@ namespace Microsoft.Extensions.ML
         where TData : class
         where TPrediction : class, new()
     {
-        private DefaultObjectPool<PredictionEngine<TData, TPrediction>> _pool;
+        private static readonly ObjectPoolProvider _poolProvider = new DefaultObjectPoolProvider();
+
+        private ObjectPool<PredictionEngine<TData, TPrediction>> _pool;
+        private ITransformer _model;
         private readonly IDisposable _changeTokenRegistration;
+
+        private readonly ConditionalWeakTable<PredictionEngine<TData, TPrediction>, ObjectPool<PredictionEngine<TData, TPrediction>>> _rentedEngines;
+        private bool _disposed;
 
         public PoolLoader(IServiceProvider sp, PredictionEnginePoolOptions<TData, TPrediction> poolOptions)
         {
             var contextOptions = sp.GetRequiredService<IOptions<MLOptions>>();
             Context = contextOptions.Value.MLContext ?? throw new ArgumentNullException(nameof(contextOptions));
             Loader = poolOptions.ModelLoader ?? throw new ArgumentNullException(nameof(poolOptions));
+
+            _rentedEngines = new ConditionalWeakTable<PredictionEngine<TData, TPrediction>, ObjectPool<PredictionEngine<TData, TPrediction>>>();
 
             LoadPool();
 
@@ -37,17 +46,104 @@ namespace Microsoft.Extensions.ML
 
         public ModelLoader Loader { get; }
         private MLContext Context { get; }
-        public ObjectPool<PredictionEngine<TData, TPrediction>> PredictionEnginePool { get { return _pool; } }
+
+        /// <summary>
+        /// The active pool generation. Exposed for compatibility; prefer <see cref="Get"/> and
+        /// <see cref="Return"/>, which route an engine back to the generation that created it.
+        /// </summary>
+        public ObjectPool<PredictionEngine<TData, TPrediction>> PredictionEnginePool { get { return Volatile.Read(ref _pool); } }
+
+        /// <summary>
+        /// Rents an engine from the current pool generation, recording its origin so it can be
+        /// returned to the correct generation later.
+        /// </summary>
+        public PredictionEngine<TData, TPrediction> Get()
+        {
+            var pool = Volatile.Read(ref _pool);
+            if (_disposed || pool == null)
+            {
+                throw new ObjectDisposedException(nameof(PoolLoader<TData, TPrediction>));
+            }
+
+            var engine = pool.Get();
+
+            _rentedEngines.Remove(engine);
+            _rentedEngines.Add(engine, pool);
+            return engine;
+        }
+
+        /// <summary>
+        /// Returns an engine to the generation it was rented from. If that generation has already
+        /// been disposed by a hot-swap, the pool disposes the engine instead of retaining it.
+        /// </summary>
+        public void Return(PredictionEngine<TData, TPrediction> engine)
+        {
+            if (engine == null)
+            {
+                throw new ArgumentNullException(nameof(engine));
+            }
+
+            if (_rentedEngines.TryGetValue(engine, out var origin))
+            {
+                _rentedEngines.Remove(engine);
+                origin.Return(engine);
+            }
+            else
+            {
+                engine.Dispose();
+            }
+        }
 
         private void LoadPool()
         {
-            var predictionEnginePolicy = new PredictionEnginePoolPolicy<TData, TPrediction>(Context, Loader.GetModel());
-            Interlocked.Exchange(ref _pool, new DefaultObjectPool<PredictionEngine<TData, TPrediction>>(predictionEnginePolicy));
+            if (_disposed)
+            {
+                return;
+            }
+
+            var model = Loader.GetModel();
+            var policy = new PredictionEnginePoolPolicy<TData, TPrediction>(Context, model);
+            var newPool = _poolProvider.Create(policy);
+
+            var oldPool = Interlocked.Exchange(ref _pool, newPool);
+            var oldModel = Interlocked.Exchange(ref _model, model);
+
+            DisposeGeneration(oldPool, oldModel, model);
+
+            if (_disposed && Interlocked.CompareExchange(ref _pool, null, newPool) == newPool)
+            {
+                DisposeGeneration(newPool, model, null);
+            }
+        }
+
+        private static void DisposeGeneration(
+            ObjectPool<PredictionEngine<TData, TPrediction>> pool,
+            ITransformer model,
+            ITransformer survivingModel)
+        {
+            (pool as IDisposable)?.Dispose();
+
+            if (model != null && !ReferenceEquals(model, survivingModel))
+            {
+                (model as IDisposable)?.Dispose();
+            }
         }
 
         public void Dispose()
         {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
             _changeTokenRegistration?.Dispose();
+
+            var pool = Interlocked.Exchange(ref _pool, null);
+            var model = Interlocked.Exchange(ref _model, null);
+            DisposeGeneration(pool, model, null);
+
+            (Loader as IDisposable)?.Dispose();
         }
     }
 }

--- a/src/Microsoft.Extensions.ML/PredictionEnginePool.cs
+++ b/src/Microsoft.Extensions.ML/PredictionEnginePool.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Extensions.ML
     /// Provides a pool of <see cref="PredictionEngine{TSrc, TDst}"/> objects
     /// that can be used to make predictions.
     /// </summary>
-    public class PredictionEnginePool<TData, TPrediction>
+    public class PredictionEnginePool<TData, TPrediction> : IDisposable
         where TData : class
         where TPrediction : class, new()
     {
@@ -23,6 +23,7 @@ namespace Microsoft.Extensions.ML
         private readonly IServiceProvider _serviceProvider;
         private readonly PoolLoader<TData, TPrediction> _defaultEnginePool;
         private readonly ConcurrentDictionary<string, PoolLoader<TData, TPrediction>> _namedPools;
+        private bool _disposed;
 
         public PredictionEnginePool(IServiceProvider serviceProvider,
                                     IOptions<MLOptions> mlContextOptions,
@@ -85,9 +86,14 @@ namespace Microsoft.Extensions.ML
         /// </param>
         public PredictionEngine<TData, TPrediction> GetPredictionEngine(string modelName)
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(PredictionEnginePool<TData, TPrediction>));
+            }
+
             if (_namedPools.TryGetValue(modelName, out var existingPool))
             {
-                return existingPool.PredictionEnginePool.Get();
+                return existingPool.Get();
             }
 
             //This is the case where someone has used string.Empty to get the default model.
@@ -100,11 +106,11 @@ namespace Microsoft.Extensions.ML
                     throw new ArgumentException("You need to configure a default, not named, model before you use this method.");
                 }
 
-                return _defaultEnginePool.PredictionEnginePool.Get();
+                return _defaultEnginePool.Get();
             }
 
             var pool = AddPool(modelName);
-            return pool.PredictionEnginePool.Get();
+            return pool.Get();
         }
 
         private PoolLoader<TData, TPrediction> AddPool(string modelName)
@@ -141,14 +147,52 @@ namespace Microsoft.Extensions.ML
                 throw new ArgumentNullException(nameof(engine));
             }
 
+            if (_disposed)
+            {
+                engine.Dispose();
+                return;
+            }
+
             if (string.IsNullOrEmpty(modelName))
             {
-                _defaultEnginePool.PredictionEnginePool.Return(engine);
+                if (_defaultEnginePool != null)
+                {
+                    _defaultEnginePool.Return(engine);
+                }
+                else
+                {
+                    engine.Dispose();
+                }
+            }
+            else if (_namedPools.TryGetValue(modelName, out var pool))
+            {
+                pool.Return(engine);
             }
             else
             {
-                _namedPools[modelName].PredictionEnginePool.Return(engine);
+                engine.Dispose();
             }
+        }
+
+        /// <summary>
+        /// Disposes the pooled prediction engines and releases the file/uri watchers backing each
+        /// model loader.
+        /// </summary>
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+
+            _defaultEnginePool?.Dispose();
+            foreach (var pool in _namedPools.Values)
+            {
+                pool.Dispose();
+            }
+            _namedPools.Clear();
         }
     }
 }

--- a/src/Microsoft.Extensions.ML/PredictionEnginePool.cs
+++ b/src/Microsoft.Extensions.ML/PredictionEnginePool.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Threading;
 using Microsoft.Extensions.Options;
 using Microsoft.ML;
 
@@ -23,7 +24,7 @@ namespace Microsoft.Extensions.ML
         private readonly IServiceProvider _serviceProvider;
         private readonly PoolLoader<TData, TPrediction> _defaultEnginePool;
         private readonly ConcurrentDictionary<string, PoolLoader<TData, TPrediction>> _namedPools;
-        private bool _disposed;
+        private int _disposed;
 
         public PredictionEnginePool(IServiceProvider serviceProvider,
                                     IOptions<MLOptions> mlContextOptions,
@@ -86,7 +87,7 @@ namespace Microsoft.Extensions.ML
         /// </param>
         public PredictionEngine<TData, TPrediction> GetPredictionEngine(string modelName)
         {
-            if (_disposed)
+            if (Volatile.Read(ref _disposed) != 0)
             {
                 throw new ObjectDisposedException(nameof(PredictionEnginePool<TData, TPrediction>));
             }
@@ -147,7 +148,7 @@ namespace Microsoft.Extensions.ML
                 throw new ArgumentNullException(nameof(engine));
             }
 
-            if (_disposed)
+            if (Volatile.Read(ref _disposed) != 0)
             {
                 engine.Dispose();
                 return;
@@ -180,12 +181,10 @@ namespace Microsoft.Extensions.ML
         /// </summary>
         public void Dispose()
         {
-            if (_disposed)
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
             {
                 return;
             }
-
-            _disposed = true;
 
             _defaultEnginePool?.Dispose();
             foreach (var pool in _namedPools.Values)

--- a/src/Microsoft.Extensions.ML/PredictionEnginePoolPolicy.cs
+++ b/src/Microsoft.Extensions.ML/PredictionEnginePoolPolicy.cs
@@ -34,7 +34,9 @@ namespace Microsoft.Extensions.ML
 
         /// <inheritdoc />
         public override PredictionEngine<TData, TPrediction> Create() =>
-            _mlContext.Model.CreatePredictionEngine<TData, TPrediction>(_model);
+            _mlContext.Model.CreatePredictionEngine<TData, TPrediction>(
+                _model,
+                new PredictionEngineOptions { OwnsTransformer = false });
 
         /// <inheritdoc />
         public override bool Return(PredictionEngine<TData, TPrediction> obj) => true;

--- a/test/Microsoft.Extensions.ML.Tests/PredictionEnginePoolTests.cs
+++ b/test/Microsoft.Extensions.ML.Tests/PredictionEnginePoolTests.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 using Microsoft.ML.TestFramework;
 using Microsoft.ML.TestFrameworkCommon;
@@ -39,6 +40,134 @@ namespace Microsoft.Extensions.ML
             var model = pool.GetModel("model1");
 
             Assert.NotNull(model);
+        }
+
+        [Fact]
+        public void pool_serves_predictions_across_a_hot_swap()
+        {
+            var loader = CreateReloadableLoader();
+            using var pool = CreatePool(loader);
+
+            var inFlight = pool.GetPredictionEngine();
+            Assert.NotNull(inFlight.Predict(new SentimentData { SentimentText = "great" }));
+
+            loader.Reload();
+
+            var afterSwap = pool.GetPredictionEngine();
+            Assert.NotNull(afterSwap.Predict(new SentimentData { SentimentText = "terrible" }));
+            pool.ReturnPredictionEngine(afterSwap);
+
+            pool.ReturnPredictionEngine(inFlight);
+
+            var reused = pool.GetPredictionEngine();
+            Assert.NotSame(inFlight, reused);
+            Assert.NotNull(reused.Predict(new SentimentData { SentimentText = "fine" }));
+            pool.ReturnPredictionEngine(reused);
+        }
+
+        [Fact]
+        public void disposing_pool_releases_loader_resources()
+        {
+            var loader = CreateReloadableLoader();
+            var pool = CreatePool(loader);
+
+            _ = pool.GetPredictionEngine();
+            pool.Dispose();
+
+            loader.Reload();
+            pool.Dispose();
+        }
+
+        [Fact]
+        public void pooled_engines_do_not_dispose_the_shared_model()
+        {
+            var context = new MLContext(seed: 1);
+            using var stream = File.OpenRead(Path.Combine("TestModels", "SentimentModel.zip"));
+            var innerModel = context.Model.Load(stream, out _);
+            var model = new DisposeCountingTransformer(innerModel);
+            var loader = new ReloadableModelLoader(model);
+            using var pool = CreatePool(loader);
+
+            var maximumRetained = Environment.ProcessorCount * 2;
+            var rented = new PredictionEngine<SentimentData, SentimentPrediction>[maximumRetained + 2];
+            for (var i = 0; i < rented.Length; i++)
+            {
+                rented[i] = pool.GetPredictionEngine();
+            }
+
+            foreach (var engine in rented)
+            {
+                pool.ReturnPredictionEngine(engine);
+            }
+
+            Assert.Equal(0, model.DisposeCount);
+
+            var afterOverflow = pool.GetPredictionEngine();
+            Assert.NotNull(afterOverflow.Predict(new SentimentData { SentimentText = "still works" }));
+            pool.ReturnPredictionEngine(afterOverflow);
+        }
+
+        private static ReloadableModelLoader CreateReloadableLoader()
+        {
+            var context = new MLContext(seed: 1);
+            using var stream = File.OpenRead(Path.Combine("TestModels", "SentimentModel.zip"));
+            var model = context.Model.Load(stream, out _);
+            return new ReloadableModelLoader(model);
+        }
+
+        private static PredictionEnginePool<SentimentData, SentimentPrediction> CreatePool(ModelLoader loader)
+        {
+            var services = new ServiceCollection().AddOptions().AddLogging();
+            services.AddPredictionEnginePool<SentimentData, SentimentPrediction>();
+            services.Configure<PredictionEnginePoolOptions<SentimentData, SentimentPrediction>>(
+                string.Empty, o => o.ModelLoader = loader);
+
+            var sp = services.BuildServiceProvider();
+            return sp.GetRequiredService<PredictionEnginePool<SentimentData, SentimentPrediction>>();
+        }
+
+        private sealed class ReloadableModelLoader : ModelLoader
+        {
+            private readonly ITransformer _model;
+            private ModelReloadToken _token = new ModelReloadToken();
+
+            public ReloadableModelLoader(ITransformer model) => _model = model;
+
+            public override IChangeToken GetReloadToken() => _token;
+
+            public override ITransformer GetModel() => _model;
+
+            public void Reload()
+            {
+                var previous = Interlocked.Exchange(ref _token, new ModelReloadToken());
+                previous.OnReload();
+            }
+        }
+
+        private sealed class DisposeCountingTransformer : ITransformer, IDisposable
+        {
+            private readonly ITransformer _inner;
+            private int _disposeCount;
+
+            public DisposeCountingTransformer(ITransformer inner) => _inner = inner;
+
+            public int DisposeCount => _disposeCount;
+
+            public bool IsRowToRowMapper => _inner.IsRowToRowMapper;
+
+            public DataViewSchema GetOutputSchema(DataViewSchema inputSchema) => _inner.GetOutputSchema(inputSchema);
+
+            public IDataView Transform(IDataView input) => _inner.Transform(input);
+
+            public IRowToRowMapper GetRowToRowMapper(DataViewSchema inputSchema) => _inner.GetRowToRowMapper(inputSchema);
+
+            public void Save(ModelSaveContext ctx) => _inner.Save(ctx);
+
+            public void Dispose()
+            {
+                Interlocked.Increment(ref _disposeCount);
+                (_inner as IDisposable)?.Dispose();
+            }
         }
 
         public class SentimentData


### PR DESCRIPTION
## Description

This PR makes zero-downtime model hot-swapping in Microsoft.Extensions.ML safe under live traffic. Before this change, reloading a PredictionEnginePool had three problems. It leaked native memory, because the pool was built with new DefaultObjectPool, which never disposes the prediction engines it holds, so every reload abandoned a generation of native engines. It could also serve predictions from the old model, because a returned engine always went back to the current pool, so an engine rented against the previous model could be handed out by the new pool after a swap. And it risked disposing the shared model out from under other engines, because each engine was created with ownsTransformer set to true and so believed it solely owned the single shared transformer. 

This PR builds each pool generation with DefaultObjectPoolProvider, which returns the framework's DisposableObjectPool for disposable types and disposes engines for us. It routes each rented engine back to the exact generation it came from using a ConditionalWeakTable and disposes the old generation atomically on swap. It creates engines with ownsTransformer set to false, so PoolLoader owns the shared model's lifetime per generation and disposes it only when no surviving generation still uses it. PredictionEnginePool now also implements IDisposable, guards against use after disposal, and disposes its loaders so the file and uri watchers are torn down. New tests cover serving across an in-flight hot-swap, loader disposal, and a regression test that forces overflow disposal and confirms the shared model is never disposed.