### PR TITLE
Fix repository health query examples

### DIFF
--- a/.github/skills/repo-health-check/SKILL.md
+++ b/.github/skills/repo-health-check/SKILL.md
@@ -12,7 +12,7 @@ Collect and analyze repository-health data from a local Copilot CLI session. Thi
 1. Confirm local GitHub access and the `dotnet/machinelearning` repository.
 2. Create state under `/tmp/mlnet-repo-health/`.
 3. Read [`references/playbook.md`](references/playbook.md) and follow its data collection, fingerprinting, severity, and dashboard-format rules.
-4. Prefer available authenticated GitHub and Azure DevOps tools. If an AzDO credential or tool is unavailable, skip only those checks and state the coverage gap.
+4. Prefer available authenticated GitHub and Azure DevOps tools. If those are unavailable, use the public `dnceng-public/public` REST API; skip AzDO checks only when both access paths fail, and state the coverage gap.
 5. Treat dashboard creation, body updates, comments, and investigation requests as drafts during analysis.
 6. For up to five critical or high-confidence warning findings, either:
    - investigate inline by following [`../repo-health-investigate/SKILL.md`](../repo-health-investigate/SKILL.md), or

--- a/.github/skills/repo-health-check/references/playbook.md
+++ b/.github/skills/repo-health-check/references/playbook.md
@@ -238,7 +238,13 @@ SINCE=$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-7d
 for definition_id in $ENABLED_DEFINITIONS; do
   curl -fSs "${AZDO_AUTH[@]}" \
     "$AZDO_BUILD_URL/builds?definitions=$definition_id&branchName=refs%2Fheads%2Fmain&minTime=$SINCE&api-version=7.0" \
-    | jq '[.value[] | .result] | group_by(.) | map({result: .[0], count: length})'
+    | jq -e '
+        if (.value | length) == 0
+        then error("No main-branch builds returned in the last 7 days")
+        else [.value[] | .result]
+          | group_by(.)
+          | map({result: .[0], count: length})
+        end'
 done
 ```
 

--- a/.github/skills/repo-health-check/references/playbook.md
+++ b/.github/skills/repo-health-check/references/playbook.md
@@ -19,9 +19,10 @@ Collect health data for **dotnet/machinelearning**, diff against the previous ru
 | Area Labels | *(none — use milestones and `untriaged` label instead)* |
 | Investigation Skill | `repo-health-investigate` |
 | Max Investigations | `5` |
-| AzDO Org | `dnceng` |
+| AzDO Org | `dnceng-public` |
 | AzDO Project | `public` |
-| AzDO Pipelines | `vsts-ci, codecoverage-ci, night-build, outer-loop-build` |
+| Enabled AzDO Definitions | `167` (`MachineLearning-CI`), `168` (`MachineLearning-CodeCoverage`) |
+| Disabled AzDO Definition | `169` (`MachineLearning-NightlyBuild`) — report as a coverage gap |
 
 ---
 
@@ -77,7 +78,7 @@ gh issue list --repo dotnet/machinelearning \
 
 ```bash
 gh issue list --repo dotnet/machinelearning \
-  --state open --label "need info,Awaiting User Input,needs-author-action" \
+  --state open --search 'label:"need info","Awaiting User Input","needs-author-action"' \
   --json number,title,updatedAt,comments \
   --limit 100
 # Filter: updatedAt older than 14 days
