### PR TITLE
Use direct URLs for test resources

### DIFF
--- a/test/Microsoft.ML.AutoML.Tests/DatasetUtil.cs
+++ b/test/Microsoft.ML.AutoML.Tests/DatasetUtil.cs
@@ -185,7 +185,7 @@ namespace Microsoft.ML.AutoML.Test
         public static string DownloadImageSet(string imagesDownloadFolder)
         {
             string fileName = "flower_photos_tiny_set_for_unit_tests.zip";
-            string url = $"https://aka.ms/mlnet-resources/datasets/flower_photos_tiny_set_for_unit_test.zip";
+            string url = "https://mlpublicassets.blob.core.windows.net/assets/datasets/flower_photos_tiny_set_for_unit_tests.zip";
 
             Download(url, imagesDownloadFolder, fileName).Wait();
             UnZip(Path.Combine(imagesDownloadFolder, fileName), imagesDownloadFolder);

--- a/test/Microsoft.ML.PerformanceTests/BenchmarkBase.cs
+++ b/test/Microsoft.ML.PerformanceTests/BenchmarkBase.cs
@@ -39,9 +39,6 @@ namespace Microsoft.ML.PerformanceTests
             if (File.Exists(filePath))
                 return filePath;
 
-            var localPath = path == "" ?
-                Path.GetFullPath(DataDir) :
-                Path.GetFullPath(Path.Combine(DataDir, path));
             string url;
             if (path == "")
             {

--- a/test/Microsoft.ML.PerformanceTests/BenchmarkBase.cs
+++ b/test/Microsoft.ML.PerformanceTests/BenchmarkBase.cs
@@ -4,8 +4,6 @@
 
 using System;
 using System.IO;
-using Microsoft.ML.Internal.Utilities;
-using Microsoft.ML.Runtime;
 using Microsoft.ML.TestFrameworkCommon;
 
 namespace Microsoft.ML.PerformanceTests
@@ -41,25 +39,23 @@ namespace Microsoft.ML.PerformanceTests
             if (File.Exists(filePath))
                 return filePath;
 
-            var mlContext = new MLContext(1);
-            int timeout = 10 * 60 * 1000;
-            string url = $"benchmarks/{name}";
             var localPath = path == "" ?
                 Path.GetFullPath(DataDir) :
                 Path.GetFullPath(Path.Combine(DataDir, path));
-
-            using (var ch = (mlContext as IHostEnvironment).Start("Ensuring dataset files are present."))
+            string url;
+            if (path == "")
             {
-                var ensureModel = ResourceManagerUtils.Instance.EnsureResourceAsync(
-                    mlContext, ch, url, name, localPath, timeout);
-                ensureModel.Wait();
-                var errorResult = ResourceManagerUtils.GetErrorMessage(out var errorMessage, ensureModel.Result);
-                if (errorResult != null)
-                {
-                    throw ch.Except($"{errorMessage}\n{name} could not be downloaded!");
-                }
+                url = $"https://raw.githubusercontent.com/dotnet/machinelearning/main/test/data/{name.Replace('\\', '/')}";
+            }
+            else
+            {
+                var blobName = Path.GetFileName(name);
+                if (blobName == "WikiDetoxAnnotated160kRows.tsv")
+                    blobName = "wikiDetoxAnnotated160kRows.tsv";
+                url = $"https://mlpublicassets.blob.core.windows.net/assets/benchmarks/{blobName}";
             }
 
+            TestDownloadUtils.DownloadFile(url, filePath, TimeSpan.FromMinutes(10));
             return filePath;
         }
     }

--- a/test/Microsoft.ML.PerformanceTests/BenchmarkBase.cs
+++ b/test/Microsoft.ML.PerformanceTests/BenchmarkBase.cs
@@ -27,30 +27,27 @@ namespace Microsoft.ML.PerformanceTests
         // is running is it sometime cause process hanging when the constructor trying 
         // to load MKL, this is related to below issue:
         // https://github.com/dotnet/machinelearning/issues/1073
