### PR TITLE
Fix the endless loop in Join and Merge when both suffixes are the same

### DIFF
--- a/src/Microsoft.Data.Analysis/DataFrame.Join.cs
+++ b/src/Microsoft.Data.Analysis/DataFrame.Join.cs
@@ -26,6 +26,15 @@ namespace Microsoft.Data.Analysis
         private void SetSuffixForDuplicatedColumnNames(DataFrame dataFrame, DataFrameColumn column, string leftSuffix, string rightSuffix)
         {
             int index = dataFrame._columnCollection.IndexOf(column.Name);
+
+            // The loop below appends leftSuffix to the existing column and rightSuffix to the new one until the two
+            // names differ. If both suffixes are the same the names stay equal however many times they are appended,
+            // so there is no name that ends the loop.
+            if (index != -1 && leftSuffix == rightSuffix)
+            {
+                throw new ArgumentException(string.Format(Strings.SuffixesMustBeDifferent, nameof(leftSuffix), nameof(rightSuffix), column.Name), nameof(rightSuffix));
+            }
+
             while (index != -1)
             {
                 // Pre-existing column. Change name

--- a/src/Microsoft.Data.Analysis/Strings.Designer.cs
+++ b/src/Microsoft.Data.Analysis/Strings.Designer.cs
@@ -493,6 +493,15 @@ namespace Microsoft.Data {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {0} and {1} must be different when both DataFrames contain a column called &apos;{2}&apos;.
+        /// </summary>
+        internal static string SuffixesMustBeDifferent {
+            get {
+                return ResourceManager.GetString("SuffixesMustBeDifferent", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Value name &apos;{0}&apos; matches an existing column name.
         /// </summary>
         internal static string ValueNameAlreadyExists {

--- a/src/Microsoft.Data.Analysis/Strings.resx
+++ b/src/Microsoft.Data.Analysis/Strings.resx
@@ -261,6 +261,9 @@
   <data name="StreamDoesntSupportReading" xml:space="preserve">
     <value>Stream doesn't support reading</value>
   </data>
+  <data name="SuffixesMustBeDifferent" xml:space="preserve">
+    <value>{0} and {1} must be different when both DataFrames contain a column called '{2}'</value>
+  </data>
   <data name="ValueNameAlreadyExists" xml:space="preserve">
     <value>Value name '{0}' matches an existing column name</value>
   </data>

--- a/test/Microsoft.Data.Analysis.Tests/DataFrameTests.Join.cs
+++ b/test/Microsoft.Data.Analysis.Tests/DataFrameTests.Join.cs
@@ -82,6 +82,40 @@ namespace Microsoft.Data.Analysis.Tests
             VerifyJoin(join, left, right, JoinAlgorithm.Inner);
         }
 
+        [Theory]
+        [InlineData(JoinAlgorithm.Left)]
+        [InlineData(JoinAlgorithm.Right)]
+        [InlineData(JoinAlgorithm.FullOuter)]
+        [InlineData(JoinAlgorithm.Inner)]
+        public void TestJoin_SameSuffixOnBothSides_Issue6128(JoinAlgorithm joinAlgorithm)
+        {
+            DataFrame left = MakeDataFrameWithNumericColumns(3, false);
+            DataFrame right = MakeDataFrameWithNumericColumns(4, false);
+
+            // Both frames have a column called "Int", and one suffix cannot make the two names different,
+            // so the join used to keep renaming for ever instead of coming back
+            Assert.Throws<ArgumentException>(() => left.Join(right, "_same", "_same", joinAlgorithm));
+            Assert.Throws<ArgumentException>(() => left.Join(right, "", "", joinAlgorithm));
+
+            // different suffixes still work
+            DataFrame join = left.Join(right, "_left", "_right", joinAlgorithm);
+            Assert.Equal(left.Columns.Count + right.Columns.Count, join.Columns.Count);
+        }
+
+        [Fact]
+        public void TestJoin_SameSuffixWithNoSharedColumnNames()
+        {
+            DataFrame left = new DataFrame(new Int32DataFrameColumn("Left", new int?[] { 0, 1, 2 }));
+            DataFrame right = new DataFrame(new Int32DataFrameColumn("Right", new int?[] { 0, 1, 2 }));
+
+            // no name is shared, so nothing is renamed and the suffixes are never used
+            DataFrame join = left.Join(right, "_same", "_same");
+
+            Assert.Equal(2, join.Columns.Count);
+            Assert.Equal("Left", join.Columns[0].Name);
+            Assert.Equal("Right", join.Columns[1].Name);
+        }
+
         private void VerifyJoin(DataFrame join, DataFrame left, DataFrame right, JoinAlgorithm joinAlgorithm)
         {
             Int64DataFrameColumn mapIndices = new Int64DataFrameColumn("map", join.Rows.Count);

--- a/test/Microsoft.Data.Analysis.Tests/DataFrameTests.Join.cs
+++ b/test/Microsoft.Data.Analysis.Tests/DataFrameTests.Join.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Data.Analysis.Tests
         [InlineData(JoinAlgorithm.Right)]
         [InlineData(JoinAlgorithm.FullOuter)]
         [InlineData(JoinAlgorithm.Inner)]
-        public void TestJoin_SameSuffixOnBothSides_Issue6128(JoinAlgorithm joinAlgorithm)
+        public void TestJoin_ColumnNamesCollide_ThrowsOnSameSuffixOnBothSides(JoinAlgorithm joinAlgorithm)
         {
             DataFrame left = MakeDataFrameWithNumericColumns(3, false);
             DataFrame right = MakeDataFrameWithNumericColumns(4, false);

--- a/test/Microsoft.Data.Analysis.Tests/DataFrameTests.Merge.cs
+++ b/test/Microsoft.Data.Analysis.Tests/DataFrameTests.Merge.cs
@@ -1014,8 +1014,7 @@ namespace Microsoft.Data.Analysis.Tests
         }
 
         [Fact]
-        //Issue 6128
-        public void TestMerge_SameSuffixOnBothSides()
+        public void TestMerge_ColumnNamesCollide_ThrowsOnSameSuffixOnBothSides()
         {
             DataFrame left = MakeDataFrameWithNumericColumns(3, false);
             DataFrame right = MakeDataFrameWithNumericColumns(4, false);

--- a/test/Microsoft.Data.Analysis.Tests/DataFrameTests.Merge.cs
+++ b/test/Microsoft.Data.Analysis.Tests/DataFrameTests.Merge.cs
@@ -1013,6 +1013,19 @@ namespace Microsoft.Data.Analysis.Tests
             Assert.NotNull(merge.Columns.GetDateTimeColumn("DateTime_right"));
         }
 
+        [Fact]
+        //Issue 6128
+        public void TestMerge_SameSuffixOnBothSides()
+        {
+            DataFrame left = MakeDataFrameWithNumericColumns(3, false);
+            DataFrame right = MakeDataFrameWithNumericColumns(4, false);
+
+            Assert.Throws<ArgumentException>(() => left.Merge<int>(right, "Int", "Int", "_same", "_same"));
+
+            DataFrame merge = left.Merge<int>(right, "Int", "Int");
+            Assert.Equal(left.Columns.Count + right.Columns.Count, merge.Columns.Count);
+        }
+
         private void VerifyMerge(DataFrame merge, DataFrame left, DataFrame right, JoinAlgorithm joinAlgorithm)
         {
             if (joinAlgorithm == JoinAlgorithm.Left || joinAlgorithm == JoinAlgorithm.Inner)


### PR DESCRIPTION
Fixes #6128

`Join` and `Merge` rename a column that appears in both frames . the existing one gets
`leftSuffix` , the new one gets `rightSuffix` , and it repeats until the two names are
different . when both suffixes are the same string the names stay equal after every round , so
nothing ever ends the loop and both names keep growing .

the reporter hit it by passing the join column name where the suffix goes . michaelgsharp
already named the cause on the issue in 2022 , this is just the patch for it .

it now throws an `ArgumentException` naming the two parameters and the column .

the check is inside `SetSuffixForDuplicatedColumnNames` rather than up front in `Join` and
`Merge` , because equal suffixes are fine when the two frames share no column name . nothing
gets renamed in that case and it works today , so an up front check would break it . i
measured that before deciding where to put it :

```
join , shared column name , same suffix        hangs , all four algorithms
join , no shared column name , same suffix     fine
merge , shared column name , same suffix       hangs
merge , default suffixes                       fine
```

three tests added . the first covers all four `JoinAlgorithm` values with `"_same"/"_same"`
and with `""/""` , then checks `"_left"/"_right"` still gives the full column set . the second
goes the other way and pins that equal suffixes are still allowed when nothing collides . the
third is the same thing for `Merge` .

worth saying how the without-the-fix run looks , since it is not an ordinary failure . the
defect is an endless loop , so the tests do not go red , they never finish . i took the fix out
and the run was still going after 150 seconds with no result , at about 92 percent cpu . with
the fix the same six tests finish in 43 ms .

`Microsoft.Data.Analysis.Tests` is 483 passing , 0 failures , 5 skipped . the tree without this
runs 477 , so the only difference is the six new ones . build is clean with
`EnforceCodeStyleInBuild`.

i also grepped every `.Join(` and `.Merge(` caller in `src` and `test` , none of them pass
equal suffixes , so the new guard cannot fire on existing code .