@@ -127,7 +128,7 @@ gh pr list --repo dotnet/machinelearning \
 
 ```bash
 gh pr list --repo dotnet/machinelearning \
-  --state open --label "needs-author-action,Awaiting User Input" \
+  --state open --search 'label:"needs-author-action","Awaiting User Input"' \
   --json number,title,updatedAt,author,labels \
   --limit 100
 # Filter: updatedAt > 7 days ago
@@ -203,29 +204,40 @@ done
 
 ### Azure DevOps Pipelines
 
-> **Note**: AzDO monitoring requires `AZDO_PAT` secret. The `dnceng` org requires authentication even for the `public` project. If `AZDO_PAT` is not set, skip all A1-A3 checks and note "AzDO pipeline monitoring disabled — no AZDO_PAT configured" in the dashboard.
+> **Note**: Prefer an authenticated Azure DevOps tool or `AZDO_PAT` when available. The `dnceng-public/public` REST API is publicly readable, so a missing PAT alone is not a coverage gap. If both authenticated access and the public API fail, skip A1-A3 and report the HTTP or tool error. Definition `169` is disabled, and there is no standalone outer-loop definition; report those coverage gaps rather than querying nonexistent pipelines.
+
+```bash
+AZDO_AUTH=()
+if [ -n "${AZDO_PAT:-}" ]; then
+  AZDO_AUTH=(-u ":$AZDO_PAT")
+fi
+
+AZDO_BUILD_URL="https://dev.azure.com/dnceng-public/public/_apis/build"
+ENABLED_DEFINITIONS="167 168"
+```
 
 **A1. Pipeline status — last run result**
 
 ```bash
-# Check if AZDO_PAT is available; skip AzDO checks if not
-if [ -z "$AZDO_PAT" ]; then
-  echo "AZDO_PAT not set — skipping Azure DevOps pipeline checks"
-else
-for pipeline in vsts-ci codecoverage-ci night-build outer-loop-build; do
-  curl -s -u ":$AZDO_PAT" \
-    "https://dev.azure.com/dnceng/public/_apis/build/builds?definitions=$pipeline&\$top=1&api-version=7.0" \
-    | jq '.value[0] | {id, buildNumber, status, result, queueTime, finishTime}'
+for definition_id in $ENABLED_DEFINITIONS; do
+  curl -fSs "${AZDO_AUTH[@]}" \
+    "$AZDO_BUILD_URL/builds?definitions=$definition_id&branchName=refs%2Fheads%2Fmain&queryOrder=finishTimeDescending&\$top=1&api-version=7.0" \
+    | jq -e 'if (.value | length) == 0 then error("No main-branch builds returned") else .value[0] | {definition: .definition.name, id, buildNumber, status, result, queueTime, finishTime} end'
 done
+
+# Surface disabled scheduled coverage explicitly.
+curl -fSs "${AZDO_AUTH[@]}" \
+  "$AZDO_BUILD_URL/definitions/169?api-version=7.0" \
+  | jq '{id, name, queueStatus}'
 ```
 
 **A2. Pipeline failure rate (last 7 days)**
 
 ```bash
 SINCE=$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-7d +%Y-%m-%dT%H:%M:%SZ)
-for pipeline in vsts-ci codecoverage-ci night-build outer-loop-build; do
-  curl -s -u ":$AZDO_PAT" \
-    "https://dev.azure.com/dnceng/public/_apis/build/builds?definitions=$pipeline&minTime=$SINCE&api-version=7.0" \
+for definition_id in $ENABLED_DEFINITIONS; do
+  curl -fSs "${AZDO_AUTH[@]}" \
+    "$AZDO_BUILD_URL/builds?definitions=$definition_id&branchName=refs%2Fheads%2Fmain&minTime=$SINCE&api-version=7.0" \
     | jq '[.value[] | .result] | group_by(.) | map({result: .[0], count: length})'
 done
 ```
@@ -233,12 +245,19 @@ done
 **A3. Queue times**
 
 ```bash