-        public static string GetBenchmarkDataPathAndEnsureData(string name, string path = "")
+        public static string GetLocalBenchmarkDataPath(string name)
         {
             if (string.IsNullOrWhiteSpace(name))
                 return null;
 
-            var filePath = path == "" ?
-                Path.GetFullPath(Path.Combine(DataDir, name)) :
-                Path.GetFullPath(Path.Combine(DataDir, path, name));
+            return Path.GetFullPath(Path.Combine(DataDir, name));
+        }
 
+        public static string GetBenchmarkDataPathAndEnsureData(string name, string path)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                return null;
+
+            var filePath = Path.GetFullPath(Path.Combine(DataDir, path, name));
             if (File.Exists(filePath))
                 return filePath;
 
-            string url;
-            if (path == "")
-            {
-                url = $"https://raw.githubusercontent.com/dotnet/machinelearning/main/test/data/{name.Replace('\\', '/')}";
-            }
-            else
-            {
-                var blobName = Path.GetFileName(name);
-                if (blobName == "WikiDetoxAnnotated160kRows.tsv")
-                    blobName = "wikiDetoxAnnotated160kRows.tsv";
-                url = $"https://mlpublicassets.blob.core.windows.net/assets/benchmarks/{blobName}";
-            }
+            var blobName = Path.GetFileName(name);
+            if (blobName == "WikiDetoxAnnotated160kRows.tsv")
+                blobName = "wikiDetoxAnnotated160kRows.tsv";
+            string url = $"https://mlpublicassets.blob.core.windows.net/assets/benchmarks/{blobName}";
 
             TestDownloadUtils.DownloadFile(url, filePath, TimeSpan.FromMinutes(10));
             return filePath;

--- a/test/Microsoft.ML.PerformanceTests/HashBench.cs
+++ b/test/Microsoft.ML.PerformanceTests/HashBench.cs
@@ -100,7 +100,7 @@ namespace Microsoft.ML.PerformanceTests
                 getter = (ref T dst) => dst = val;
             _inRow = RowImpl.Create(type, getter);
 
-            var modelPath = GetBenchmarkDataPathAndEnsureData("backcompat/MurmurHashV1.zip");
+            var modelPath = GetLocalBenchmarkDataPath("backcompat/MurmurHashV1.zip");
             var estimator = _env.Model.Load(modelPath, out var schema);
             var mapper = ((ITransformer)estimator).GetRowToRowMapper(_inRow.Schema);
             var column = mapper.OutputSchema["Bar"];

--- a/test/Microsoft.ML.PerformanceTests/ImageClassificationBench.cs
+++ b/test/Microsoft.ML.PerformanceTests/ImageClassificationBench.cs
@@ -139,7 +139,7 @@ namespace Microsoft.ML.PerformanceTests
 
             //SINGLE SMALL FLOWERS IMAGESET (200 files)
             string fileName = "flower_photos_small_set.zip";
-            string url = $"https://aka.ms/mlnet-resources/datasets/flower_photos_small_set.zip/";
+            string url = "https://mlpublicassets.blob.core.windows.net/assets/datasets/flower_photos_small_set.zip";
 
             Download(url, imagesDownloadFolder, fileName);
             UnZip(Path.Combine(imagesDownloadFolder, fileName), imagesDownloadFolder);

--- a/test/Microsoft.ML.PerformanceTests/KMeansAndLogisticRegressionBench.cs
+++ b/test/Microsoft.ML.PerformanceTests/KMeansAndLogisticRegressionBench.cs
@@ -13,7 +13,7 @@ namespace Microsoft.ML.PerformanceTests
     [CIBenchmark]
     public class KMeansAndLogisticRegressionBench : BenchmarkBase
     {
-        private readonly string _dataPath = GetBenchmarkDataPathAndEnsureData("adult.with-schema.txt");
+        private readonly string _dataPath = GetLocalBenchmarkDataPath("adult.with-schema.txt");
 
         [Benchmark]
         public CalibratedModelParametersBase<LinearBinaryModelParameters, PlattCalibrator> TrainKMeansAndLR()

--- a/test/Microsoft.ML.PerformanceTests/PredictionEngineBench.cs
+++ b/test/Microsoft.ML.PerformanceTests/PredictionEngineBench.cs
@@ -33,7 +33,7 @@ namespace Microsoft.ML.PerformanceTests
                 PetalWidth = 5.1f,
             };
 
