### PR TITLE
Update JsonSchema.Net.Generation to 5.0.4

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -37,7 +37,7 @@
     <ApacheArrowVersion>14.0.2</ApacheArrowVersion>
     <GoogleProtobufVersion>3.30.2</GoogleProtobufVersion>
     <LightGBMVersion>4.6.0</LightGBMVersion>
-    <JsonSchemaNetGenerationVersion>5.0.2</JsonSchemaNetGenerationVersion>
+    <JsonSchemaNetGenerationVersion>5.0.4</JsonSchemaNetGenerationVersion>
     <JsonSchemaNetVersion>7.3.4</JsonSchemaNetVersion>
     <MicrosoftBclHashCodeVersion>6.0.0</MicrosoftBclHashCodeVersion>
     <MicrosoftBclMemoryVersion>9.0.4</MicrosoftBclMemoryVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -37,7 +37,7 @@
     <ApacheArrowVersion>14.0.2</ApacheArrowVersion>
     <GoogleProtobufVersion>3.30.2</GoogleProtobufVersion>
     <LightGBMVersion>4.6.0</LightGBMVersion>
-    <JsonSchemaNetGenerationVersion>5.0.1</JsonSchemaNetGenerationVersion>
+    <JsonSchemaNetGenerationVersion>5.0.2</JsonSchemaNetGenerationVersion>
     <JsonSchemaNetVersion>7.3.4</JsonSchemaNetVersion>
     <MicrosoftBclHashCodeVersion>6.0.0</MicrosoftBclHashCodeVersion>
     <MicrosoftBclMemoryVersion>9.0.4</MicrosoftBclMemoryVersion>


### PR DESCRIPTION
## Summary

Update `JsonSchema.Net.Generation` from 5.0.1 to 5.0.4. Keep `JsonSchema.Net` at 7.3.4.

Version 5.0.1 was unlisted because it declared an incorrect minimum dependency of `JsonSchema.Net` 1.0.0. Version 5.0.2 corrected that dependency to 7.3.4. See json-everything/json-everything#894.

Use 5.0.4, as suggested in review, to also include the fixes for properties hidden with the C# `new` keyword (5.0.3) and schema-definition name collisions (5.0.4). Version 5.0.4 supports the same target frameworks and requires the same minimum dependency versions as 5.0.2. See the [upstream release notes](https://docs.json-everything.net/rn-json-schema-generation/#release-schemagen-5.0.4).

The published ML.NET GenAI packages already require `JsonSchema.Net` 7.3.4 or later. This change removes the unlisted dependency from future releases.

## Validation

- Built `src/Microsoft.ML.GenAI.Mistral/Microsoft.ML.GenAI.Mistral.csproj` with its dependencies: 0 warnings and 0 errors.
- Confirmed that restore resolves `JsonSchema.Net.Generation` 5.0.4 and `JsonSchema.Net` 7.3.4.
- Used an isolated console runner with published `Microsoft.ML.GenAI.Mistral` 0.24.0-preview.26457.2 and Generation 5.0.4 on macOS ARM64 with .NET 10.0.11. Confirmed that the loaded Generation assembly reports version 5.0.4. Both existing prompt scenarios, with and without tools, match their repository approval baselines. The prompt-builder source is unchanged from the published release.
- `git diff --check` passed.

These are targeted build and runtime checks, not a full GenAI test-suite run.