-for pipeline in vsts-ci codecoverage-ci night-build outer-loop-build; do
-  curl -s -u ":$AZDO_PAT" \
-    "https://dev.azure.com/dnceng/public/_apis/build/builds?definitions=$pipeline&\$top=10&api-version=7.0" \
-    | jq '[.value[] | {queueTime, startTime} | {wait: ((.startTime | fromdateiso8601) - (.queueTime | fromdateiso8601))}] | {avg_wait_seconds: (map(.wait) | add / length)}'
+for definition_id in $ENABLED_DEFINITIONS; do
+  curl -fSs "${AZDO_AUTH[@]}" \
+    "$AZDO_BUILD_URL/builds?definitions=$definition_id&branchName=refs%2Fheads%2Fmain&queryOrder=finishTimeDescending&\$top=10&api-version=7.0" \
+    | jq '
+        def epoch: sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601;
+        [.value[]
+          | select(.queueTime != null and .startTime != null)
+          | {wait: ((.startTime | epoch) - (.queueTime | epoch))}]
+        | if length == 0
+          then {samples: 0, avg_wait_seconds: null}
+          else {samples: length, avg_wait_seconds: (map(.wait) | add / length)}
+          end'
 done
-fi
 ```
 
 ---

--- a/.github/skills/repo-health-investigate/references/playbook.md
+++ b/.github/skills/repo-health-investigate/references/playbook.md
@@ -94,18 +94,26 @@ curl -fSs "${AZDO_AUTH[@]}" \
   | jq '.value[] | {id, buildNumber, result, sourceBranch, startTime, finishTime}'
 
 # Get failed build timeline for root cause
-FAILED_BUILD_ID=$(curl -fSs "${AZDO_AUTH[@]}" \
+if ! FAILED_BUILD_ID=$(curl -fSs "${AZDO_AUTH[@]}" \
   "$AZDO_BUILD_URL/builds?definitions=$PIPELINE_ID&branchName=refs%2Fheads%2Fmain&resultFilter=failed&queryOrder=finishTimeDescending&\$top=1&api-version=7.0" \
-  | jq -r '.value[0].id')
+  | jq -er 'if (.value | length) == 0 then error("No failed main-branch build found") else .value[0].id end'); then
+  echo "Unable to select a failed main-branch build for definition $PIPELINE_ID" >&2
+  exit 1
+fi
 
 curl -fSs "${AZDO_AUTH[@]}" \
   "$AZDO_BUILD_URL/builds/$FAILED_BUILD_ID/timeline?api-version=7.0" \
   | jq '[.records[] | select(.result == "failed") | {name, result, errorCount, issues: [.issues[]? | {type, message}]}]'
 
 # Compare with last green run
-GREEN_BUILD_ID=$(curl -fSs "${AZDO_AUTH[@]}" \
+if ! GREEN_BUILD_ID=$(curl -fSs "${AZDO_AUTH[@]}" \
   "$AZDO_BUILD_URL/builds?definitions=$PIPELINE_ID&branchName=refs%2Fheads%2Fmain&resultFilter=succeeded&queryOrder=finishTimeDescending&\$top=1&api-version=7.0" \
-  | jq -r '.value[0].id')
+  | jq -er 'if (.value | length) == 0 then error("No successful main-branch build found") else .value[0].id end'); then
+  echo "Unable to select a successful main-branch build for definition $PIPELINE_ID" >&2
+  exit 1
+fi
+
+printf 'Compare failed build %s with last green build %s\n' "$FAILED_BUILD_ID" "$GREEN_BUILD_ID"
 
 # Check for infrastructure vs code issues
 curl -fSs "${AZDO_AUTH[@]}" \

--- a/.github/skills/repo-health-investigate/references/playbook.md
+++ b/.github/skills/repo-health-investigate/references/playbook.md
@@ -73,28 +73,43 @@ Analyze:
 Deep-dive into the pipeline/workflow failure:
 
 ```bash
