### PR TITLE
Fix ichEnd offset bug in DoubleParser when input has leading whitespace

### DIFF
--- a/src/Microsoft.ML.Core/Utilities/DoubleParser.cs
+++ b/src/Microsoft.ML.Core/Utilities/DoubleParser.cs
@@ -145,6 +145,7 @@ namespace Microsoft.ML.Internal.Utilities
                 value = default(Single);
                 return Result.Error;
             }
+            ichEnd += ich;
 
             // Make sure everything was consumed.
             while (ichEnd < span.Length)
@@ -197,6 +198,7 @@ namespace Microsoft.ML.Internal.Utilities
                 value = default(Double);
                 return Result.Error;
             }
+            ichEnd += ich;
 
             // Make sure everything was consumed.
             while (ichEnd < span.Length)

--- a/test/Microsoft.ML.Core.Tests/UnitTests/DoubleParserTests.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/DoubleParserTests.cs
@@ -1,0 +1,55 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.ML.Internal.Utilities;
+using Microsoft.ML.TestFramework;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.ML.Core.Tests.UnitTests
+{
+    public class DoubleParserTests : BaseTestClass
+    {
+        public DoubleParserTests(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        [Fact]
+        public void Parse_WithLeadingAndTrailingWhitespace_ReturnsGood()
+        {
+            var result = DoubleParser.Parse(" 1.234 ".AsSpan(), out double value);
+
+            Assert.Equal(DoubleParser.Result.Good, result);
+            Assert.Equal(1.234, value);
+        }
+
+        [Fact]
+        public void Parse_WithoutWhitespace_ReturnsGood()
+        {
+            var result = DoubleParser.Parse("1.234".AsSpan(), out double value);
+
+            Assert.Equal(DoubleParser.Result.Good, result);
+            Assert.Equal(1.234, value);
+        }
+
+        [Fact]
+        public void Parse_WithTrailingGarbageCharacter_ReturnsExtra()
+        {
+            var result = DoubleParser.Parse("1.234x".AsSpan(), out double value);
+
+            Assert.Equal(DoubleParser.Result.Extra, result);
+        }
+
+        [Fact]
+        public void Parse_Single_WithLeadingAndTrailingWhitespace_ReturnsGood()
+        {
+            var result = DoubleParser.Parse(" 1.234 ".AsSpan(), out float value);
+
+            Assert.Equal(DoubleParser.Result.Good, result);
+            Assert.Equal(1.234f, value);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #7181

Fixes the whitespace handling in `DoubleParser.Parse` when the input contains leading whitespace.

`TryParse` returns `ichEnd` relative to the sliced span. The subsequent validation compares it against the original span, which can incorrectly return `Result.Extra` for valid inputs such as `" 1.234 "`.

This change adjusts `ichEnd` back to the original span before validating the remaining characters.

Added unit tests covering:

- parsing with leading and trailing whitespace (`double`)
- parsing without whitespace
- parsing with trailing invalid characters
- parsing with leading and trailing whitespace (`float`)