### PR TITLE
Fix GPT-4o token IDs in the tokenizer package README

### DIFF
--- a/src/Microsoft.ML.Tokenizers/PACKAGE.md
+++ b/src/Microsoft.ML.Tokenizers/PACKAGE.md
@@ -40,7 +40,7 @@ Console.WriteLine($"5 tokens from start: {(normalizedText ?? source).Substring(0
 
 IReadOnlyList<int> ids = tokenizer.EncodeToIds(source);
 Console.WriteLine(string.Join(", ", ids));
-// prints: 1199, 4037, 2065, 374, 279, 1920, 315, 45473, 264, 925, 1139, 264, 1160, 315, 11460, 13
+// prints: 1279, 6602, 2860, 382, 290, 2273, 328, 87130, 261, 1621, 1511, 261, 1562, 328, 20290, 13
 
 //
 // Using Llama Tokenizer


### PR DESCRIPTION
## Description

Update the expected token IDs in `src/Microsoft.ML.Tokenizers/PACKAGE.md` to match `TiktokenTokenizer.CreateForModel("gpt-4o")`.

#7360 changed the example from GPT-4 to GPT-4o but left the GPT-4 token IDs in the output comment. This change corrects only that comment. The token count and both trimming examples remain correct.

## Validation

Ran the example with the published `Microsoft.ML.Tokenizers` version `3.0.0-preview.26457.2` and matching data packages. The new list matches GPT-4o output; the old list matches GPT-4 output.

## Checklist

- [x] The title describes the change.
- [x] No new issue is needed for this one-line documentation correction. Related PR: #7360.
- [x] The description explains the change and its cause.
- [x] No unit test change is needed; the example output was checked against the published package.