-            string irisDataPath = GetBenchmarkDataPathAndEnsureData("iris.txt");
+            string irisDataPath = GetLocalBenchmarkDataPath("iris.txt");
 
             var env = new MLContext(seed: 1);
 
@@ -72,7 +72,7 @@ namespace Microsoft.ML.PerformanceTests
                 SentimentText = "Not a big fan of this."
             };
 
-            string sentimentDataPath = GetBenchmarkDataPathAndEnsureData("wikipedia-detox-250-line-data.tsv");
+            string sentimentDataPath = GetLocalBenchmarkDataPath("wikipedia-detox-250-line-data.tsv");
 
             var mlContext = new MLContext(seed: 1);
 
@@ -107,7 +107,7 @@ namespace Microsoft.ML.PerformanceTests
                 Features = new[] { 5f, 1f, 1f, 1f, 2f, 1f, 3f, 1f, 1f }
             };
 
-            string breastCancerDataPath = GetBenchmarkDataPathAndEnsureData("breast-cancer.txt");
+            string breastCancerDataPath = GetLocalBenchmarkDataPath("breast-cancer.txt");
 
             var env = new MLContext(seed: 1);
 

--- a/test/Microsoft.ML.PerformanceTests/StochasticDualCoordinateAscentClassifierBench.cs
+++ b/test/Microsoft.ML.PerformanceTests/StochasticDualCoordinateAscentClassifierBench.cs
@@ -17,8 +17,8 @@ namespace Microsoft.ML.PerformanceTests
     [CIBenchmark]
     public class StochasticDualCoordinateAscentClassifierBench : WithExtraMetrics
     {
-        private readonly string _dataPath = GetBenchmarkDataPathAndEnsureData("iris.txt");
-        private readonly string _sentimentDataPath = GetBenchmarkDataPathAndEnsureData("wikipedia-detox-250-line-data.tsv");
+        private readonly string _dataPath = GetLocalBenchmarkDataPath("iris.txt");
+        private readonly string _sentimentDataPath = GetLocalBenchmarkDataPath("wikipedia-detox-250-line-data.tsv");
         private readonly Consumer _consumer = new Consumer(); // BenchmarkDotNet utility type used to prevent dead code elimination
 
         private readonly MLContext _mlContext = new MLContext(seed: 1);

--- a/test/Microsoft.ML.PerformanceTests/TextPredictionEngineCreation.cs
+++ b/test/Microsoft.ML.PerformanceTests/TextPredictionEngineCreation.cs
@@ -22,7 +22,7 @@ namespace micro
         {
             _context = new MLContext(1);
             var data = _context.Data.LoadFromTextFile<SentimentData>(
-                GetBenchmarkDataPathAndEnsureData("wikipedia-detox-250-line-data.tsv"), hasHeader: true);
+                GetLocalBenchmarkDataPath("wikipedia-detox-250-line-data.tsv"), hasHeader: true);
 
             // Pipeline.
             var pipeline = _context.Transforms.Text.FeaturizeText("Features", "SentimentText")

--- a/test/Microsoft.ML.TensorFlow.Tests/TensorflowTests.cs
+++ b/test/Microsoft.ML.TensorFlow.Tests/TensorflowTests.cs
@@ -8,8 +8,6 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using Microsoft.ML.Data;
-using Microsoft.ML.Internal.Utilities;
-using Microsoft.ML.Runtime;
 using Microsoft.ML.TensorFlow;
 using Microsoft.ML.TestFramework;
 using Microsoft.ML.TestFramework.Attributes;
@@ -61,7 +59,6 @@ namespace Microsoft.ML.TensorFlow.Scenarios
     {
         private readonly string _fullImagesetFolderPath;
         private readonly string _finalImagesFolderName;
-        private string _timeOutOldValue;
         private MLContext _mlContext = new MLContext(seed: 1);
 
         public TensorFlowScenariosTests(ITestOutputHelper output) : base(output)
@@ -75,19 +72,6 @@ namespace Microsoft.ML.TensorFlow.Scenarios
 
             _fullImagesetFolderPath = Path.Combine(
                 imagesDownloadFolderPath, _finalImagesFolderName);
-        }
-
-        protected override void Initialize()
-        {
-            // set timeout to 3 minutes, download sometimes will stuck so set smaller timeout to fail fast and retry download
-            _timeOutOldValue = Environment.GetEnvironmentVariable(ResourceManagerUtils.TimeoutEnvVariable);
-            Environment.SetEnvironmentVariable(ResourceManagerUtils.TimeoutEnvVariable, (3 * 60 * 1000).ToString());
-        }
-
-        protected override void Cleanup()
-        {
-            // set back timeout value
-            Environment.SetEnvironmentVariable(ResourceManagerUtils.TimeoutEnvVariable, _timeOutOldValue);
         }
 
         private class TestData
@@ -1952,7 +1936,7 @@ namespace Microsoft.ML.TensorFlow.Scenarios
         {
             string fileName = "flower_photos_tiny_set_for_unit_tests.zip";
             string filenameAlias = "FPTSUT"; // FPTSUT = flower photos tiny set for unit tests
-            string url = "datasets/flower_photos_tiny_set_for_unit_test.zip";
+            string url = "https://mlpublicassets.blob.core.windows.net/assets/datasets/flower_photos_tiny_set_for_unit_tests.zip";
 
             Download(url, imagesDownloadFolder, fileName);
             UnZip(Path.Combine(imagesDownloadFolder, fileName), imagesDownloadFolder);
@@ -1965,7 +1949,7 @@ namespace Microsoft.ML.TensorFlow.Scenarios
         public string DownloadBadImageSet(string imagesDownloadFolder)
         {
             string fileName = "CatsVsDogs_tiny_for_unit_tests.zip";
-            string url = "datasets/CatsVsDogs_tiny_for_unit_tests.zip";
+            string url = "https://mlpublicassets.blob.core.windows.net/assets/datasets/CatsVsDogs_tiny_for_unit_tests.zip";
 
             Download(url, imagesDownloadFolder, fileName);
             UnZip(Path.Combine(imagesDownloadFolder, fileName), imagesDownloadFolder);
@@ -1985,20 +1969,7 @@ namespace Microsoft.ML.TensorFlow.Scenarios
             if (File.Exists(relativeFilePath))
                 return false;
 
-            int timeout = 10 * 60 * 1000;
-            using (var ch = (_mlContext as IHostEnvironment).Start("Ensuring image files are present."))
-            {
-                var ensureModel = ResourceManagerUtils.Instance.EnsureResourceAsync(_mlContext, ch, url, destFileName, destDir, timeout);
-                ensureModel.Wait();
-                var errorResult = ResourceManagerUtils.GetErrorMessage(out var errorMessage, ensureModel.Result);
-                if (errorResult != null)
-                {
-                    var directory = Path.GetDirectoryName(errorResult.FileName);
-                    var name = Path.GetFileName(errorResult.FileName);
-                    throw ch.Except($"{errorMessage}\nImage file could not be downloaded!");
-                }
-            }
-
+            TestDownloadUtils.DownloadFile(url, relativeFilePath, TimeSpan.FromMinutes(3));
             return true;
         }
 

--- a/test/Microsoft.ML.TestFrameworkCommon/Microsoft.ML.TestFrameworkCommon.csproj
+++ b/test/Microsoft.ML.TestFrameworkCommon/Microsoft.ML.TestFrameworkCommon.csproj
@@ -2,6 +2,10 @@
 
   <Import Project="..\TestFrameworkDependency.props" />
 
+  <PropertyGroup>
+    <Nullable>annotations</Nullable>
+  </PropertyGroup>
+
   <ItemGroup>
     <None Update="xunit.runner.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -11,6 +15,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyModel" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\src\Common\tests\RetryHelper.cs" Link="RetryHelper.cs" />
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.ML.TestFrameworkCommon/TestDownloadUtils.cs
+++ b/test/Microsoft.ML.TestFrameworkCommon/TestDownloadUtils.cs
@@ -1,0 +1,59 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.ML.TestFrameworkCommon
+{
+    public static class TestDownloadUtils
+    {
+        public static void DownloadFile(string url, string filePath, TimeSpan timeout)
+        {
+            var directory = Path.GetDirectoryName(filePath);
+            if (!string.IsNullOrEmpty(directory))
+                Directory.CreateDirectory(directory);
+
+            string temporaryFilePath = $"{filePath}.{Guid.NewGuid():N}.download";
+            using (var client = new HttpClient { Timeout = Timeout.InfiniteTimeSpan })
+            {
+                RetryHelper.Execute(() =>
+                {
+                    try
+                    {
+                        if (File.Exists(filePath))
+                            return;
+
+                        using (var cancellationSource = new CancellationTokenSource(timeout))
+                        using (var response = client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancellationSource.Token).GetAwaiter().GetResult())
+                        {
+                            response.EnsureSuccessStatusCode();
+                            using (var contentStream = response.Content.ReadAsStreamAsync().GetAwaiter().GetResult())
+                            using (var fileStream = new FileStream(temporaryFilePath, FileMode.Create, FileAccess.Write, FileShare.None))
+                                contentStream.CopyToAsync(fileStream, 81920, cancellationSource.Token).GetAwaiter().GetResult();
+                        }
+
+                        try
+                        {
+                            File.Move(temporaryFilePath, filePath);
+                        }
+                        catch (IOException) when (File.Exists(filePath))
+                        {
+                            // Another caller completed the same download first.
+                        }
+                    }
+                    finally
+                    {
+                        if (File.Exists(temporaryFilePath))
+                            File.Delete(temporaryFilePath);
+                    }
+                }, backoffFunc: attempt => 10_000,
+                    retryWhen: ex => ex is HttpRequestException || ex is TaskCanceledException || ex is IOException);
+            }
+        }
+    }
+}

--- a/test/Microsoft.ML.TestFrameworkCommon/TestDownloadUtils.cs
+++ b/test/Microsoft.ML.TestFrameworkCommon/TestDownloadUtils.cs
@@ -6,7 +6,6 @@ using System;
 using System.IO;
 using System.Net.Http;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace Microsoft.ML.TestFrameworkCommon
 {
@@ -57,7 +56,7 @@ namespace Microsoft.ML.TestFrameworkCommon
                             File.Delete(temporaryFilePath);
                     }
                 }, backoffFunc: attempt => 10_000,