-# For Azure DevOps pipelines — get recent runs with details
-curl -s -u ":$AZDO_PAT" \
-  "https://dev.azure.com/dnceng/public/_apis/build/builds?definitions=PIPELINE_ID&\$top=10&api-version=7.0" \
+# For Azure DevOps pipelines, PIPELINE_ID must be a numeric definition ID
+# carried by the finding (for example, 167 for MachineLearning-CI).
+case "$PIPELINE_ID" in
+  ""|*[!0-9]*)
+    echo "PIPELINE_ID must be a numeric Azure DevOps definition ID" >&2
+    exit 1
+    ;;
+esac
+
+AZDO_AUTH=()
+if [ -n "${AZDO_PAT:-}" ]; then
+  AZDO_AUTH=(-u ":$AZDO_PAT")
+fi
+AZDO_BUILD_URL="https://dev.azure.com/dnceng-public/public/_apis/build"
+
+# Get recent main-branch runs with details.
+curl -fSs "${AZDO_AUTH[@]}" \
+  "$AZDO_BUILD_URL/builds?definitions=$PIPELINE_ID&branchName=refs%2Fheads%2Fmain&queryOrder=finishTimeDescending&\$top=10&api-version=7.0" \
   | jq '.value[] | {id, buildNumber, result, sourceBranch, startTime, finishTime}'
 
 # Get failed build timeline for root cause
-FAILED_BUILD_ID=$(curl -s -u ":$AZDO_PAT" \
-  "https://dev.azure.com/dnceng/public/_apis/build/builds?definitions=PIPELINE_ID&resultFilter=failed&\$top=1&api-version=7.0" \
+FAILED_BUILD_ID=$(curl -fSs "${AZDO_AUTH[@]}" \
+  "$AZDO_BUILD_URL/builds?definitions=$PIPELINE_ID&branchName=refs%2Fheads%2Fmain&resultFilter=failed&queryOrder=finishTimeDescending&\$top=1&api-version=7.0" \
   | jq -r '.value[0].id')
 
-curl -s -u ":$AZDO_PAT" \
-  "https://dev.azure.com/dnceng/public/_apis/build/builds/$FAILED_BUILD_ID/timeline?api-version=7.0" \
+curl -fSs "${AZDO_AUTH[@]}" \
+  "$AZDO_BUILD_URL/builds/$FAILED_BUILD_ID/timeline?api-version=7.0" \
   | jq '[.records[] | select(.result == "failed") | {name, result, errorCount, issues: [.issues[]? | {type, message}]}]'
 
 # Compare with last green run
-GREEN_BUILD_ID=$(curl -s -u ":$AZDO_PAT" \
-  "https://dev.azure.com/dnceng/public/_apis/build/builds?definitions=PIPELINE_ID&resultFilter=succeeded&\$top=1&api-version=7.0" \
+GREEN_BUILD_ID=$(curl -fSs "${AZDO_AUTH[@]}" \
+  "$AZDO_BUILD_URL/builds?definitions=$PIPELINE_ID&branchName=refs%2Fheads%2Fmain&resultFilter=succeeded&queryOrder=finishTimeDescending&\$top=1&api-version=7.0" \
   | jq -r '.value[0].id')
 
 # Check for infrastructure vs code issues
-curl -s -u ":$AZDO_PAT" \
-  "https://dev.azure.com/dnceng/public/_apis/build/builds/$FAILED_BUILD_ID/timeline?api-version=7.0" \
+curl -fSs "${AZDO_AUTH[@]}" \
+  "$AZDO_BUILD_URL/builds/$FAILED_BUILD_ID/timeline?api-version=7.0" \
   | jq '[.records[] | select(.result == "failed") | .issues[]? | .message]' \
   | grep -iE "timeout|oom|disk.space|rate.limit|connection|pool|agent" | head -10
 ```


### PR DESCRIPTION
## Summary
- use the verified `dnceng-public/public` Azure DevOps profile and numeric ML.NET definition IDs
- monitor active CI definitions while reporting disabled nightly and missing standalone outer-loop coverage
- use OR label searches and align pipeline investigations with the corrected public endpoint

## Validation
- queried definitions 167 and 168 and their latest `main` builds successfully
- confirmed definition 169 is disabled
- retrieved a failed-build timeline and parsed queue-time data
- confirmed OR searches match the union of individual labels (24 issues and 1 PR)