### PR TITLE
Stabilize SDCA logistic regression test

### DIFF
--- a/test/Microsoft.ML.Tests/TrainerEstimators/SdcaTests.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/SdcaTests.cs
@@ -122,17 +122,12 @@ namespace Microsoft.ML.Tests.TrainerEstimators
                 });
 
             var transformedData = pipeline.Fit(data).Transform(data);
-            var predictions = mlContext.Data.CreateEnumerable<SamplesUtils.DatasetUtils.CalibratedBinaryClassifierOutput>(transformedData, false).ToArray();
+            var metrics = mlContext.BinaryClassification.Evaluate(transformedData);
+            var priorModel = mlContext.BinaryClassification.Trainers.Prior().Fit(data);
+            var priorMetrics = mlContext.BinaryClassification.Evaluate(priorModel.Transform(data));
 
-            Assert.Equal(100, predictions.Length);
-            Assert.All(predictions, prediction =>
-            {
-                Assert.False(float.IsNaN(prediction.Score));
-                Assert.False(float.IsInfinity(prediction.Score));
-                Assert.InRange(prediction.Probability, 0, 1);
-            });
-            Assert.True(predictions.Where(prediction => prediction.Label).Average(prediction => prediction.Score) >
-                predictions.Where(prediction => !prediction.Label).Average(prediction => prediction.Score));
+            Assert.InRange(metrics.AreaUnderRocCurve, 0.9, 1);
+            Assert.True(metrics.LogLoss < priorMetrics.LogLoss);
         }
 
         [Fact]

--- a/test/Microsoft.ML.Tests/TrainerEstimators/SdcaTests.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/SdcaTests.cs
@@ -109,9 +109,17 @@ namespace Microsoft.ML.Tests.TrainerEstimators
         {
             // Keep coverage of the nondeterministic parallel path while the quality test above remains deterministic.
             // See https://github.com/dotnet/machinelearning/blob/240a849becda954f3e17d39f7606328be3a7f0de/src/Microsoft.ML.StandardTrainers/Standard/SdcaBinary.cs#L180-L188.
+
+            // Generate C# objects as training examples.
             var rawData = SamplesUtils.DatasetUtils.GenerateBinaryLabelFloatFeatureVectorFloatWeightSamples(100);
+
+            // Create a new context for ML.NET operations.
             var mlContext = new MLContext(1);
+
+            // Step 1: Read and cache the data as an IDataView.
             var data = mlContext.Data.Cache(mlContext.Data.LoadFromEnumerable(rawData));
+
+            // Step 2: Create a binary classifier that exercises the parallel training path.
             var pipeline = mlContext.BinaryClassification.Trainers.SdcaLogisticRegression(
                 new SdcaLogisticRegressionBinaryTrainer.Options
                 {
@@ -121,11 +129,15 @@ namespace Microsoft.ML.Tests.TrainerEstimators
                     NumberOfThreads = 4
                 });
 
+            // Step 3: Train and evaluate the classifier on the training data.
             var transformedData = pipeline.Fit(data).Transform(data);
             var metrics = mlContext.BinaryClassification.Evaluate(transformedData);
+
+            // Step 4: Evaluate a featureless classifier as a quality baseline.
             var priorModel = mlContext.BinaryClassification.Trainers.Prior().Fit(data);
             var priorMetrics = mlContext.BinaryClassification.Evaluate(priorModel.Transform(data));
 
+            // Verify the multithreaded classifier learns the signal in the generated data.
             Assert.InRange(metrics.AreaUnderRocCurve, 0.9, 1);
             Assert.True(metrics.LogLoss < priorMetrics.LogLoss);
         }

--- a/test/Microsoft.ML.Tests/TrainerEstimators/SdcaTests.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/SdcaTests.cs
@@ -72,7 +72,14 @@ namespace Microsoft.ML.Tests.TrainerEstimators
 
             // Step 2: Create a binary classifier.
             // We set the "Label" column as the label of the dataset, and the "Features" column as the features column.
-            var pipeline = mlContext.BinaryClassification.Trainers.SdcaLogisticRegression(labelColumnName: "Label", featureColumnName: "Features", l2Regularization: 0.001f);
+            var pipeline = mlContext.BinaryClassification.Trainers.SdcaLogisticRegression(
+                new SdcaLogisticRegressionBinaryTrainer.Options
+                {
+                    LabelColumnName = "Label",
+                    FeatureColumnName = "Features",
+                    L2Regularization = 0.001f,
+                    NumberOfThreads = 1
+                });
 
             // Step 3: Train the pipeline created.
             var model = pipeline.Fit(data);
@@ -95,6 +102,37 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             Assert.True(first.Score > 0);
             // Positive example should have high probability of belonging the positive class.
             Assert.InRange(first.Probability, 0.8, 1);
+        }
+
+        [Fact]
+        public void SdcaLogisticRegressionMultithreaded()
+        {
+            // Keep coverage of the nondeterministic parallel path while the quality test above remains deterministic.
+            // See https://github.com/dotnet/machinelearning/blob/240a849becda954f3e17d39f7606328be3a7f0de/src/Microsoft.ML.StandardTrainers/Standard/SdcaBinary.cs#L180-L188.
+            var rawData = SamplesUtils.DatasetUtils.GenerateBinaryLabelFloatFeatureVectorFloatWeightSamples(100);
+            var mlContext = new MLContext(1);
+            var data = mlContext.Data.Cache(mlContext.Data.LoadFromEnumerable(rawData));
+            var pipeline = mlContext.BinaryClassification.Trainers.SdcaLogisticRegression(
+                new SdcaLogisticRegressionBinaryTrainer.Options
+                {
+                    LabelColumnName = "Label",
+                    FeatureColumnName = "Features",
+                    L2Regularization = 0.001f,
+                    NumberOfThreads = 4
+                });
+
+            var transformedData = pipeline.Fit(data).Transform(data);
+            var predictions = mlContext.Data.CreateEnumerable<SamplesUtils.DatasetUtils.CalibratedBinaryClassifierOutput>(transformedData, false).ToArray();
+
+            Assert.Equal(100, predictions.Length);
+            Assert.All(predictions, prediction =>
+            {
+                Assert.False(float.IsNaN(prediction.Score));
+                Assert.False(float.IsInfinity(prediction.Score));
+                Assert.InRange(prediction.Probability, 0, 1);
+            });
+            Assert.True(predictions.Where(prediction => prediction.Label).Average(prediction => prediction.Score) >
+                predictions.Where(prediction => !prediction.Label).Average(prediction => prediction.Score));
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #7343.

The strict `SdcaLogisticRegression` quality assertions now use a single training thread, making their results deterministic. A separate four-thread test retains correctness coverage of SDCA's nondeterministic parallel path by preserving the original AUC requirement and verifying that its LogLoss outperforms a featureless Prior baseline.


My theory is that the macOS arm64 runners have more threads than the Windows/Linux runners which leads to more non-determinism, triggering the flaky failure.