-                    retryWhen: ex => ex is HttpRequestException || ex is TaskCanceledException || ex is IOException);
+                    retryWhen: ex => ex is HttpRequestException || ex is OperationCanceledException || ex is IOException);
             }
         }
     }

--- a/test/Microsoft.ML.TestFrameworkCommon/TestDownloadUtils.cs
+++ b/test/Microsoft.ML.TestFrameworkCommon/TestDownloadUtils.cs
@@ -32,9 +32,14 @@ namespace Microsoft.ML.TestFrameworkCommon
                         using (var response = client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancellationSource.Token).GetAwaiter().GetResult())
                         {
                             response.EnsureSuccessStatusCode();
+                            long? expectedLength = response.Content.Headers.ContentLength;
                             using (var contentStream = response.Content.ReadAsStreamAsync().GetAwaiter().GetResult())
                             using (var fileStream = new FileStream(temporaryFilePath, FileMode.Create, FileAccess.Write, FileShare.None))
+                            {
                                 contentStream.CopyToAsync(fileStream, 81920, cancellationSource.Token).GetAwaiter().GetResult();
+                                if (expectedLength.HasValue && fileStream.Length != expectedLength.Value)
+                                    throw new IOException($"Expected {expectedLength.Value} bytes from '{url}', but downloaded {fileStream.Length} bytes.");
+                            }
                         }
 
                         try


### PR DESCRIPTION
## Summary

- temporarily bypass deleted `aka.ms/mlnet-resources` aliases in tests
- use direct public blob URLs for image and benchmark datasets
- centralize bounded, retrying test downloads in `TestDownloadUtils`

Fixes #7662

## Validation

- rebuilt Microsoft.ML.TestFrameworkCommon, Microsoft.ML.AutoML.Tests, Microsoft.ML.TensorFlow.Tests, and Microsoft.ML.PerformanceTests
- ran `TensorFlowGettingSchemaMultipleTimes` and `AutoFeaturizer_image_test` on net8.0