### PR TITLE
[ci-scan] Add Hard Rule 10 for early exit on no scannable build

### DIFF
--- a/.github/workflows/ci-scan.agent.md
+++ b/.github/workflows/ci-scan.agent.md
@@ -78,6 +78,7 @@ These invariants are not delegated to the shared file. Honor them even if a shar
 7. **All state under `/tmp/gh-aw/agent/`;** each bash call is a fresh subshell.
 8. **AzDO REST is anonymous;** stay on `https://dev.azure.com/dnceng-public/public/_apis/build/...`. Follow every rule in [Environment constraints](shared/ci-scan.instructions.md#environment-constraints) (pre-bind URLs, `%24top`, no redirection).
 9. **Sanitize every embedded log excerpt** per [Sanitization](shared/ci-scan.instructions.md#sanitization).
+10. **Exit immediately on empty build window.** When Step 1 determines no scannable build exists, immediately: append one outcome line to `/tmp/gh-aw/agent/coverage/MachineLearning-CI.txt` with the skip reason, print `| 0 | 0 | 0 | 1 |` as the Step 7 tally, emit `noop` with the skip reason, and stop. Do not fetch the AzDO timeline, download task logs, query Helix work items, or execute any step beyond Step 1.
 
 ## Step 1 - Select the source build
 
@@ -88,7 +89,7 @@ url='https://dev.azure.com/dnceng-public/public/_apis/build/builds?definitions=1
 curl -s "$url" | tee /tmp/gh-aw/agent/builds.json | jq -r '.value[] | "\(.id) \(.result) \(.finishTime)"' | head -25
 ```
 
-If selection yields no scannable build, record the matching skip reason (`stale build window (>14d)`, `no follow-up build yet, defer to next run`, or `no failed build in 7d`) and stop.
+If selection yields no scannable build, apply **Hard Rule 10** immediately.
 
 ## Step 2 - Walk the timeline
 

--- a/.github/workflows/ci-scan.agent.md
+++ b/.github/workflows/ci-scan.agent.md
@@ -78,7 +78,7 @@ These invariants are not delegated to the shared file. Honor them even if a shar
 7. **All state under `/tmp/gh-aw/agent/`;** each bash call is a fresh subshell.
 8. **AzDO REST is anonymous;** stay on `https://dev.azure.com/dnceng-public/public/_apis/build/...`. Follow every rule in [Environment constraints](shared/ci-scan.instructions.md#environment-constraints) (pre-bind URLs, `%24top`, no redirection).
 9. **Sanitize every embedded log excerpt** per [Sanitization](shared/ci-scan.instructions.md#sanitization).
-10. **Exit immediately on empty build window.** When Step 1 determines no scannable build exists, immediately: append one outcome line to `/tmp/gh-aw/agent/coverage/MachineLearning-CI.txt` with the skip reason, print `| 0 | 0 | 0 | 1 |` as the Step 7 tally, emit `noop` with the skip reason, and stop. Do not fetch the AzDO timeline, download task logs, query Helix work items, or execute any step beyond Step 1.
+10. **Exit immediately on empty build window.** When Step 1 determines no scannable build exists, immediately append one Step 7 coverage line to `/tmp/gh-aw/agent/coverage/MachineLearning-CI.txt` in the documented `<sig-short>  <outcome>  <reason-if-skipped>` format as `-  skipped: <reason>`, print the full Step 7 summary table (the `| total-signatures | issues-filed | reused-existing | skipped-with-reason |` header followed by the `| 0 | 0 | 0 | 1 |` row), emit `noop` with the skip reason, and stop. Do not fetch the AzDO timeline, download task logs, query Helix work items, or execute any step beyond Step 1.
 
 ## Step 1 - Select the source build
 


### PR DESCRIPTION
## Description

Adds Hard Rule 10 to ci-scan.agent.md so the scanner exits immediately when Step 1 finds no scannable build instead of continuing through later steps and burning hundreds of thousands of tokens on a run that ends in a no-op. The rule appends the documented Step 7 coverage line, prints the full Step 7 summary table including the skipped-with-reason count, emits noop, and stops without fetching the AzDO timeline, downloading task logs, or querying Helix. This is the change the ci-scan-feedback workflow proposed repeatedly but could not push, and the lock file runtime-imports the prompt so no recompile is needed.