### PR TITLE
Update CI pool image to 1es-windows-2022-open

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -167,7 +167,7 @@ jobs:
     vsTestConfiguration: "/Framework:.NETCoreApp,Version=v6.0"
     pool:
       name: NetCore-Public
-      demands: ImageOverride -equals 1es-windows-2019-open
+      demands: ImageOverride -equals 1es-windows-2022-open
     helixQueue: windows.11.arm64.open
 
 - template: /build/ci/job-template.yml
@@ -178,7 +178,7 @@ jobs:
     vsTestConfiguration: "/Framework:.NETCoreApp,Version=v3.1"
     pool:
       name: NetCore-Public
-      demands: ImageOverride -equals 1es-windows-2019-open
+      demands: ImageOverride -equals 1es-windows-2022-open
     helixQueue: Windows.10.Amd64.Open
 
 - template: /build/ci/job-template.yml
@@ -200,7 +200,7 @@ jobs:
     vsTestConfiguration: "/Framework:.NETCoreApp,Version=v4.0"
     pool:
       name: NetCore-Public
-      demands: ImageOverride -equals 1es-windows-2019-open
+      demands: ImageOverride -equals 1es-windows-2022-open
     helixQueue: Windows.10.Amd64.Open
 
 - template: /build/ci/job-template.yml
@@ -212,5 +212,5 @@ jobs:
     vsTestConfiguration: "/Framework:.NETCoreApp,Version=v3.1"
     pool:
       name: NetCore-Public
-      demands: ImageOverride -equals 1es-windows-2019-open
+      demands: ImageOverride -equals 1es-windows-2022-open
     helixQueue: Windows.10.Amd64.Open

--- a/build/codecoverage-ci.yml
+++ b/build/codecoverage-ci.yml
@@ -48,4 +48,4 @@ jobs:
     codeCoverage: true
     pool:
       name: NetCore-Public
-      demands: ImageOverride -equals 1es-windows-2019-open
+      demands: ImageOverride -equals 1es-windows-2022-open


### PR DESCRIPTION
Replaces the retired `1es-windows-2019-open` image with `1es-windows-2022-open` in the `NetCore-Public` pool to fix agent allocation failures in CI.